### PR TITLE
Fixes a build issue on pre-10.x FreeBSD systems, where MK_CTF is not def...

### DIFF
--- a/tests/bsd.tests.mk
+++ b/tests/bsd.tests.mk
@@ -25,7 +25,7 @@ NO_WERROR=
 CFLAGS+=${DEBUG_FLAGS}
 CXXFLAGS+=${DEBUG_FLAGS}
 
-.  if ${MK_CTF} != "no" && ${DEBUG_FLAGS:M-g} != ""
+.  if defined(MK_CTF) && ${MK_CTF} != "no" && ${DEBUG_FLAGS:M-g} != ""
 CTFFLAGS+= -g
 .  endif
 .endif
@@ -98,7 +98,7 @@ ${_test}: ${${_test}_OBJS}
 .    else
 	${CC} ${CFLAGS} ${LDFLAGS} -o ${.TARGET} ${${_test}_OBJS} ${LDADD} ${LATF_C}
 .    endif
-.    if ${MK_CTF} != "no"
+.    if defined(MK_CTF) && ${MK_CTF} != "no"
 	${CTFMERGE} ${CTFFLAGS} -o ${.TARGET} ${${_test}_OBJS}
 .    endif
 .  endif			# defined(${_test}_OBJS)


### PR DESCRIPTION
...ined (by /usr/share/mk/bsd.own.mk) yet.

The default on 9.1 and 10-CURRENT as of now is that CTF information is not used. With this patch, if MK_CTF is
undefined, the same logic as for MK_CTF == "no" will be employed.

PS.: Thanks at marino from IRC for hinting MK_CTF probably being undefined.
