### PR TITLE
Fix environment when running scripts

### DIFF
--- a/libpkg/scripts.c
+++ b/libpkg/scripts.c
@@ -18,13 +18,17 @@ pkg_script_pre_install(struct pkg *pkg)
 		switch (pkg_script_type(scripts[i])) {
 			case PKG_SCRIPT_INSTALL:
 				sbuf_reset(script_cmd);
-				sbuf_printf(script_cmd, "set -- %s-%s PRE-INSTALL\n%s", pkg_get(pkg, PKG_NAME), pkg_get(pkg, PKG_VERSION), pkg_script_data(scripts[i]));
+				sbuf_printf(script_cmd, "PKG_PREFIX=%s\nset -- %s-%s PRE-INSTALL\n%s",
+					pkg_get(pkg, PKG_PREFIX), pkg_get(pkg, PKG_NAME),
+					pkg_get(pkg, PKG_VERSION), pkg_script_data(scripts[i]));
 				sbuf_finish(script_cmd);
 				system(sbuf_data(script_cmd));
 				break;
 			case PKG_SCRIPT_PRE_INSTALL:
 				sbuf_reset(script_cmd);
-				sbuf_printf(script_cmd, "set -- %s-%s\n%s", pkg_get(pkg, PKG_NAME), pkg_get(pkg, PKG_VERSION), pkg_script_data(scripts[i]));
+				sbuf_printf(script_cmd, "PKG_PREFIX=%s\nset -- %s-%s\n%s",
+				  pkg_get(pkg, PKG_PREFIX), pkg_get(pkg, PKG_NAME),
+				  pkg_get(pkg, PKG_VERSION), pkg_script_data(scripts[i]));
 				sbuf_finish(script_cmd);
 				system(sbuf_data(script_cmd));
 				break;
@@ -55,13 +59,17 @@ pkg_script_post_install(struct pkg *pkg)
 		switch (pkg_script_type(scripts[i])) {
 			case PKG_SCRIPT_INSTALL:
 				sbuf_reset(script_cmd);
-				sbuf_printf(script_cmd, "set -- %s-%s POST-INSTALL\n%s", pkg_get(pkg, PKG_NAME), pkg_get(pkg, PKG_VERSION), pkg_script_data(scripts[i]));
+				sbuf_printf(script_cmd, "PKG_PREFIX=%s\nset -- %s-%s POST-INSTALL\n%s",
+				  pkg_get(pkg, PKG_PREFIX), pkg_get(pkg, PKG_NAME),
+				  pkg_get(pkg, PKG_VERSION), pkg_script_data(scripts[i]));
 				sbuf_finish(script_cmd);
 				system(sbuf_data(script_cmd));
 				break;
 			case PKG_SCRIPT_POST_INSTALL:
 				sbuf_reset(script_cmd);
-				sbuf_printf(script_cmd, "set -- %s-%s\n%s", pkg_get(pkg, PKG_NAME), pkg_get(pkg, PKG_VERSION), pkg_script_data(scripts[i]));
+				sbuf_printf(script_cmd, "PKG_PREFIX=%s\nset -- %s-%s\n%s",
+				  pkg_get(pkg, PKG_PREFIX), pkg_get(pkg, PKG_NAME),
+				  pkg_get(pkg, PKG_VERSION), pkg_script_data(scripts[i]));
 				sbuf_finish(script_cmd);
 				system(sbuf_data(script_cmd));
 				break;
@@ -90,13 +98,17 @@ pkg_script_pre_upgrade(struct pkg *pkg)
 		switch (pkg_script_type(scripts[i])) {
 			case PKG_SCRIPT_UPGRADE:
 				sbuf_reset(script_cmd);
-				sbuf_printf(script_cmd, "set -- %s-%s PRE-UPGRADE\n%s", pkg_get(pkg, PKG_NAME), pkg_get(pkg, PKG_VERSION), pkg_script_data(scripts[i]));
+				sbuf_printf(script_cmd, "PKG_PREFIX=%s\nset -- %s-%s PRE-UPGRADE\n%s",
+				  pkg_get(pkg, PKG_PREFIX), pkg_get(pkg, PKG_NAME),
+				  pkg_get(pkg, PKG_VERSION), pkg_script_data(scripts[i]));
 				sbuf_finish(script_cmd);
 				system(sbuf_data(script_cmd));
 				break;
 			case PKG_SCRIPT_PRE_UPGRADE:
 				sbuf_reset(script_cmd);
-				sbuf_printf(script_cmd, "set -- %s-%s\n%s", pkg_get(pkg, PKG_NAME), pkg_get(pkg, PKG_VERSION), pkg_script_data(scripts[i]));
+				sbuf_printf(script_cmd, "PKG_PREFIX=%s\nset -- %s-%s\n%s",
+				  pkg_get(pkg, PKG_PREFIX), pkg_get(pkg, PKG_NAME),
+				  pkg_get(pkg, PKG_VERSION), pkg_script_data(scripts[i]));
 				sbuf_finish(script_cmd);
 				system(sbuf_data(script_cmd));
 				break;
@@ -127,13 +139,17 @@ pkg_script_post_upgrade(struct pkg *pkg)
 		switch (pkg_script_type(scripts[i])) {
 			case PKG_SCRIPT_UPGRADE:
 				sbuf_reset(script_cmd);
-				sbuf_printf(script_cmd, "set -- %s-%s POST-UPGRADE\n%s", pkg_get(pkg, PKG_NAME), pkg_get(pkg, PKG_VERSION), pkg_script_data(scripts[i]));
+				sbuf_printf(script_cmd, "PKG_PREFIX=%s\nset -- %s-%s POST-UPGRADE\n%s",
+				  pkg_get(pkg, PKG_PREFIX), pkg_get(pkg, PKG_NAME),
+				  pkg_get(pkg, PKG_VERSION), pkg_script_data(scripts[i]));
 				sbuf_finish(script_cmd);
 				system(sbuf_data(script_cmd));
 				break;
 			case PKG_SCRIPT_POST_UPGRADE:
 				sbuf_reset(script_cmd);
-				sbuf_printf(script_cmd, "set -- %s-%s\n%s", pkg_get(pkg, PKG_NAME), pkg_get(pkg, PKG_VERSION), pkg_script_data(scripts[i]));
+				sbuf_printf(script_cmd, "PKG_PREFIX=%s\nset -- %s-%s\n%s",
+				  pkg_get(pkg, PKG_PREFIX), pkg_get(pkg, PKG_NAME),
+				  pkg_get(pkg, PKG_VERSION), pkg_script_data(scripts[i]));
 				sbuf_finish(script_cmd);
 				system(sbuf_data(script_cmd));
 				break;
@@ -164,13 +180,17 @@ pkg_script_pre_deinstall(struct pkg *pkg)
 		switch (pkg_script_type(scripts[i])) {
 			case PKG_SCRIPT_DEINSTALL:
 				sbuf_reset(script_cmd);
-				sbuf_printf(script_cmd, "set -- %s-%s DEINSTALL\n%s", pkg_get(pkg, PKG_NAME), pkg_get(pkg, PKG_VERSION), pkg_script_data(scripts[i]));
+				sbuf_printf(script_cmd, "PKG_PREFIX=%s\nset -- %s-%s DEINSTALL\n%s",
+				  pkg_get(pkg, PKG_PREFIX), pkg_get(pkg, PKG_NAME),
+				  pkg_get(pkg, PKG_VERSION), pkg_script_data(scripts[i]));
 				sbuf_finish(script_cmd);
 				system(sbuf_data(script_cmd));
 				break;
 			case PKG_SCRIPT_PRE_DEINSTALL:
 				sbuf_reset(script_cmd);
-				sbuf_printf(script_cmd, "set -- %s-%s\n%s", pkg_get(pkg, PKG_NAME), pkg_get(pkg, PKG_VERSION), pkg_script_data(scripts[i]));
+				sbuf_printf(script_cmd, "PKG_PREFIX=%s\nset -- %s-%s\n%s",
+				  pkg_get(pkg, PKG_PREFIX), pkg_get(pkg, PKG_NAME),
+				  pkg_get(pkg, PKG_VERSION), pkg_script_data(scripts[i]));
 				sbuf_finish(script_cmd);
 				system(sbuf_data(script_cmd));
 				break;
@@ -201,13 +221,17 @@ pkg_script_post_deinstall(struct pkg *pkg)
 		switch (pkg_script_type(scripts[i])) {
 			case PKG_SCRIPT_DEINSTALL:
 				sbuf_reset(script_cmd);
-				sbuf_printf(script_cmd, "set -- %s-%s POST-DEINSTALL\n%s", pkg_get(pkg, PKG_NAME), pkg_get(pkg, PKG_VERSION), pkg_script_data(scripts[i]));
+				sbuf_printf(script_cmd, "PKG_PREFIX=%s\nset -- %s-%s POST-DEINSTALL\n%s",
+				  pkg_get(pkg, PKG_PREFIX), pkg_get(pkg, PKG_NAME),
+				  pkg_get(pkg, PKG_VERSION), pkg_script_data(scripts[i]));
 				sbuf_finish(script_cmd);
 				system(sbuf_data(script_cmd));
 				break;
 			case PKG_SCRIPT_POST_DEINSTALL:
 				sbuf_reset(script_cmd);
-				sbuf_printf(script_cmd, "set -- %s-%s\n%s", pkg_get(pkg, PKG_NAME), pkg_get(pkg, PKG_VERSION), pkg_script_data(scripts[i]));
+				sbuf_printf(script_cmd, "PKG_PREFIX=%s\nset -- %s-%s\n%s",
+				  pkg_get(pkg, PKG_PREFIX), pkg_get(pkg, PKG_NAME),
+				  pkg_get(pkg, PKG_VERSION), pkg_script_data(scripts[i]));
 				sbuf_finish(script_cmd);
 				system(sbuf_data(script_cmd));
 				break;


### PR DESCRIPTION
Scripts expect PKG_PREFIX to be set.
