### PR TITLE
Add indices on *.package_id and pkg_directories.directory_id

### DIFF
--- a/libpkg/pkgdb.c
+++ b/libpkg/pkgdb.c
@@ -49,7 +49,7 @@
 #include "private/utils.h"
 
 #include "private/db_upgrades.h"
-#define DBVERSION 11
+#define DBVERSION 12
 
 static struct pkgdb_it * pkgdb_it_new(struct pkgdb *, sqlite3_stmt *, int);
 static void pkgdb_regex(sqlite3_context *, int, sqlite3_value **, int);
@@ -524,7 +524,19 @@ pkgdb_init(sqlite3 *sdb)
 	/* Mark the end of the array */
 
 	"CREATE INDEX deporigini on deps(origin);"
-	"PRAGMA user_version = 11;"
+	"CREATE INDEX scripts_package_id ON scripts (package_id);"
+	"CREATE INDEX options_package_id ON options (package_id);"
+	"CREATE INDEX deps_package_id ON deps (package_id);"
+	"CREATE INDEX files_package_id ON files (package_id);"
+	"CREATE INDEX pkg_directories_package_id ON pkg_directories (package_id);"
+	"CREATE INDEX pkg_categories_package_id ON pkg_categories (package_id);"
+	"CREATE INDEX pkg_licenses_package_id ON pkg_licenses (package_id);"
+	"CREATE INDEX pkg_users_package_id ON pkg_users (package_id);"
+	"CREATE INDEX pkg_groups_package_id ON pkg_groups (package_id);"
+	"CREATE INDEX pkg_shlibs_package_id ON pkg_shlibs (package_id);"
+	"CREATE INDEX pkg_directories_directory_id ON pkg_directories (directory_id);"
+
+	"PRAGMA user_version = 12;"
 	"COMMIT;"
 	;
 

--- a/libpkg/private/db_upgrades.h
+++ b/libpkg/private/db_upgrades.h
@@ -219,6 +219,19 @@ static struct db_upgrades {
 		"FROM oldpkgs;"
 	"DROP TABLE oldpkgs;"
 	},
+	{12,
+	"CREATE INDEX scripts_package_id ON scripts (package_id);"
+	"CREATE INDEX options_package_id ON options (package_id);"
+	"CREATE INDEX deps_package_id ON deps (package_id);"
+	"CREATE INDEX files_package_id ON files (package_id);"
+	"CREATE INDEX pkg_directories_package_id ON pkg_directories (package_id);"
+	"CREATE INDEX pkg_categories_package_id ON pkg_categories (package_id);"
+	"CREATE INDEX pkg_licenses_package_id ON pkg_licenses (package_id);"
+	"CREATE INDEX pkg_users_package_id ON pkg_users (package_id);"
+	"CREATE INDEX pkg_groups_package_id ON pkg_groups (package_id);"
+	"CREATE INDEX pkg_shlibs_package_id ON pkg_shlibs (package_id);"
+	"CREATE INDEX pkg_directories_directory_id ON pkg_directories (directory_id);"
+	},
 
 	/* Mark the end of the array */
 	{ -1, NULL },


### PR DESCRIPTION
This speeds up some `portupgrade` work from 5 min to 2m22s. I've documented some of this on my repo:
https://github.com/bdrewery/pkgng/issues/1
