### PR TITLE
Fix bug that made pkg repo segfault

### DIFF
--- a/libpkg/pkg_manifest.c
+++ b/libpkg/pkg_manifest.c
@@ -803,7 +803,8 @@ pkg_emit_filelist(struct pkg *pkg, FILE *f)
 		urlencode(pkg_file_path(file), &b);
 		seq = ucl_array_append(seq, ucl_object_fromlstring(sbuf_data(b), sbuf_len(b)));
 	}
-	obj = ucl_object_insert_key(obj, seq, "files", 5, false);
+	if (seq != NULL)
+		obj = ucl_object_insert_key(obj, seq, "files", 5, false);
 
 	output = ucl_object_emit(obj, UCL_EMIT_JSON_COMPACT);
 	fprintf(f, "%s", output);


### PR DESCRIPTION
Introduced in 5dc36026fc60c64763d82a69ef2921b3cd78e913, pkg repo -l
crashed on packages (meta ports) that don't install files on their own.

See also:
http://lists.freebsd.org/pipermail/freebsd-ports/2013-December/088276.html
