### PR TITLE
Stop processing the note section at the end of it.

### DIFF
--- a/libpkg/pkg_elf.c
+++ b/libpkg/pkg_elf.c
@@ -575,12 +575,17 @@ pkg_get_myarch(char *dest, size_t sz)
 
 	data = elf_getdata(scn, NULL);
 	src = data->d_buf;
-	while (1) {
+	while ((uintptr_t)src < ((uintptr_t)data->d_buf + data->d_size)) {
 		memcpy(&note, src, sizeof(Elf_Note));
 		src += sizeof(Elf_Note);
 		if (note.n_type == NT_VERSION)
 			break;
 		src += note.n_namesz + note.n_descsz;
+	}
+	if ((uintptr_t)src >= ((uintptr_t)data->d_buf + data->d_size)) {
+		ret = EPKG_FATAL;
+		pkg_emit_error("fail to find the version elf note");
+		goto cleanup;
 	}
 	osname = src;
 	src += roundup2(note.n_namesz, 4);


### PR DESCRIPTION
The code may look past the end of the .note.tag section if there is no version note in it. This patch fixes this b checking if it is still in it before continuing the loop.
