### PR TITLE
fixes build issue for clang-3.2 and later (missing variable declaration ...

### DIFF
--- a/pkg/pkgcli.h
+++ b/pkg/pkgcli.h
@@ -28,7 +28,9 @@
 #define _PKGCLI_H
 
 extern bool quiet;
+extern int nbactions;
 int nbactions;
+extern int nbdone;
 int nbdone;
 
 /* pkg add */


### PR DESCRIPTION
...in combination with -Werror causes build failure)

Clang 3.2 and newer complain if you define a variable in a header without an accompanying extern declaration. Since "cc" defaults to clang on 10-CURRENT, the build from master fails on my raspberry pi without this patch.

Note that this only causes a build failure due to the combination of -Wall and -Werror.
