### PR TITLE
Bring portmaster+pkgng almost to feature parity with vanilla portmaster

### DIFF
--- a/ports/portmaster.patch
+++ b/ports/portmaster.patch
@@ -1,5 +1,5 @@
 --- portmaster.orig	2012-01-31 03:17:17.681285114 +0100
-+++ portmaster	2012-02-03 04:08:11.584430592 +0100
++++ portmaster	2012-02-03 04:19:47.404428436 +0100
 @@ -125,6 +125,8 @@
  			if [ -n "$files" ]; then
  				pm_sv Deleting \'install complete\' flags
@@ -129,7 +129,7 @@
  
  	if [ -n "$PM_PACKAGES" -o -n "$PM_PACKAGES_BUILD" ]; then
 +		if [ -n "$use_pkgng" ]; then
-+			unset PM_PACKAGES ; unset PM_PACKAGES_BUILD ; unset PM_PACKAGES_LOCAL ; unset PM_PACKAGES_NEWER ; unset PM_ALWAYS_FETCH ; unset PM_DELETE_PACKAGES
++			unset PM_PACKAGES PM_PACKAGES_BUILD PM_PACKAGES_LOCAL PM_PACKAGES_NEWER PM_ALWAYS_FETCH PM_DELETE_PACKAGES
 +			echo "===>>> Package installation support cannot be used with pkgng yet,"
 +			echo "       it will be disabled"
 +			echo ''


### PR DESCRIPTION
Still missing: packages, file preservation on upgrade, and broken dependency data fixing in `portmaster -e`. Also, a couple of bugs of portmaster were fixed.
