### PR TITLE
Support readline on FreeBSD 8.3

### DIFF
--- a/external/sqlite/Makefile
+++ b/external/sqlite/Makefile
@@ -10,6 +10,8 @@ WFORMAT=	1
 .if exists(/usr/include/edit/readline/readline.h)
 CFLAGS+=	-DHAVE_READLINE=1 \
 		-I/usr/include/edit
+.elif exists(/usr/include/readline/readline.h)
+CFLAGS+=	-DHAVE_READLINE=1
 .endif
 # http://www.sqlite.org/compile.html
 CFLAGS+=	-DSQLITE_OMIT_AUTOVACUUM \

--- a/libpkg/Makefile
+++ b/libpkg/Makefile
@@ -52,7 +52,7 @@ LDADD+=		-L${.OBJDIR}/../external/sqlite \
 		-lutil \
 		-lpthread
 
-.if exists(/usr/include/edit/readline/readline.h)
+.if exists(/usr/include/edit/readline/readline.h) || exists(/usr/include/readline/readline.h)
 LDADD+=		-ledit
 .endif
 

--- a/pkg-static/Makefile
+++ b/pkg-static/Makefile
@@ -18,7 +18,7 @@ LDADD_STATIC=	-L${.OBJDIR}/../external/sqlite \
 		-lbz2 \
 		-llzma
 
-.if exists(/usr/include/edit/readline/readline.h)
+.if exists(/usr/include/edit/readline/readline.h) || exists(/usr/include/readline/readline.h)
 LDADD_STATIC+=	-ledit \
 		-lncursesw
 .endif


### PR DESCRIPTION
readline is in _/usr/include/readline/readline.h_ on 8.3 instead of _/usr/include/edit_
