### PR TITLE
dlopen() cannot be used in a staticly linked application

### DIFF
--- a/libpkg/Makefile
+++ b/libpkg/Makefile
@@ -43,6 +43,7 @@ CFLAGS+=	-std=c99
 CFLAGS+=	-I${.CURDIR} \
 		-I${.CURDIR}/../external/sqlite \
 		-I${.CURDIR}/../external/libyaml/include
+STATIC_CFLAGS+=	-DSTATIC_LINKAGE
 LDADD+=		-L${.OBJDIR}/../external/sqlite \
 		-L${.OBJDIR}/../external/libyaml \
 		-lsqlite3 \

--- a/libpkg/pkg_elf.c
+++ b/libpkg/pkg_elf.c
@@ -57,6 +57,12 @@ test_depends(struct pkgdb *db, struct pkg *pkg, const char *name)
 	bool shlibs = false;
 	bool autodeps = false;
 
+#ifdef STATIC_LINKAGE
+	/* If we're compiled using static linkage, ie. as pkg-static,
+	   calls to dlopen(3) will fail, so bail out immediately. */
+	return (EPKG_OK);
+#endif
+
 	pkg_config_bool(PKG_CONFIG_AUTODEPS, &autodeps);
 	pkg_config_bool(PKG_CONFIG_SHLIBS, &shlibs);
 

--- a/pkg-static/Makefile
+++ b/pkg-static/Makefile
@@ -1,5 +1,6 @@
 PROG=pkg-static
 
+CFLAGS+=	-DSTATIC_LINKAGE
 STATIC_PKGNG=	yes
 NO_SHARED?=	yes
 NO_MAN=		yes


### PR DESCRIPTION
Add a CPP #define when compiling for static linkage.  Bail out early
from the function calling dlopen() conditionally on that.
