### PR TITLE
Significantly speedup loading files into struct pkg* by not checking for duplicates

### DIFF
--- a/libpkg/pkg.c
+++ b/libpkg/pkg.c
@@ -588,23 +588,25 @@ pkg_addrdep(struct pkg *pkg, const char *name, const char *origin, const char *v
 }
 
 int
-pkg_addfile(struct pkg *pkg, const char *path, const char *sha256)
+pkg_addfile(struct pkg *pkg, const char *path, const char *sha256, bool check_duplicates)
 {
-	return (pkg_addfile_attr(pkg, path, sha256, NULL, NULL, 0));
+	return (pkg_addfile_attr(pkg, path, sha256, NULL, NULL, 0, check_duplicates));
 }
 
 int
-pkg_addfile_attr(struct pkg *pkg, const char *path, const char *sha256, const char *uname, const char *gname, mode_t perm)
+pkg_addfile_attr(struct pkg *pkg, const char *path, const char *sha256, const char *uname, const char *gname, mode_t perm, bool check_duplicates)
 {
 	struct pkg_file *f = NULL;
 
 	assert(pkg != NULL);
 	assert(path != NULL && path[0] != '\0');
 
-	while (pkg_files(pkg, &f) != EPKG_END) {
-		if (!strcmp(path, pkg_file_get(f, PKG_FILE_PATH))) {
-			pkg_emit_error("duplicate file listing: %s, ignoring", pkg_file_get(f, PKG_FILE_PATH));
-			return (EPKG_OK);
+	if (check_duplicates) {
+		while (pkg_files(pkg, &f) != EPKG_END) {
+			if (!strcmp(path, pkg_file_get(f, PKG_FILE_PATH))) {
+				pkg_emit_error("duplicate file listing: %s, ignoring", pkg_file_get(f, PKG_FILE_PATH));
+				return (EPKG_OK);
+			}
 		}
 	}
 

--- a/libpkg/pkg.h
+++ b/libpkg/pkg.h
@@ -448,9 +448,10 @@ int pkg_addrdep(struct pkg *pkg, const char *name, const char *origin, const
 /**
  * Allocate a new struct pkg_file and add it to the files of pkg.
  * @param sha256 The ascii representation of the sha256 or a NULL pointer.
+ * @param check_duplicates ensure no duplicate files are added to the pkg?
  * @return An error code.
  */
-int pkg_addfile(struct pkg *pkg, const char *path, const char *sha256);
+int pkg_addfile(struct pkg *pkg, const char *path, const char *sha256, bool check_duplicates);
 
 /**
  * Allocate a new struct pkg_file and add it to the files of pkg;
@@ -459,9 +460,10 @@ int pkg_addfile(struct pkg *pkg, const char *path, const char *sha256);
  * @param uname the user name of the file
  * @param gname the group name of the file
  * @param perm the permission
+ * @param check_duplicates ensure no duplicate files are added to the pkg?
  * @return An error code.
  */
-int pkg_addfile_attr(struct pkg *pkg, const char *path, const char *sha256, const char *uname, const char *gname, mode_t perm);
+int pkg_addfile_attr(struct pkg *pkg, const char *path, const char *sha256, const char *uname, const char *gname, mode_t perm, bool check_duplicates);
 
 /**
  * Add a path

--- a/libpkg/pkg_manifest.c
+++ b/libpkg/pkg_manifest.c
@@ -345,7 +345,7 @@ parse_mapping(struct pkg *pkg, yaml_node_t *item, yaml_document_t *doc, int attr
 			case PKG_FILES:
 				if (val->type == YAML_SCALAR_NODE && val->data.scalar.length > 0) {
 					urldecode(key->data.scalar.value, &tmp);
-					pkg_addfile(pkg, sbuf_get(tmp), val->data.scalar.length == 64 ? val->data.scalar.value : NULL);
+					pkg_addfile(pkg, sbuf_get(tmp), val->data.scalar.length == 64 ? val->data.scalar.value : NULL, true);
 				} else if (val->type == YAML_MAPPING_NODE)
 					pkg_set_files_from_node(pkg, val, doc, key->data.scalar.value);
 				else
@@ -446,7 +446,7 @@ pkg_set_files_from_node(struct pkg *pkg, yaml_node_t *item, yaml_document_t *doc
 	}
 
 	if (key != NULL)
-	    pkg_addfile_attr(pkg, key->data.scalar.value, sum, uname, gname, perm);
+	    pkg_addfile_attr(pkg, key->data.scalar.value, sum, uname, gname, perm, true);
 
 	return (EPKG_OK);
 }

--- a/libpkg/pkg_ports.c
+++ b/libpkg/pkg_ports.c
@@ -194,7 +194,7 @@ file(struct plist *p, char *line)
 			sha256_file(path, sha256);
 			buf = sha256;
 		}
-		return (pkg_addfile_attr(p->pkg, path, buf, p->uname, p->gname, p->perm));
+		return (pkg_addfile_attr(p->pkg, path, buf, p->uname, p->gname, p->perm, true));
 	}
 
 	pkg_emit_errno("lstat", path);

--- a/libpkg/pkgdb.c
+++ b/libpkg/pkgdb.c
@@ -1128,7 +1128,7 @@ pkgdb_load_files(struct pkgdb *db, struct pkg *pkg)
 	sqlite3_bind_int64(stmt, 1, pkg->rowid);
 
 	while ((ret = sqlite3_step(stmt)) == SQLITE_ROW) {
-		pkg_addfile(pkg, sqlite3_column_text(stmt, 0), sqlite3_column_text(stmt, 1));
+		pkg_addfile(pkg, sqlite3_column_text(stmt, 0), sqlite3_column_text(stmt, 1), false);
 	}
 	sqlite3_finalize(stmt);
 


### PR DESCRIPTION
### Before

<pre>
time pkg query '%Fp' ruby-1.8.7.358,1
...
real    0m23.212s
user    0m21.003s
sys     0m0.458s
</pre>

### After

<pre>
time pkg query '%Fp' ruby-1.8.7.358,1
...
real    0m2.072s
user    0m0.188s
sys     0m0.457s
</pre>
