### PR TITLE
Fix output of `pkg check -s`.

### DIFF
--- a/pkg/event.c
+++ b/pkg/event.c
@@ -226,6 +226,7 @@ event_callback(void *data, struct pkg_event *ev)
 		    PKG_VERSION, &version);
 		fprintf(stderr, "%s-%s: checksum mismatch for %s\n", name,
 		    version, pkg_file_path(ev->e_file_mismatch.file));
+		break;
 	case PKG_EVENT_PLUGIN_ERRNO:
 		warnx("%s: %s(%s): %s", pkg_plugin_get(ev->e_plugin_errno.plugin, PKG_PLUGIN_NAME),
 		    ev->e_plugin_errno.func, ev->e_plugin_errno.arg, strerror(ev->e_plugin_errno.no));


### PR DESCRIPTION
Due to a lacking break, `pkg` output:

```
pkg-1.0.6: checksum mismatch for /usr/local/lib/libpkg.a
pkg: : /usr/local/lib/libpkg.a(f218119bf90cfda565a798efa772210e564397d623772de67149523cfe4a7ab6): Unknown error: -46
pkg-1.0.6: checksum mismatch for /usr/local/sbin/pkg
pkg: : /usr/local/sbin/pkg(8d2b9ff7309d0be85962a7de9406157735d9c0bce4592aabc00a9c8e34452abd): Unknown error: -14144
pkg-1.0.6: checksum mismatch for /usr/local/sbin/pkg-static
pkg: : /usr/local/sbin/pkg-static(cf9ef62ad4235fa5f6d461c1ac7a87292e4c0c3dec5f915ded83d0d1568c8175): Unknown error: -14144
```

instead of:

```
pkg-1.0.6: checksum mismatch for /usr/local/lib/libpkg.a
pkg-1.0.6: checksum mismatch for /usr/local/sbin/pkg
pkg-1.0.6: checksum mismatch for /usr/local/sbin/pkg-static
```
