### PR TITLE
fixes issue #377

### DIFF
--- a/pkg/utils.c
+++ b/pkg/utils.c
@@ -587,10 +587,11 @@ print_jobs_summary(struct pkg_jobs *jobs, pkg_jobs_t type, const char *msg, ...)
 
 		switch (type) {
 		case PKG_JOBS_INSTALL:
-			dlsize += pkgsize;
 			snprintf(path, MAXPATHLEN, "%s/%s", cachedir, pkgrepopath);
-			if (stat(path, &st) != -1)
-				dlsize -= st.st_size;
+			if (stat(path, &st) == -1 || pkgsize != st.st_size)
+				/* file looks corrupted (wrong size), assume a checksum mismatch will
+				   occur later and the file will be fetched from remote again */
+				dlsize += pkgsize;
 
 			if (newversion != NULL) {
 				switch (pkg_version_cmp(version, newversion)) {


### PR DESCRIPTION
See https://github.com/pkgng/pkgng/pull/397 , conforms to style(9) this time. (changed comment syntax from // to /\* ... */. Thanks @bapt for feedback.

PS.: We didn't add  the 'unlink' call as discussed with @bapt on IRC for the following reason:
- This is merely a "display format" function. It should shows the estimated download size  - not change the filesystem.
- "pkg install screen" asks for confirmation. If you say "No" pkg should not change the filesystem in our opinion. Adding the 'unlink' call to the display function would delete (invalid) cached package files even if you say "No" at the confirmation dialog.

We suggest to add a size-check before the checksum check to pkg_repo_fetch() in libpkg/pkg_repo.c near line 218 - if you do not want to make unneeded checksum checks when the file size is off anyways. Another advantage of this is that it becomes easier to add a "continue downloads" feature later (since incomplete files wont get deleted earlier in the "display format" function).
