### PR TITLE
Cross root installing

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Table of Contents:
 * [Installing from remote repositories](#pkginstall)
 * [Backing up your package database](#pkgbackup)
 * [Creating a package repository](#pkgcreate)
+* [Cross root installing](#crossroot)
 * [Additional resources](#resources)
 
 <a name="libpkg"></a>
@@ -439,6 +440,12 @@ Here's an example that will create a repository of all your currently installed 
 The above commands will create a repository of all packages on your system.
 
 Now you can share your repo with other people by letting them know of your repository :)
+
+<a name="crossroot"></a>
+### Install packages to mounted directory
+
+You can use pkg for installing to mounted other system (not chroot or jail way):
+_OVERRIDDEN_ROOT_ = /mnt _PKG_DBDIR_ = /mnt/var/db/pkg _PKG_CACHEDIR_ = /mnt/var/cache/pkg
 
 <a name="resources"></a>
 ### Additional resources

--- a/libpkg/pkg.h.in
+++ b/libpkg/pkg.h.in
@@ -348,6 +348,7 @@ typedef enum _pkg_config_key {
 	PKG_CONFIG_ENV,
 	PKG_CONFIG_DISABLE_MTREE,
 	PKG_CONFIG_DEBUG_LEVEL,
+	PKG_CONFIG_OVERRIDDEN_ROOT,
 } pkg_config_key;
 
 typedef enum {

--- a/libpkg/pkg_add.c
+++ b/libpkg/pkg_add.c
@@ -47,10 +47,21 @@ do_extract(struct archive *a, struct archive_entry *ae)
 	int	retcode = EPKG_OK;
 	int	ret = 0;
 	char	path[MAXPATHLEN + 1];
-	struct stat st;
+	struct stat st;	
+	const char* overridden_root;
+	pkg_config_string(PKG_CONFIG_OVERRIDDEN_ROOT, &overridden_root);
 
 	do {
 		const char *pathname = archive_entry_pathname(ae);
+		/*
+		 * If we have overridden path - make changes to archive entry.
+		 */
+		if(overridden_root != NULL) {
+			char newPath[MAXPATHLEN + 1];
+			snprintf(newPath, MAXPATHLEN, "%s%s", overridden_root, pathname);
+			archive_entry_set_pathname(ae, newPath);
+			*pathname = archive_entry_pathname(ae);
+		}
 
 		ret = archive_read_extract(a, ae, EXTRACT_ARCHIVE_FLAGS);
 		if (ret != ARCHIVE_OK) {

--- a/libpkg/pkg_config.c
+++ b/libpkg/pkg_config.c
@@ -281,6 +281,12 @@ static struct config_entry c[] = {
 		"0",
 		"Level for debug messages",
 	},
+	[PKG_CONFIG_OVERRIDDEN_ROOT] = {
+		PKG_CONFIG_STRING,
+		"OVERRIDDEN_ROOT",
+		NULL,
+		"Directory to which all packages will be extracted",
+	},
 };
 
 static bool parsed = false;


### PR DESCRIPTION
In some cases when neither chroot nor jail not an option, would be good to have ability to install packages into some specified dir.

This can be used when you for example preparing install media, or you have host amd64 and want to install packages for i386/arm/etc - there not much reason to deny this, as package handling is pretty straighforward "unpack and tell to DB about this". With specifying PKG_CONFIG_ABI, PKG_CONFIG_OVERRIDDEN_ROOT, PKG_CONFIG_DBDIR, PKG_CONFIG_CACHEDIR and with PKG_ADD_NOSCRIPT that could be done.
