### PR TITLE
Cleanup pkg set line

### DIFF
--- a/ports/patch-portmaster-pkgng
+++ b/ports/patch-portmaster-pkgng
@@ -1205,7 +1205,7 @@ $FreeBSD$
 +else
 +	if [ -n "$ro_opd" ]; then
 +		echo "===>>> Updating dependency entry for $new_port in each dependent port"
-+		pkg set -yo $ro_opd:$portdir -g "*"
++		pkg set -yo $ro_opd:$portdir
 +	fi
  fi
  


### PR DESCRIPTION
pkg set -o now acts on all packages by default, remove -g "*" (which, by the way, has been replaced by -a).
