### PR TITLE
pkg/update.c cleanup

### DIFF
--- a/pkg/update.c
+++ b/pkg/update.c
@@ -34,6 +34,7 @@ update_from_remote_repo(const char *name, const char *url)
 	const char *dbdir = NULL;
 	unsigned char *sig = NULL;
 	int siglen = 0;
+	int rc = EPKG_OK;
 
 	(void)strlcpy(tmp, "/tmp/repo.txz.XXXXXX", sizeof(tmp));
 	if (mktemp(tmp) == NULL) {
@@ -79,18 +80,20 @@ update_from_remote_repo(const char *name, const char *url)
 			warnx("Invalid signature, removing repository.\n");
 			unlink(repofile_unchecked);
 			free(sig);
-			return (EPKG_FATAL);
+			rc = EPKG_FATAL;
+			goto cleanup;
 		}
 	}
 
 	rename(repofile_unchecked, repofile);
 
+cleanup:
 	if (a != NULL)
 		archive_read_finish(a);
 
-	unlink(tmp);
+	(void)unlink(tmp);
 
-	return (EPKG_OK);
+	return (rc);
 }
 
 void


### PR DESCRIPTION
The following 3 changes were applied:
- Use a stack-based instead of a heap-based storage for temporary file
  path to avoid unnecessary memory allocation/deallocation. Also check
  for temporary file creation failure.
- Remove unneeded unlink() as it is already done in pkg_fetch_file() in
  case fetch failed.
- Perform cleanup in case of invalid signature.
