### PR TITLE
Repo with older versions

### DIFF
--- a/libpkg/private/pkgdb.h
+++ b/libpkg/private/pkgdb.h
@@ -48,5 +48,4 @@ int pkgdb_lock(struct pkgdb *db);
 int pkgdb_unlock(struct pkgdb *db);
 
 void pkgshell_open(const char **r);
-
 #endif


### PR DESCRIPTION
'pkg repo' changes to help interaction with portmaster(8) -- make repo
generation tolerant of duplicated packages or repo directory
structures with several tarballs for some package origins.

Update schema for repo.sqlite to add foreign key cascade options --
fixes cleanly deleting packages from repo.sqlite for incremental updates

Add checks for PRAGMA user_version handling for repo.sqlite.  At the
moment, this is only applied on the generating side (pkg repo).  TODO:
add similar checks when installing (pkg install)

Use package cksum to detect packages already in the repo when
updating, independent of location in repo

Fix cleaning the shlibs table

Some style fixes

After these changes:

```
worm:/usr/ports/packages:# pkg repo /usr/ports/packages
Generating repo.sqlite in /usr/ports/packages: \pkg:
duplicate package origin: package All/pkg-1.0.b15_3.txz is not newer than version 1.0.b16 already in repo for origin ports-mgmt/pkg
|pkg: duplicate package origin: replacing older version 1.43 in repo with package All/p5-Filter-1.45.txz for origin devel/p5-Filter
\pkg: duplicate package origin: replacing older version 3.12.1 in repo with package All/portmaster-3.12.2.txz for origin ports-mgmt/portmaster
done!
```
