### PR TITLE
Handle fatal error in pkg_jobs_install() if pkg_jobs_fetch() fails

### DIFF
--- a/libpkg/pkg_jobs.c
+++ b/libpkg/pkg_jobs.c
@@ -164,7 +164,8 @@ pkg_jobs_install(struct pkg_jobs *j)
 	STAILQ_INIT(&pkg_queue);
 
 	/* Fetch */
-	pkg_jobs_fetch(j);
+	if (pkg_jobs_fetch(j) != EPKG_OK)
+		return (EPKG_FATAL);
 
 	if (pkg_config_string(PKG_CONFIG_CACHEDIR, &cachedir) != EPKG_OK)
 		return (EPKG_FATAL);


### PR DESCRIPTION
This fixes `pkg install package` when not having PACKAGESITE defined.
