### PR TITLE
Add -n option to pkg-check.

### DIFF
--- a/pkg/pkg-check.8
+++ b/pkg/pkg-check.8
@@ -24,7 +24,7 @@
 .Sh SYNOPSIS
 .Nm
 .Op Fl Bdsr
-.Op Fl vy
+.Op Fl vyn
 .Op Fl a | gix Ar <pattern>
 .Sh DESCRIPTION
 .Nm
@@ -53,6 +53,8 @@ The following options are supported by
 Assume yes when asked for confirmation before installing missing dependencies.
 .It Fl v
 Be verbose.
+.It Fl n
+Merely check for missing dependencies and do not install them. 
 .It Fl a
 Process all packages.
 .It Fl i


### PR DESCRIPTION
Add -n option to pkg-check to allow querying dependencies without
installing them to a system. When this option is specified pkg-check
swithces to reduced output mode that simplify parsing by side scripts
merely printing origins of the dependencies of a package.
