### PR TITLE
When creating a package, compute the flatsize if it is not specified in the manifest.

### DIFF
--- a/libpkg/private/pkg.h
+++ b/libpkg/private/pkg.h
@@ -152,6 +152,7 @@ struct pkg_category {
 
 struct pkg_file {
 	char		 path[MAXPATHLEN +1];
+	int64_t		 size;
 	char		 sum[SHA256_DIGEST_LENGTH * 2 +1];
 	char		 uname[MAXLOGNAME +1];
 	char		 gname[MAXLOGNAME +1];


### PR DESCRIPTION
Note that there is just a short leap from here to allowing the sizes of individual files to be recorded in the manifest, but that requires an API change.
