### PR TITLE
Change manual page so the -d and -r are more mnemonic

### DIFF
--- a/pkg/pkg-info.8
+++ b/pkg/pkg-info.8
@@ -72,10 +72,11 @@ as a regular expression according to the "modern" or "extended" syntax
 of
 .Xr re_format 7 .
 .It Fl d
-Display the list of packages required by
-.Ar pkg-name .
+Display the list of packages on which
+.Ar pkg-name 
+depends.
 .It Fl r
-Display the list of packages which depend on
+Display the list of packages which require
 .Ar pkg-name .
 .It Fl k
 Show the locking status for


### PR DESCRIPTION
-d  Display the list of packages on which pkg-name **depends**.
-r  Display the list of packages which **require** pkg-name.

I don't know if aligning text on the manual page entries for depends and requires to be mnemonic for -d -r is enough. I am using pkg-1.1.1 - in previous releases an informational message "<pkgname> is required by" or "<pkgname> is depends on" accompanied the output when these options were used.  I think the message is important to avoid ambiguity (-d could be "depends" or "dependencies" ; -r could be "requires" or "requirements"), whereas the mnemonics help users establish cached copies of manual pages in their brains.
