### PR TITLE
- Fix an error that prevents the use of `pkg add' or `pkg annotate'.

### DIFF
--- a/pkg/main.c
+++ b/pkg/main.c
@@ -687,7 +687,7 @@ main(int argc, char **argv)
 	}
 
 	len = strlen(newargv[0]);
-	for (i = 2; i < cmd_len; i++) {
+	for (i = 0; i < cmd_len; i++) {
 		if (strncmp(newargv[0], cmd[i].name, len) == 0) {
 			/* if we have the exact cmd */
 			if (len == strlen(cmd[i].name)) {


### PR DESCRIPTION
@bapt broke this in commit 50239e307a4b5a037403c38dca75ed11c41f0017
