### PR TITLE
[pull-request] pkg/pkg-shlib.8: Add missing full stop.

### DIFF
--- a/pkg/pkg.conf.5
+++ b/pkg/pkg.conf.5
@@ -99,7 +99,7 @@ This option when enabled will tell
 to work in multiple repositories mode.
 For example repositories
 definitions, please have a look at the sample configuration file.
-.It Cm PLIST_KEYWORS_DIR: string
+.It Cm PLIST_KEYWORDS_DIR: string
 < To be added >
 .It Cm PORTSDIR: string
 Specifies the location to the Ports directory.


### PR DESCRIPTION
Adds trailing '.' to DESCRIPTION.
