### PR TITLE
pkg fails to register a package with NFS root

### DIFF
--- a/libpkg/elfhints.c
+++ b/libpkg/elfhints.c
@@ -225,8 +225,11 @@ scan_dirs_for_shlibs(struct shlib_list **shlib_list, int numdirs,
 			int		 ret;
 			const char	*vers;
 
-			/* Only regular files and sym-links */
-			if (dp->d_type != DT_REG && dp->d_type != DT_LNK)
+			/* Only regular files and sym-links. On some
+			   filesystems d_type is not set, on these the d_type
+			   field will be DT_UNKNOWN. */
+			if (dp->d_type != DT_REG && dp->d_type != DT_LNK &&
+			    dp->d_type != DT_UNKNOWN)
 				continue;
 
 			len = strlen(dp->d_name);


### PR DESCRIPTION
While building packages on a PandaBoard with an NFS root pkg failed to register the installation with the error:

```
Assertion failed: (!STAILQ_EMPTY(&shlibs)), function shlib_list_find_by_name, file elfhints.c, line 125.
```

On further investigation I found this was because the `readdir` call in `scan_dirs_for_shlibs` was returning a dirent structure with the `d_type` field set to `DT_UNKNOWN` (= 0) and therefore not adding anything to the `shlibs` list.

When I asked about this on IRC Jilles Tjoelker said it is a valid response as this field is not guaranteed:

```
21:08  * _andy_t_ wonders why readdir is returning a dirent with d_type == 0
21:10 <@jilles> _andy_t_, that's a normal thing for many filesystems such as
                NFS without the rdirplus option
21:11 <@jilles> d_type is not guaranteed; if the filesystem would have to
                perform work equivalent to a full lstat(), it just returns
                DT_UNKNOWN
```

To fix this I've changed the check after the `readline` call in `scan_dirs_for_shlibs` to allow for `DT_UNKNOWN`. With this packages are correctly registered.
