### PR TITLE
Stop service only if it enabled in rc.conf

### DIFF
--- a/libpkg/rcscripts.c
+++ b/libpkg/rcscripts.c
@@ -115,7 +115,7 @@ rc_stop(const char *rc_file)
 			return (-1);
 		case 0:
 			/* child */
-			execl("/usr/sbin/service", "service", rc_file, "forcestop", (char *)NULL);
+			execl("/usr/sbin/service", "service", rc_file, "stop", (char *)NULL);
 			_exit(1);
 			/* NOT REACHED */
 		default:


### PR DESCRIPTION
This is more close to POLA, since if service started by user with "onestart" or via some other mean (for example, kdm started via /etc/ttys), updating package should not stop it and possibly break things.
