### PR TITLE
Change pkg check -r to also update file checksums.

### DIFF
--- a/libpkg/pkg.h
+++ b/libpkg/pkg.h
@@ -444,6 +444,16 @@ int pkgdb_set2(struct pkgdb *db, struct pkg *pkg, ...);
 #define pkgdb_set(db, pkg, ...) pkgdb_set2(db, pkg, __VA_ARGS__, -1)
 
 /**
+ * update the checksum of a file in the database (and the object)
+ * XXX I don't think this function should be part of a public API.
+ * @param db A pointer to a struct pkgdb object
+ * @param file A pointer to a struct pkg_file object
+ * @param sha256 The new checksum
+ * @return An error code
+ */
+int pkgdb_file_set_cksum(struct pkgdb *db, struct pkg_file *file, const char *sha256);
+
+/**
  * Read the content of a file into a buffer, then call pkg_set().
  */
 int pkg_set_from_file(struct pkg *pkg, pkg_attr attr, const char *file);
@@ -914,7 +924,7 @@ int pkg_init(const char *);
 int pkg_shutdown(void);
 
 void pkg_test_filesum(struct pkg *);
-int64_t pkg_recompute_flatsize(struct pkg *);
+void pkg_recompute(struct pkgdb *, struct pkg *);
 
 int pkg_get_myarch(char *pkgarch, size_t sz);
 

--- a/pkg/check.c
+++ b/pkg/check.c
@@ -239,10 +239,8 @@ exec_check(int argc, char **argv)
 	bool yes = false;
 	bool dcheck = false;
 	bool checksums = false;
-	bool recomputeflatsize = false;
+	bool recompute = false;
 	int nbpkgs = 0;
-	int64_t flatsize;
-	int64_t newflatsize;
 	int i;
 	int verbose = 0;
 
@@ -274,10 +272,10 @@ exec_check(int argc, char **argv)
 				flags |= PKG_LOAD_FILES;
 				break;
 			case 'r':
-				recomputeflatsize = true;
+				recompute = true;
 				flags |= PKG_LOAD_FILES;
 				if (geteuid() != 0)
-					errx(EX_USAGE, "Needs to be root to recompute the flatsize");
+					errx(EX_USAGE, "Needs to be root to recompute the checksums and size");
 				break;
 			case 'v':
 				verbose = 1;
@@ -291,9 +289,9 @@ exec_check(int argc, char **argv)
 	argv += optind;
 
 	/* Default to all packages if no pkg provided */
-	if (argc == 0 && (dcheck || checksums || recomputeflatsize)) {
+	if (argc == 0 && (dcheck || checksums || recompute)) {
 		match = MATCH_ALL;
-	} else if ((argc == 0 && match != MATCH_ALL) || !(dcheck || checksums || recomputeflatsize)) {
+	} else if ((argc == 0 && match != MATCH_ALL) || !(dcheck || checksums || recompute)) {
 		usage_check();
 		return (EX_USAGE);
 	}
@@ -330,13 +328,10 @@ exec_check(int argc, char **argv)
 					printf("Checking checksums: %s\n", pkgname);
 				pkg_test_filesum(pkg);
 			}
-			if (recomputeflatsize) {
+			if (recompute) {
 				if (verbose)
-					printf("Recomputing size: %s\n", pkgname);
-				newflatsize = pkg_recompute_flatsize(pkg);
-				pkg_get(pkg, PKG_FLATSIZE, &flatsize);
-				if (newflatsize != flatsize)
-					pkgdb_set(db, pkg, PKG_SET_FLATSIZE, newflatsize);
+					printf("Recomputing size and sums: %s\n", pkgname);
+				pkg_recompute(db, pkg);
 			}
 		}
 

--- a/pkg/pkg-check.8
+++ b/pkg/pkg-check.8
@@ -33,7 +33,7 @@ is used to check for and install missing dependencies.
 .Pp
 .Nm
 .Fl r
-is used to recompute sizes of installed packages.
+is used to recompute sizes and checksums of installed packages.
 .Pp
 .Nm
 .Fl s


### PR DESCRIPTION
This is an attempt to allow fixing of checksums with pkgng.

Since I couldn't find any example of altering an installed package, I wrote a specialized function that simply updates the sha256 for a file. I'm wondering if a more general approach to altering a package might be appropriate, but I got the impression this is not desired anyway.

I also think that having pkg check actually alter data is a bit counter-intuitive. But since it was already altering the size and it was suggested on irc, I've just extended it (and moved some stuff around to fit). After all, why would the size change but not the checksums?

Please let me know what you think and if you'd like me to change anything.
