### PR TITLE
Documentation Fix: Sync Manpage and Help Message of 'pkg install'

### DIFF
--- a/pkg/install.c
+++ b/pkg/install.c
@@ -44,7 +44,7 @@
 void
 usage_install(void)
 {
-	fprintf(stderr, "usage: pkg install [-r reponame] [-yqfgxX] <pkg-name> <...>\n\n");
+	fprintf(stderr, "usage: pkg install [-r reponame] [-yqfgxXL] <pkg-name> <...>\n\n");
 	fprintf(stderr, "For more information see 'pkg help install'.\n");
 }
 

--- a/pkg/pkg-install.8
+++ b/pkg/pkg-install.8
@@ -23,6 +23,7 @@
 .Nd installs packages from remote package repositories
 .Sh SYNOPSIS
 .Nm
+.Op Fl r Ar reponame
 .Op Fl yqfgxXL
 .Ar <pkg-origin> <...>
 .Sh DESCRIPTION


### PR DESCRIPTION
Pkg install's help message lacks does not mention the -L flag, the manpage does not contain the -r flag.
The patch adds them both.
