### PR TITLE
check the return value of sqlite3_column_text() against NULL in get_sql_string()

### DIFF
--- a/libpkg/pkgdb.c
+++ b/libpkg/pkgdb.c
@@ -2894,8 +2894,11 @@ get_sql_string(sqlite3 *s, const char *sql, char **res)
 
 	ret = sqlite3_step(stmt);
 
-	if (ret == SQLITE_ROW)
-		*res = strdup(sqlite3_column_text(stmt, 0));
+	if (ret == SQLITE_ROW) {
+		const unsigned char *tmp;
+		tmp = sqlite3_column_text(stmt, 0);
+		*res = (tmp == NULL ? NULL : strdup(tmp));
+	}
 
 	if (ret == SQLITE_DONE)
 		*res = NULL;


### PR DESCRIPTION
The return value of sqlite3_column_text() was not checked and passed
directly to strdup() causing a SIGSEV from libc. This patch ensure that
a NULL returned value will not be given to strdup().

see #455
