### PR TITLE
Separate the package creation and package query stages.

### DIFF
--- a/pkg/create.c
+++ b/pkg/create.c
@@ -93,15 +93,16 @@ pkg_create_matches(int argc, char **argv, match_t match, pkg_formats fmt, const 
 
 	for (i = 0; i < argc || match == MATCH_ALL; i++) {
 		if (match == MATCH_ALL) {
-			if ((it == pkgdb_query(db, NULL, match)) == NULL)
+			printf("Loading package list...\n");
+			if ((it = pkgdb_query(db, NULL, match)) == NULL)
 				goto cleanup;
 			match = !MATCH_ALL;
 		} else
-			if ((it == pkgdb_query(db, argv[i], match)) == NULL)
+			if ((it = pkgdb_query(db, argv[i], match)) == NULL)
 				goto cleanup;
 
 		while ((ret = pkgdb_it_next(it, &pkg, query_flags)) == EPKG_OK) {
-			if ((e = malloc(sizeof(struct pkg_entry)) == NULL))
+			if ((e = malloc(sizeof(struct pkg_entry))) == NULL)
 				err(1, "malloc(pkg_entry)");
 			e->pkg = pkg;
 			pkg = NULL;


### PR DESCRIPTION
Before, after each package query the package would be created however the pkgdb
holds (in the current implementation) a SHARED lock.  Since package creation
could take a long time it resulted in the SHARED lock being help for an extended
amount of time blocking any attempts to alter the database (such as a package
install or package deletion).

By separating the package query and package creation the SHARED lock is only
held for the shortest possible time allowing other operations to continue.

WARNING: this can result in some spurious errors where a package is deleted
before it is created however this results in an error in package creation (vs
the current error of either delayed package deletion or database access timeout)
NOTE: this change cannot introduce inconsistencies into the database.
