### PR TITLE
Fix SIGFPE when SHLIBS: yes is set in pkg.conf

### DIFF
--- a/libpkg/pkgdb.c
+++ b/libpkg/pkgdb.c
@@ -1856,41 +1856,6 @@ pkgdb_register_pkg(struct pkgdb *db, struct pkg *pkg, int complete)
 	stmt = NULL;
 	stmt2 = NULL;
 
-
-	/*
-	 * Insert shlibs
-	 */
-
-	if (sqlite3_prepare_v2(s, sql_shlib, -1, &stmt, NULL) != SQLITE_OK) {
-		ERROR_SQLITE(s);
-		goto cleanup;
-	}
-	if (sqlite3_prepare_v2(s, sql_shlibs, -1, &stmt2, NULL) != SQLITE_OK) {
-		ERROR_SQLITE(s);
-		goto cleanup;
-	}
-
-	while (pkg_shlibs(pkg, &shlib) == EPKG_OK) {
-		sqlite3_bind_text(stmt, 1, pkg_shlib_name(shlib), -1, SQLITE_STATIC);
-		sqlite3_bind_int64(stmt2, 1, package_id);
-		sqlite3_bind_text(stmt2, 2, pkg_shlib_name(shlib), -1, SQLITE_STATIC);
-
-		if ((ret = sqlite3_step(stmt)) != SQLITE_DONE) {
-			if (ret == SQLITE_CONSTRAINT) {
-				pkg_emit_error("sqlite: constraint violation on shlibs.name: %s",
-						pkg_shlib_name(shlib));
-			} else
-				ERROR_SQLITE(s);
-			goto cleanup;
-		}
-		if (( ret = sqlite3_step(stmt2)) != SQLITE_DONE) {
-			ERROR_SQLITE(s);
-			goto cleanup;
-		}
-		sqlite3_reset(stmt);
-		sqlite3_reset(stmt2);
-	}
-
 	retcode = EPKG_OK;
 
 	cleanup:


### PR DESCRIPTION
(analyse_elf) Extract some data to do with dynamic libraries from shdr
within the loop scanning all ELF sections, while shdr still refers to
the .DYNAMIC section.

(analyse_elf) Don't try and read data from the notes section if no
notes section was found.

(analyse_elf) No need to read shlibs and autodeps configuration
settings from pkg.conf in this function.

(test_depends) Call dlclose() when returning early because of not
doing autodeps processing.

(pkgdb_register_pkg) Delete duplicated block of code.
