### PR TITLE
Fix Clang build.

### DIFF
--- a/libpkg/pkg_add.c
+++ b/libpkg/pkg_add.c
@@ -56,7 +56,7 @@ do_extract(struct archive *a, struct archive_entry *ae)
 		 * if conf1.cfg doesn't exists create it based on
 		 * conf1.cfg.pkgconf
 		 */
-		if (is_conf_file(archive_entry_pathname(ae), path)
+		if (is_conf_file(archive_entry_pathname(ae), path, sizeof(path))
 		    && lstat(path, &st) == ENOENT) {
 			archive_entry_set_pathname(ae, path);
 			if (archive_read_extract(a, ae, EXTRACT_ARCHIVE_FLAGS) != ARCHIVE_OK) {

--- a/libpkg/pkg_util.c
+++ b/libpkg/pkg_util.c
@@ -274,7 +274,7 @@ sha256_file(const char *path, char out[SHA256_DIGEST_LENGTH * 2 + 1])
 }
 
 int
-is_conf_file(const char *path, char newpath[MAXPATHLEN + 1])
+is_conf_file(const char *path, char *newpath, size_t len)
 {
 	size_t n;
 	char *p = NULL;
@@ -287,7 +287,7 @@ is_conf_file(const char *path, char newpath[MAXPATHLEN + 1])
 	p = strrchr(path, '.');
 
 	if (p != NULL && !strcmp(p, ".pkgconf")) {
-		strlcpy(newpath, path, sizeof(newpath));
+		strlcpy(newpath, path, len);
 		newpath[n - 8] = '\0';
 		return (1);
 	}

--- a/libpkg/pkg_util.h
+++ b/libpkg/pkg_util.h
@@ -23,7 +23,7 @@ int format_exec_cmd(char **, const char *, const char *, const char *);
 int split_chr(char *, char);
 int file_fetch(const char *, const char *);
 int is_dir(const char *);
-int is_conf_file(const char *path, char newpath[MAXPATHLEN]);
+int is_conf_file(const char *path, char *newpath, size_t len);
 
 int sha256_file(const char *, char[SHA256_DIGEST_LENGTH * 2 +1]);
 void sha256_str(const char *, char[SHA256_DIGEST_LENGTH * 2 +1]);


### PR DESCRIPTION
newpath[MAXPATHLEN + 1] is a function parameter, so sizeof(newpath) will return sizeof(char*), not MAXPATHLEN + 1.

Therefore, it's unsafe to rely on type checking for path length bounds, so it's better to pass a size_t len explicitly into is_conf_file().
