### PR TITLE
Fix for Issue #377

### DIFF
--- a/pkg/upgrade.c
+++ b/pkg/upgrade.c
@@ -52,7 +52,7 @@ exec_upgrade(int argc, char **argv)
 	int retcode = 1;
 	int updcode;
 	int ch;
-	bool yes = false;
+	bool yes;
 	bool all = false;
 	bool dry_run = false;
 	bool auto_update = true;


### PR DESCRIPTION
Matthias and I have finished our fix for issue #377. An explanation follows:
# Status Quo

So far, the message telling you how many bytes need to be downloaded if you use pkg-install is created this way:
- add recorded package size to variable dlsize
- if cached package file exists, remove actual size of cached package from dlsize

There are four cases to consider regarding the cache file:
1. nonexistent: the old solution **works**
2. correct: the old solution **works**
3. corrupted; size is different than recorded in repo: weidest **bogus** results currently, see text in issue #377
4. corrupted; size is the same as recorded: **wrong** results (0 B to be downloaded)

Point 3. is common if you build packages yourself from time to time, no. 4. should be rare.
# Solution in Pull Request

We thought about adding a checksum-check to the function to make sure
the messages are 100% precise, but considered a duplicate sha256 check of
(possibly large) file to be too expensive. Thus, we decided to ignore
no. 4 (file corrupted but file of presisely same size as recorded in
repo) since it should be rare anyways. We merely compare the size of
the cache file with the recorded size in the repository to catch case
no. 3.

In order to catch case no. 4, you would have to:
- calculate checksum twice
- OR refactor libpkg code to do checksum caching

Both look like a worse choice to us.

PS.: There are 3 bogus commits in the pull request. 1 to revert another and one merge with upstream. Not sure if github ignores them, feel free to remove those commits (if you manage to figure out how :-) ).

Regards,
Matthias Bohnstedt and Roman Naumann
