### PR TITLE
Fixed segmentation fault in 'pkg audit -F'

### DIFF
--- a/pkg/audit.c
+++ b/pkg/audit.c
@@ -92,8 +92,6 @@ fetch_and_extract(const char *src, const char *dest)
 	unlink(tmp);
 	if (a != NULL)
 		archive_read_finish(a);
-	if (ae != NULL)
-		archive_entry_free(ae);
 	if (fd > 0)
 		close(fd);
 


### PR DESCRIPTION
Removed unnecessary archive_entry_free(), because archive_read_finish()
already cleaned the same memory that entry was using.

I used ar and cpio sources as reference.
