### PR TITLE
Fix license logic

### DIFF
--- a/libpkg/pkg_manifest.c
+++ b/libpkg/pkg_manifest.c
@@ -221,12 +221,12 @@ pkg_set_licenselogic_from_node(struct pkg *pkg, yaml_node_t *val,
 {
 	if (!strcmp(val->data.scalar.value, "single"))
 		pkg_set(pkg, PKG_LICENSE_LOGIC, (int64_t) LICENSE_SINGLE);
-	else if (!strcmp(val->data.scalar.value, "and") ||
-	    !strcmp(val->data.scalar.value, "dual"))
-		pkg_set(pkg, PKG_LICENSE_LOGIC, (int64_t)LICENSE_AND);
 	else if (!strcmp(val->data.scalar.value, "or") ||
-	    !strcmp(val->data.scalar.value, "multi"))
+	    !strcmp(val->data.scalar.value, "dual"))
 		pkg_set(pkg, PKG_LICENSE_LOGIC, (int64_t)LICENSE_OR);
+	else if (!strcmp(val->data.scalar.value, "and") ||
+	    !strcmp(val->data.scalar.value, "multi"))
+		pkg_set(pkg, PKG_LICENSE_LOGIC, (int64_t)LICENSE_AND);
 	else {
 		pkg_emit_error("Unknown license logic: %s",
 		    val->data.scalar.value);


### PR DESCRIPTION
`dual` equals to `OR`, `multi` to `AND`; they were inverted.
