### PR TITLE
jobs_solve_fetch(): remove unused `flag' variable.

### DIFF
--- a/libpkg/pkg_jobs.c
+++ b/libpkg/pkg_jobs.c
@@ -915,10 +915,6 @@ jobs_solve_fetch(struct pkg_jobs *j)
 	struct pkg *pkg = NULL;
 	struct pkgdb_it *it;
 	char *origin;
-	unsigned flag = PKG_LOAD_BASIC;
-
-	if ((j->flags & PKG_FLAG_WITH_DEPS) == PKG_FLAG_WITH_DEPS)
-		flag |= PKG_LOAD_DEPS;
 
 	if ((j->flags & PKG_FLAG_UPGRADES_FOR_INSTALLED) == PKG_FLAG_UPGRADES_FOR_INSTALLED) {
 		if ((it = pkgdb_query(j->db, NULL, MATCH_ALL)) == NULL)


### PR DESCRIPTION
scan-build (clang's static analyzer) did complain about `flag` being unused. This patch just removes it but it may be a bug where `flag` should be used but is not.

see 8a3385f5a8997003bff9305c91fe783de9b13e86 where `flag` is unused and removed from `jobs_solve_upgrade` and unused from `jobs_solve_fetch`  but not removed. Hence I believe that this PR, which remove `flag` from `jobs_solve_fetch` seems reasonable.
