### PR TITLE
When pkg add fails, we try to clean up, and may issue tons of warnings about missing (not yet installed) files

### DIFF
--- a/libpkg/pkg_add.c
+++ b/libpkg/pkg_add.c
@@ -315,8 +315,8 @@ pkg_add(struct pkgdb *db, const char *path, unsigned flags, struct pkg_manifest_
 	 * Extract the files on disk.
 	 */
 	if (extract && (retcode = do_extract(a, ae)) != EPKG_OK) {
-		/* If the add failed, clean up */
-		pkg_delete_files(pkg, 1);
+		/* If the add failed, clean up (silently) */
+		pkg_delete_files(pkg, 2);
 		pkg_delete_dirs(db, pkg, 1);
 		goto cleanup_reg;
 	}

--- a/libpkg/private/pkg.h
+++ b/libpkg/private/pkg.h
@@ -362,7 +362,7 @@ int packing_append_tree(struct packing *pack, const char *treepath,
 int packing_finish(struct packing *pack);
 pkg_formats packing_format_from_string(const char *str);
 
-int pkg_delete_files(struct pkg *pkg, bool force);
+int pkg_delete_files(struct pkg *pkg, unsigned force);
 int pkg_delete_dirs(struct pkgdb *db, struct pkg *pkg, bool force);
 
 int pkgdb_is_dir_used(struct pkgdb *db, const char *dir, int64_t *res);


### PR DESCRIPTION
When pkg add fails and we try to clean up what we may have installed
already, be silent about failures doing so (since things may not have
been installed actually).

Change the force parameter of pkg_delete_files() from a boolean to a
tri-state on the implementation side and a add bit of documentation.
