### PR TITLE
Properly show how much space is going to be free/required when deinstalling (which is the opposite of the installation case).

### DIFF
--- a/pkg/utils.c
+++ b/pkg/utils.c
@@ -663,7 +663,7 @@ print_jobs_summary(struct pkg_jobs *jobs, const char *msg, ...)
 			break;
 		case PKG_JOBS_DEINSTALL:
 		case PKG_JOBS_AUTOREMOVE:
-			printf("\nThe deinstallation will free %s\n", size);
+			printf("\nThe deinstallation will require %s more space\n", size);
 			break;
 		case PKG_JOBS_FETCH:
 			/* nothing to report here */
@@ -681,7 +681,7 @@ print_jobs_summary(struct pkg_jobs *jobs, const char *msg, ...)
 			break;
 		case PKG_JOBS_DEINSTALL:
 		case PKG_JOBS_AUTOREMOVE:
-			printf("\nThe deinstallation will require %s more space\n", size);
+			printf("\nThe deinstallation will free %s\n", size);
 			break;
 		case PKG_JOBS_FETCH:
 			/* nothing to report here */


### PR DESCRIPTION
Testing one of my ports with the beta announced today, I noticed the following:

"Deinstallation has been requested for the following 1 packages:

```
    wine-gecko-2.21
```

The deinstallation will require 20 MB more space
[1/1] Deleting wine-gecko-2.21... done"

This is clearly incorrect, and looking at the code in pkg/utils.c I realized that
installation and deinstallation are handled the same when, really, they are the
respective opposites.
