### PR TITLE
Optionally set LOCALBASE in order to find libs.

### DIFF
--- a/libpkg/Makefile
+++ b/libpkg/Makefile
@@ -3,6 +3,7 @@
 LIB=		pkg
 INCS=		pkg.h
 WARNS=		6
+LOCALBASE?=	/usr/local
 SHLIBDIR?=	/usr/lib
 SHLIB_MAJOR=	0
 
@@ -32,6 +33,7 @@ CFLAGS+=	-I${.CURDIR} \
 		-I${.CURDIR}/../external/libyaml/include
 LDADD+=		-L${.CURDIR}/../external/sqlite \
 		-L${.CURDIR}/../external/libyaml \
+		-L${LOCALBASE}/lib \
 		-lsqlite3 \
 		-lyaml \
 		-larchive \


### PR DESCRIPTION
libpkg depends on libraries like libsqllite3.so, which in a default system, are installed in /usr/local/lib. Thus, we need to add /usr/local/lib to the library search path, but provide a mechanism for it to be overridden to a custom path.
