### PR TITLE
Do not warn twice (and incorrectly so) about the same issue in do_extrac...

### DIFF
--- a/libpkg/pkg_add.c
+++ b/libpkg/pkg_add.c
@@ -66,7 +66,7 @@ do_extract(struct archive *a, struct archive_entry *ae)
 				pkg_emit_error("archive_read_extract(): %s",
 				    archive_error_string(a));
 				retcode = EPKG_FATAL;
-				break;
+				goto cleanup;
 			}
 		}
 
@@ -86,7 +86,7 @@ do_extract(struct archive *a, struct archive_entry *ae)
 				pkg_emit_error("archive_read_extract(): %s",
 				    archive_error_string(a));
 				retcode = EPKG_FATAL;
-				break;
+				goto cleanup;
 			}
 		}
 	} while ((ret = archive_read_next_header(a, &ae)) == ARCHIVE_OK);
@@ -97,6 +97,7 @@ do_extract(struct archive *a, struct archive_entry *ae)
 		retcode = EPKG_FATAL;
 	}
 
+cleanup:
 	return (retcode);
 }
 


### PR DESCRIPTION
Debugging something I noticed that for a permission problem installing a package I
would always get the following two lines of diagnostics:

  pkg: archive_read_extract(): Can't set UID=0
  pkg: archive_read_next_header(): Can't set UID=0

Reviewing the code in libpkg/pkg_add.c I found that the second was actually only
an artefact of incorrect error handling code.  Using "break" to exit the loop would
then involve the second error handler, after the loop, since this was an issue
different from EOF and hence that second error handler would fire.
