### PR TITLE
pkg/pkg.8: Set FreeBSD version

### DIFF
--- a/pkg/pkg.8
+++ b/pkg/pkg.8
@@ -189,7 +189,7 @@ See
 The
 .Nm
 command first appeared in
-.Fx \" TODO: Put release there
+.Fx 9.1 .
 .\" ---------------------------------------------------------------------------
 .Sh AUTHORS AND CONTRIBUTORS
 .An Baptiste Daroussin Aq bapt@FreeBSD.org


### PR DESCRIPTION
Since FreeBSD 9.1 has /usr/sbin/pkg, set Fx version to 9.1.
