### PR TITLE
First steps towards ARCH_INDEP package support

### DIFF
--- a/libpkg/pkg.c
+++ b/libpkg/pkg.c
@@ -176,6 +176,15 @@ pkg_is_valid(struct pkg *pkg)
 	return (EPKG_OK);
 }
 
+int
+pkg_is_arch_indep(struct pkg *pkg)
+{
+	if (pkg->flags & PKG_CONTAINS_ARCH_DEP)
+		return EPKG_FATAL;
+	else
+		return EPKG_OK;
+}
+
 static int
 pkg_vget(struct pkg const *const pkg, va_list ap)
 {

--- a/libpkg/pkg.h
+++ b/libpkg/pkg.h
@@ -258,6 +258,7 @@ typedef enum _pkg_config_key {
 	PKG_CONFIG_SIGNED_REPOS = 13,
 	PKG_CONFIG_ABI = 14,
 	PKG_CONFIG_DEVELOPER_MODE = 15,
+	PKG_CONFIG_ARCH_INDEP = 16,
 } pkg_config_key;
 
 typedef enum {
@@ -322,6 +323,11 @@ void pkg_free(struct pkg *);
  * Check if a package is valid according to its type.
  */
 int pkg_is_valid(struct pkg *);
+
+/**
+ * Check if a package is marked architecture independent
+ */
+int pkg_is_arch_indep(struct pkg *);
 
 /**
  * Open a package file archive and retrive informations.
@@ -432,6 +438,8 @@ int pkg_shlibs(struct pkg *pkg, struct pkg_shlib **shlib);
  * It respects the SHLIBS and AUTODEPS options from configuration
  * @return An error code
  */
+
+#define PKG_CONTAINS_ARCH_DEP (1<<24) /* Don't conflict with PKG_LOAD_* q.v. */
 
 int pkg_analyse_files(struct pkgdb *, struct pkg *);
 /**
@@ -917,6 +925,7 @@ void pkg_test_filesum(struct pkg *);
 int64_t pkg_recompute_flatsize(struct pkg *);
 
 int pkg_get_myarch(char *pkgarch, size_t sz);
+int pkg_get_myarch_indep(char *pkgarch, size_t sz);
 
 void pkgdb_cmd(int argc, char **argv);
 #endif

--- a/libpkg/pkg_config.c
+++ b/libpkg/pkg_config.c
@@ -157,6 +157,12 @@ static struct config_entry c[] = {
 		"DEVELOPER_MODE",
 		"NO",
 		{ NULL }
+	},
+	[PKG_CONFIG_ARCH_INDEP] = {
+		BOOL,
+		"ARCH_INDEP",
+		"NO",
+		{ NULL }
 	}
 };
 

--- a/libpkg/pkg_elf.c
+++ b/libpkg/pkg_elf.c
@@ -130,6 +130,14 @@ analyse_elf(struct pkgdb *db, struct pkg *pkg, const char *fpath)
 	size_t dynidx;
 	const char *osname;
 
+	bool shlibs = false;
+	bool autodeps = false;
+	bool arch_indep = false;
+
+	pkg_config_bool(PKG_CONFIG_AUTODEPS, &autodeps);
+	pkg_config_bool(PKG_CONFIG_SHLIBS, &shlibs);
+	pkg_config_bool(PKG_CONFIG_ARCH_INDEP, &arch_indep);
+
 	int fd;
 
 	if ((fd = open(fpath, O_RDONLY, 0)) < 0) {
@@ -152,6 +160,14 @@ analyse_elf(struct pkgdb *db, struct pkg *pkg, const char *fpath)
 	if (elf_kind(e) != ELF_K_ELF) {
 		close(fd);
 		return (EPKG_END); /* Not an elf file: no results */
+	}
+
+	if (arch_indep)
+		pkg->flags |= PKG_CONTAINS_ARCH_DEP;
+
+	if (!autodeps && !shlibs) {
+	   ret = EPKG_OK;
+	   goto cleanup;
 	}
 
 	if (gelf_getehdr(e, &elfhdr) == NULL) {
@@ -233,15 +249,20 @@ pkg_analyse_files(struct pkgdb *db, struct pkg *pkg)
 	int ret = EPKG_OK;
 	bool shlibs = false;
 	bool autodeps = false;
+	bool arch_indep = false;
 
 	pkg_config_bool(PKG_CONFIG_SHLIBS, &shlibs);
 	pkg_config_bool(PKG_CONFIG_AUTODEPS, &autodeps);
+	pkg_config_bool(PKG_CONFIG_ARCH_INDEP, &arch_indep);
 
-	if (!autodeps && !shlibs)
+	if (!autodeps && !shlibs && !arch_indep)
 		return (EPKG_OK);
 
 	if (elf_version(EV_CURRENT) == EV_NONE)
 		return (EPKG_FATAL);
+
+	if (arch_indep)
+		pkg->flags &= ~PKG_CONTAINS_ARCH_DEP; /* Assume no architecture dependence, for contradiction */
 
 	while (pkg_files(pkg, &file) == EPKG_OK)
 		analyse_elf(db, pkg, pkg_file_get(file, PKG_FILE_PATH));
@@ -262,8 +283,8 @@ elf_corres_to_string(struct _elf_corres* m, int e)
 }
 
 
-int
-pkg_get_myarch(char *dest, size_t sz)
+static int
+get_myarch(char *dest, size_t sz, bool arch_indep)
 {
 	Elf *elf = NULL;
 	GElf_Ehdr elfhdr;
@@ -338,44 +359,51 @@ pkg_get_myarch(char *dest, size_t sz)
 	for (i = 0; osname[i] != '\0'; i++)
 		osname[i] = (char)tolower(osname[i]);
 
-	snprintf(dest, sz, "%s:%d:%s:%s",
-	    osname,
-	    version / 100000,
-	    elf_corres_to_string(mach_corres, (int) elfhdr.e_machine),
-	    elf_corres_to_string(wordsize_corres, (int)elfhdr.e_ident[EI_CLASS]));
+	if (arch_indep) {
+		snprintf(dest, sz, "%s:%d:%s",
+			 osname,
+			 version / 100000,
+			 "arch-indep");
+	} else {
+		snprintf(dest, sz, "%s:%d:%s:%s",
+			 osname,
+			 version / 100000,
+			 elf_corres_to_string(mach_corres, (int) elfhdr.e_machine),
+			 elf_corres_to_string(wordsize_corres, (int)elfhdr.e_ident[EI_CLASS]));
 
-	switch (elfhdr.e_machine) {
-		case EM_ARM:
-			snprintf(dest + strlen(dest), sz - strlen(dest), ":%s:%s:%s",
-			    elf_corres_to_string(endian_corres, (int) elfhdr.e_ident[EI_DATA]),
-			    (elfhdr.e_flags & EF_ARM_NEW_ABI) > 0 ? "eabi" : "oabi",
-			    (elfhdr.e_flags & EF_ARM_VFP_FLOAT) > 0 ? "softfp" : "vfp");
-			break;
-		case EM_MIPS:
-			/*
-			 * this is taken from binutils sources:
-			 * include/elf/mips.h
-			 * mapping is figured out from binutils:
-			 * gas/config/tc-mips.c
-			 */
-			switch (elfhdr.e_flags & EF_MIPS_ABI) {
-				case E_MIPS_ABI_O32:
-					abi = "o32";
-					break;
-				case E_MIPS_ABI_N32:
-					abi = "n32";
-					break;
-				default:
-					if (elfhdr.e_ident[EI_DATA] == ELFCLASS32)
+		switch (elfhdr.e_machine) {
+			case EM_ARM:
+				snprintf(dest + strlen(dest), sz - strlen(dest), ":%s:%s:%s",
+					 elf_corres_to_string(endian_corres, (int) elfhdr.e_ident[EI_DATA]),
+					 (elfhdr.e_flags & EF_ARM_NEW_ABI) > 0 ? "eabi" : "oabi",
+					 (elfhdr.e_flags & EF_ARM_VFP_FLOAT) > 0 ? "softfp" : "vfp");
+				break;
+			case EM_MIPS:
+				/*
+				 * this is taken from binutils sources:
+				 * include/elf/mips.h
+				 * mapping is figured out from binutils:
+				 * gas/config/tc-mips.c
+				 */
+				switch (elfhdr.e_flags & EF_MIPS_ABI) {
+					case E_MIPS_ABI_O32:
 						abi = "o32";
-					else if (elfhdr.e_ident[EI_DATA] == ELFCLASS64)
-						abi = "n64";
-					break;
-			}
-			snprintf(dest + strlen(dest), sz - strlen(dest), ":%s:%s",
-			    elf_corres_to_string(endian_corres, (int) elfhdr.e_ident[EI_DATA]),
-			    abi);
-			break;
+						break;
+					case E_MIPS_ABI_N32:
+						abi = "n32";
+						break;
+					default:
+						if (elfhdr.e_ident[EI_DATA] == ELFCLASS32)
+							abi = "o32";
+						else if (elfhdr.e_ident[EI_DATA] == ELFCLASS64)
+							abi = "n64";
+						break;
+				}
+				snprintf(dest + strlen(dest), sz - strlen(dest), ":%s:%s",
+					 elf_corres_to_string(endian_corres, (int) elfhdr.e_ident[EI_DATA]),
+					 abi);
+				break;
+		}
 	}
 
 cleanup:
@@ -384,4 +412,16 @@ cleanup:
 
 	close(fd);
 	return (ret);
+}
+
+int
+pkg_get_myarch(char *dest, size_t sz)
+{
+	return (get_myarch(dest, sz, false));
+}
+
+int
+pkg_get_myarch_indep(char *dest, size_t sz)
+{
+	return (get_myarch(dest, sz, true));
 }

--- a/pkg/main.c
+++ b/pkg/main.c
@@ -265,6 +265,8 @@ main(int argc, char **argv)
 			printf("Custom keywords directory: %s\n", buf ? buf : "none");
 			pkg_config_bool(PKG_CONFIG_DEVELOPER_MODE, &b);
 			printf("Developer mode: %s\n", b ? "yes" : "no");
+			pkg_config_bool(PKG_CONFIG_ARCH_INDEP, &b);
+			printf("Detect achitecture independence: %s\n", b ? "yes" : "no");
 		}
 		pkg_config_bool(PKG_CONFIG_MULTIREPOS, &b);
 		if (b) {

--- a/pkg/pkg.conf.5
+++ b/pkg/pkg.conf.5
@@ -114,6 +114,11 @@ All the remote repositories should be signed.
 default: off
 .It Cm ABI: string
 the abi of the package you want to install, by default the /bin/sh abi is used
+.It Cm ARCH_INDEP: boolean
+Analyse package contents to detect when it consists entirely of
+architecture independent files (ie. no ELF objects are contained
+within it)
+default: off
 .El
 .Sh ENVIRONMENT
 An environment variable with the same name as the option in the configuration


### PR DESCRIPTION
For review: it struck me that if SHLIBS or AUTODEPS processing was turned on, pkgng was
already doing 99% of the processing necessary to recognize when a pkg doesn't install any
architecture dependent packages.  Here is a first cut at doing that.
