### PR TITLE
Use MAX* consistently

### DIFF
--- a/libpkg/pkg.c
+++ b/libpkg/pkg.c
@@ -1337,8 +1337,8 @@ pkg_copy_tree(struct pkg *pkg, const char *src, const char *dest)
 	struct packing *pack;
 	struct pkg_file *file = NULL;
 	struct pkg_dir *dir = NULL;
-	char spath[MAXPATHLEN + 1];
-	char dpath[MAXPATHLEN + 1];
+	char spath[MAXPATHLEN];
+	char dpath[MAXPATHLEN];
 	bool disable_mtree;
 	const char *prefix;
 	char *mtree;

--- a/libpkg/pkg_add.c
+++ b/libpkg/pkg_add.c
@@ -46,7 +46,7 @@ do_extract(struct archive *a, struct archive_entry *ae)
 {
 	int	retcode = EPKG_OK;
 	int	ret = 0;
-	char	path[MAXPATHLEN + 1];
+	char	path[MAXPATHLEN];
 	struct stat st;
 
 	do {
@@ -163,7 +163,7 @@ pkg_add(struct pkgdb *db, const char *path, unsigned flags, struct pkg_manifest_
 	bool		 extract = true;
 	bool		 handle_rc = false;
 	bool		 disable_mtree;
-	char		 dpath[MAXPATHLEN + 1];
+	char		 dpath[MAXPATHLEN];
 	const char	*basedir;
 	const char	*ext;
 	char		*mtree;

--- a/libpkg/pkg_create.c
+++ b/libpkg/pkg_create.c
@@ -44,7 +44,7 @@ static int
 pkg_create_from_dir(struct pkg *pkg, const char *root,
     struct packing *pkg_archive)
 {
-	char		 fpath[MAXPATHLEN + 1];
+	char		 fpath[MAXPATHLEN];
 	struct pkg_file	*file = NULL;
 	struct pkg_dir	*dir = NULL;
 	char		*m;

--- a/libpkg/pkg_jobs.c
+++ b/libpkg/pkg_jobs.c
@@ -1047,7 +1047,7 @@ pkg_jobs_install(struct pkg_jobs *j)
 	struct pkgdb_it *it = NULL;
 	struct pkg *pkg_queue = NULL;
 	struct pkg_manifest_key *keys = NULL;
-	char path[MAXPATHLEN + 1];
+	char path[MAXPATHLEN];
 	const char *cachedir = NULL;
 	int flags = 0;
 	int retcode = EPKG_FATAL;
@@ -1286,7 +1286,7 @@ pkg_jobs_fetch(struct pkg_jobs *j)
 	struct pkg *pkg = NULL;
 	struct statfs fs;
 	struct stat st;
-	char path[MAXPATHLEN + 1];
+	char path[MAXPATHLEN];
 	int64_t dlsize = 0;
 	const char *cachedir = NULL;
 	const char *repopath = NULL;

--- a/libpkg/pkg_ports.c
+++ b/libpkg/pkg_ports.c
@@ -490,7 +490,7 @@ meta_exec(struct plist *p, char *line, struct file_attr *a, bool unexec)
 {
 	char *cmd, *buf, *tmp;
 	char comment[2];
-	char path[MAXPATHLEN + 1];
+	char path[MAXPATHLEN];
 	regmatch_t pmatch[2];
 	int ret;
 

--- a/libpkg/pkg_repo.c
+++ b/libpkg/pkg_repo.c
@@ -54,8 +54,8 @@
 int
 pkg_repo_fetch(struct pkg *pkg)
 {
-	char dest[MAXPATHLEN + 1];
-	char url[MAXPATHLEN + 1];
+	char dest[MAXPATHLEN];
+	char url[MAXPATHLEN];
 	int fetched = 0;
 	char cksum[SHA256_DIGEST_LENGTH * 2 +1];
 	char *path = NULL;
@@ -168,7 +168,7 @@ pkg_create_repo(char *path, const char *output_dir, bool filelist,
 	int retcode = EPKG_OK;
 
 	char *repopath[2];
-	char repodb[MAXPATHLEN + 1];
+	char repodb[MAXPATHLEN];
 	char *manifest_digest;
 	FILE *psyml, *fsyml, *mandigests;
 
@@ -342,9 +342,9 @@ read_pkg_file(void *data)
 	struct pkg_manifest_key *keys = NULL;
 
 	FTSENT *fts_ent = NULL;
-	char fts_accpath[MAXPATHLEN + 1];
-	char fts_path[MAXPATHLEN + 1];
-	char fts_name[MAXPATHLEN + 1];
+	char fts_accpath[MAXPATHLEN];
+	char fts_path[MAXPATHLEN];
+	char fts_name[MAXPATHLEN];
 	off_t st_size;
 	int fts_info, flags;
 
@@ -586,8 +586,8 @@ int
 pkg_finish_repo(const char *output_dir, pem_password_cb *password_cb,
     char **argv, int argc, bool filelist)
 {
-	char repo_path[MAXPATHLEN + 1];
-	char repo_archive[MAXPATHLEN + 1];
+	char repo_path[MAXPATHLEN];
+	char repo_archive[MAXPATHLEN];
 	struct rsa_key *rsa = NULL;
 	struct stat st;
 	int ret = EPKG_OK;

--- a/libpkg/pkgdb.c
+++ b/libpkg/pkgdb.c
@@ -783,7 +783,7 @@ static int
 pkgdb_open_multirepos(const char *dbdir, struct pkgdb *db)
 {
 	int		  ret;
-	char		  remotepath[MAXPATHLEN + 1];
+	char		  remotepath[MAXPATHLEN];
 	struct pkg_repo	 *r = NULL;
 	int		  repocount = 0;
 
@@ -898,7 +898,7 @@ file_mode_insecure(const char *path, bool install_as_user)
 static int
 database_access(unsigned mode, const char* dbdir, const char *dbname)
 {
-	char		 dbpath[MAXPATHLEN + 1];
+	char		 dbpath[MAXPATHLEN];
 	int		 retval;
 	bool		 database_exists;
 	bool		 install_as_user;
@@ -1034,7 +1034,7 @@ pkgdb_open(struct pkgdb **db_p, pkgdb_t type)
 	struct pkgdb	*db = NULL;
 	struct statfs	 stfs;
 	bool		 reopen = false;
-	char		 localpath[MAXPATHLEN + 1];
+	char		 localpath[MAXPATHLEN];
 	const char	*dbdir = NULL;
 	bool		 create = false;
 	bool		 createdir = false;
@@ -3952,7 +3952,7 @@ pkgdb_cmd(int argc, char **argv)
 void
 pkgshell_open(const char **reponame)
 {
-	char		 localpath[MAXPATHLEN + 1];
+	char		 localpath[MAXPATHLEN];
 	const char	*dbdir;
 
 	sqlite3_auto_extension((void(*)(void))sqlcmd_init);

--- a/libpkg/private/pkg.h
+++ b/libpkg/private/pkg.h
@@ -157,20 +157,20 @@ struct pkg_category {
 };
 
 struct pkg_file {
-	char		 path[MAXPATHLEN +1];
+	char		 path[MAXPATHLEN];
 	int64_t		 size;
-	char		 sum[SHA256_DIGEST_LENGTH * 2 +1];
-	char		 uname[MAXLOGNAME +1];
-	char		 gname[MAXLOGNAME +1];
+	char		 sum[SHA256_DIGEST_LENGTH * 2 + 1];
+	char		 uname[MAXLOGNAME];
+	char		 gname[MAXLOGNAME];
 	bool		 keep;
 	mode_t		 perm;
 	UT_hash_handle	 hh;
 };
 
 struct pkg_dir {
-	char		 path[MAXPATHLEN +1];
-	char		 uname[MAXLOGNAME +1];
-	char		 gname[MAXLOGNAME +1];
+	char		 path[MAXPATHLEN];
+	char		 uname[MAXLOGNAME];
+	char		 gname[MAXLOGNAME];
 	mode_t		 perm;
 	bool		 keep;
 	bool		 try;
@@ -204,13 +204,13 @@ struct job_pattern {
 };
 
 struct pkg_user {
-	char		 name[MAXLOGNAME+1];
+	char		 name[MAXLOGNAME];
 	char		 uidstr[8192];/* taken from pw_util.c */
 	UT_hash_handle	hh;
 };
 
 struct pkg_group {
-	char		 name[MAXLOGNAME+1];
+	char		 name[MAXLOGNAME];
 	char		 gidstr[8192]; /* taken from gw_util.c */
 	UT_hash_handle	hh;
 };

--- a/libpkg/private/thd_repo.h
+++ b/libpkg/private/thd_repo.h
@@ -32,7 +32,7 @@
 
 struct pkg_result {
 	struct pkg *pkg;
-	char path[MAXPATHLEN + 1];
+	char path[MAXPATHLEN];
 	char cksum[SHA256_DIGEST_LENGTH * 2 + 1];
 	off_t size;
 	int retcode; /* to pass errors */

--- a/libpkg/rcscripts.c
+++ b/libpkg/rcscripts.c
@@ -45,7 +45,7 @@ int
 pkg_start_stop_rc_scripts(struct pkg *pkg, pkg_rc_attr attr)
 {
 	struct pkg_file *file = NULL;
-	char rc_d_path[PATH_MAX + 1];
+	char rc_d_path[PATH_MAX];
 	const char *rcfile;
 	const char *rc;
 	size_t len = 0;

--- a/libpkg/utils.c
+++ b/libpkg/utils.c
@@ -100,7 +100,7 @@ sbuf_free(struct sbuf *buf)
 int
 mkdirs(const char *_path)
 {
-	char path[MAXPATHLEN + 1];
+	char path[MAXPATHLEN];
 	char *p;
 
 	strlcpy(path, _path, sizeof(path));
@@ -183,7 +183,7 @@ format_exec_cmd(char **dest, const char *in, const char *prefix,
     const char *plist_file, char *line)
 {
 	struct sbuf *buf = sbuf_new_auto();
-	char path[MAXPATHLEN + 1];
+	char path[MAXPATHLEN];
 	char *cp;
 
 	while (in[0] != '\0') {

--- a/pkg/add.c
+++ b/pkg/add.c
@@ -64,7 +64,7 @@ exec_add(int argc, char **argv)
 {
 	struct pkgdb *db = NULL;
 	struct sbuf *failedpkgs = NULL;
-	char path[MAXPATHLEN + 1];
+	char path[MAXPATHLEN];
 	char *file;
 	int retcode;
 	int ch;

--- a/pkg/audit.c
+++ b/pkg/audit.c
@@ -832,7 +832,7 @@ exec_audit(int argc, char **argv)
 	const char *db_dir;
 	char *name;
 	char *version;
-	char audit_file[MAXPATHLEN + 1];
+	char audit_file[MAXPATHLEN];
 	unsigned int vuln = 0;
 	bool fetch = false;
 	bool xml = true;

--- a/pkg/event.c
+++ b/pkg/event.c
@@ -38,7 +38,7 @@
 #include "pkgcli.h"
 
 static off_t fetched = 0;
-static char url[MAXPATHLEN+1];
+static char url[MAXPATHLEN];
 struct sbuf *messages = NULL;
 
 static void

--- a/pkg/register.c
+++ b/pkg/register.c
@@ -88,7 +88,7 @@ exec_register(int argc, char **argv)
 	char		*arch = NULL;
 	char		 myarch[BUFSIZ];
 	char		*www  = NULL;
-	char		 fpath[MAXPATHLEN + 1];
+	char		 fpath[MAXPATHLEN];
 
 	const char	*plist      = NULL;
 	const char	*mdir       = NULL;

--- a/pkg/shlib.c
+++ b/pkg/shlib.c
@@ -141,7 +141,7 @@ int
 exec_shlib(int argc, char **argv)
 {
 	struct pkgdb	*db = NULL;
-	char		 libname[MAXPATHLEN + 1];
+	char		 libname[MAXPATHLEN];
 	int		 retcode = EPKG_OK;
 	int		 ch;
 	bool		 provides_only = false;

--- a/pkg/version.c
+++ b/pkg/version.c
@@ -144,7 +144,7 @@ exec_version(int argc, char **argv)
 	unsigned int opt = 0;
 	int ch;
 	FILE *indexfile;
-	char indexpath[MAXPATHLEN + 1];
+	char indexpath[MAXPATHLEN];
 	struct index_entry *indexhead = NULL;
 	struct utsname u;
 	int rel_major_ver;

--- a/pkg/which.c
+++ b/pkg/which.c
@@ -49,7 +49,7 @@ exec_which(int argc, char **argv)
 	struct pkgdb *db = NULL;
 	struct pkgdb_it *it = NULL;
 	struct pkg *pkg = NULL;
-	char pathabs[MAXPATHLEN + 1];
+	char pathabs[MAXPATHLEN];
 	int ret = EPKG_OK, retcode = EX_SOFTWARE;
 	int ch;
 	bool orig = false;


### PR DESCRIPTION
pkg used MAXPATHLEN, MAXLOGNAME and PATH_MAX inconsistently,
sometimes path[MAXPATHLEN] and sometimes path[MAXPATHLEN + 1].

Since those constants already include the trailing '\0' and snprintf's
size parameter also does, it was changed to path[MAXPATHLEN] (or
MAXLOGNAME, PATH_MAX) everywhere.
