### PR TITLE
Targets are in .OBJDIR, not necessarily .CURDIR.

### DIFF
--- a/pkg/Makefile
+++ b/pkg/Makefile
@@ -29,11 +29,11 @@ STATIC_PKGNG=	yes
 .endif
 
 CFLAGS+=	-I${.CURDIR}/../libpkg
-LDADD+=		-L${.CURDIR}/../libpkg \
+LDADD+=		-L${.OBJDIR}/../libpkg \
 		-lutil \
 		-ljail
 .if defined(STATIC_PKGNG)
-LDADD+=		${.CURDIR}/../libpkg/libpkg.a \
+LDADD+=		${.OBJDIR}/../libpkg/libpkg.a \
 		-L${.CURDIR}/../external/sqlite \
 		-L${.CURDIR}/../external/libyaml \
 		-lsqlite3 \


### PR DESCRIPTION
If you've run 'make obj', build targets like libpkg.so are not located in .CURDIR alongside the source; they're in MAKEOBJDIR, something like /usr/obj/${HOME}/pkgng/...
