### PR TITLE
Avoid an abort trap when trying to restore an empty database.

### DIFF
--- a/libpkg/backup.c
+++ b/libpkg/backup.c
@@ -98,7 +98,8 @@ pkgdb_load(struct pkgdb *db, char *dest)
 		} else 
 			continue;
 	}
-	pkgdb_register_pkg(db, pkg, 1);
+	if (pkg != NULL)
+		pkgdb_register_pkg(db, pkg, 1);
 
 cleanup:
 	if (a != NULL)


### PR DESCRIPTION
Simple check added to make sure pkg does not dump core when using 'pkg backup -r db.txz' with db.txz being an empty database.
To reproduce, simply issue the following commands with no packages installed:

$ pkg backup -d db
$ pkg backup -r db.txz
