### PR TITLE
Make duplicate-related warning fatal in developer mode

### DIFF
--- a/libpkg/pkg.c
+++ b/libpkg/pkg.c
@@ -490,8 +490,15 @@ pkg_addlicense(struct pkg *pkg, const char *name)
 
 	HASH_FIND_STR(pkg->licenses, name, l);
 	if (l != NULL) {
-		pkg_emit_error("duplicate license listing: %s, ignoring", name);
-		return (EPKG_OK);
+		bool developer;
+		pkg_config_bool(PKG_CONFIG_DEVELOPER_MODE, &developer);
+		if (developer) {
+			pkg_emit_error("duplicate license listing: %s, fatal (developer mode)", name);
+			return (EPKG_FATAL);
+		} else {
+			pkg_emit_error("duplicate license listing: %s, ignoring", name);
+			return (EPKG_OK);
+		}
 	}
 
 	pkg_license_new(&l);
@@ -513,8 +520,15 @@ pkg_adduid(struct pkg *pkg, const char *name, const char *uidstr)
 
 	HASH_FIND_STR(pkg->users, name, u);
 	if (u != NULL) {
-		pkg_emit_error("duplicate user listing: %s, ignoring", name);
-		return (EPKG_OK);
+		bool developer;
+		pkg_config_bool(PKG_CONFIG_DEVELOPER_MODE, &developer);
+		if (developer) {
+			pkg_emit_error("duplicate user listing: %s, fatal (developer mode)", name);
+			return (EPKG_FATAL);
+		} else {
+			pkg_emit_error("duplicate user listing: %s, ignoring", name);
+			return (EPKG_OK);
+		}
 	}
 
 	pkg_user_new(&u);
@@ -547,8 +561,15 @@ pkg_addgid(struct pkg *pkg, const char *name, const char *gidstr)
 
 	HASH_FIND_STR(pkg->groups, name, g);
 	if (g != NULL) {
-		pkg_emit_error("duplicate group listing: %s, ignoring", name);
-		return (EPKG_OK);
+		bool developer;
+		pkg_config_bool(PKG_CONFIG_DEVELOPER_MODE, &developer);
+		if (developer) {
+			pkg_emit_error("duplicate group listing: %s, fatal (developer mode)", name);
+			return (EPKG_FATAL);
+		} else {
+			pkg_emit_error("duplicate group listing: %s, ignoring", name);
+			return (EPKG_OK);
+		}
 	}
 
 	pkg_group_new(&g);
@@ -584,10 +605,18 @@ pkg_adddep(struct pkg *pkg, const char *name, const char *origin, const char *ve
 	pkg_debug(3, "Pkg: add a new dependency origin: %s, name: %s, version: %s", origin, name, version);
 	HASH_FIND_STR(pkg->deps, origin, d);
 	if (d != NULL) {
+		bool developer;
+		pkg_config_bool(PKG_CONFIG_DEVELOPER_MODE, &developer);
 		pkg_get(pkg, PKG_NAME, &n1, PKG_VERSION, &v1);
-		pkg_emit_error("%s-%s: duplicate dependency listing: %s-%s, ignoring",
-		    n1, v1, name, version);
-		return (EPKG_OK);
+		if (developer) {
+			pkg_emit_error("%s-%s: duplicate dependency listing: %s-%s, fatal (developer mode)",
+			    n1, v1, name, version);
+			return (EPKG_FATAL);
+		} else {
+			pkg_emit_error("%s-%s: duplicate dependency listing: %s-%s, ignoring",
+			    n1, v1, name, version);
+			return (EPKG_OK);
+		}
 	}
 
 	pkg_dep_new(&d);
@@ -646,8 +675,15 @@ pkg_addfile_attr(struct pkg *pkg, const char *path, const char *sha256, const ch
 	if (check_duplicates) {
 		HASH_FIND_STR(pkg->files, path, f);
 		if (f != NULL) {
-			pkg_emit_error("duplicate file listing: %s, ignoring", pkg_file_path(f));
-			return (EPKG_OK);
+			bool developer;
+			pkg_config_bool(PKG_CONFIG_DEVELOPER_MODE, &developer);
+			if (developer) {
+				pkg_emit_error("duplicate file listing: %s, fatal (developer mode)", pkg_file_path(f));
+				return (EPKG_FATAL);
+			} else {
+				pkg_emit_error("duplicate file listing: %s, ignoring", pkg_file_path(f));
+				return (EPKG_OK);
+			}
 		}
 	}
 
@@ -681,8 +717,15 @@ pkg_addcategory(struct pkg *pkg, const char *name)
 
 	HASH_FIND_STR(pkg->categories, name, c);
 	if (c != NULL) {
-		pkg_emit_error("duplicate category listing: %s, ignoring", name);
-		return (EPKG_OK);
+		bool developer;
+		pkg_config_bool(PKG_CONFIG_DEVELOPER_MODE, &developer);
+		if (developer) {
+			pkg_emit_error("duplicate category listing: %s, fatal (developer mode)", name);
+			return (EPKG_FATAL);
+		} else {
+			pkg_emit_error("duplicate category listing: %s, ignoring", name);
+			return (EPKG_OK);
+		}
 	}
 
 	pkg_category_new(&c);
@@ -713,8 +756,15 @@ pkg_adddir_attr(struct pkg *pkg, const char *path, const char *uname, const char
 	if (check_duplicates) {
 		HASH_FIND_STR(pkg->dirs, path, d);
 		if (d != NULL) {
-			pkg_emit_error("duplicate directory listing: %s, ignoring", path);
-			return (EPKG_OK);
+			bool developer;
+			pkg_config_bool(PKG_CONFIG_DEVELOPER_MODE, &developer);
+			if (developer) {
+				pkg_emit_error("duplicate directory listing: %s, fatal (developer mode)", path);
+				return (EPKG_FATAL);
+			} else {
+				pkg_emit_error("duplicate directory listing: %s, ignoring", path);
+				return (EPKG_OK);
+			}
 		}
 	}
 
@@ -848,8 +898,15 @@ pkg_addoption(struct pkg *pkg, const char *key, const char *value)
 		pkg_option_new(&o);
 		sbuf_set(&o->key, key);
 	} else if ( o->value != NULL) {
-		pkg_emit_error("duplicate options listing: %s, ignoring", key);
-		return (EPKG_OK);
+		bool developer;
+		pkg_config_bool(PKG_CONFIG_DEVELOPER_MODE, &developer);
+		if (developer) {
+			pkg_emit_error("duplicate options listing: %s, fatal (developer mode)", key);
+			return (EPKG_FATAL);
+		} else {
+			pkg_emit_error("duplicate options listing: %s, ignoring", key);
+			return (EPKG_OK);
+		}
 	}
 
 	sbuf_set(&o->value, value);
@@ -881,8 +938,15 @@ pkg_addoption_default(struct pkg *pkg, const char *key,
 		pkg_option_new(&o);
 		sbuf_set(&o->key, key);
 	} else if ( o->default_value != NULL) {
-		pkg_emit_error("duplicate default value for option: %s, ignoring", key);
-		return (EPKG_OK);
+		bool developer;
+		pkg_config_bool(PKG_CONFIG_DEVELOPER_MODE, &developer);
+		if (developer) {
+			pkg_emit_error("duplicate default value for option: %s, fatal (developer mode)", key);
+			return (EPKG_FATAL);
+		} else {
+			pkg_emit_error("duplicate default value for option: %s, ignoring", key);
+			return (EPKG_OK);
+		}
 	}
 
 	sbuf_set(&o->default_value, default_value);
@@ -913,8 +977,15 @@ pkg_addoption_description(struct pkg *pkg, const char *key,
 		pkg_option_new(&o);
 		sbuf_set(&o->key, key);
 	} else if ( o->description != NULL) {
-		pkg_emit_error("duplicate description for option: %s, ignoring", key);
-		return (EPKG_OK);
+		bool developer;
+		pkg_config_bool(PKG_CONFIG_DEVELOPER_MODE, &developer);
+		if (developer) {
+			pkg_emit_error("duplicate description for option: %s, fatal (developer mode)", key);
+			return (EPKG_FATAL);
+		} else {
+			pkg_emit_error("duplicate description for option: %s, ignoring", key);
+			return (EPKG_OK);
+		}
 	}
 
 	sbuf_set(&o->description, description);
@@ -986,9 +1057,17 @@ pkg_addannotation(struct pkg *pkg, const char *tag, const char *value)
 
 	HASH_FIND_STR(pkg->annotations, tag, an);
 	if (an != NULL) {
-		pkg_emit_error("duplicate annotation tag: %s value: %s,"
-			       " ignoring", tag, value);
-		return (EPKG_OK);
+		bool developer;
+		pkg_config_bool(PKG_CONFIG_DEVELOPER_MODE, &developer);
+		if (developer) {
+			pkg_emit_error("duplicate annotation tag: %s value: %s,"
+				       " ignoring", tag, value);
+			return (EPKG_FATAL);
+		} else {
+			pkg_emit_error("duplicate annotation tag: %s value: %s,"
+				       " ignoring", tag, value);
+			return (EPKG_OK);
+		}
 	}
 	an = NULL;
 	pkg_annotation_new(&an);


### PR DESCRIPTION
Fixes #605

I've thought of another variant using macro - it has less copypasta, but hides a return which is not really good. But if you find it more applicable, I can modify the request.

Macro:

```
#define DUPLICATE_WARNING(format, ...) do { \
  bool developer; \
  pkg_config_bool(PKG_CONFIG_DEVELOPER_MODE, &developer); \
  if (developer) { \
    pkg_emit_error(format", fatal (developer mode)", __VA_ARGS__); \
    return (EPKG_FATAL); \
  } else { \
    pkg_emit_error(format", ignoring", __VA_ARGS__); \
  } \
} while(0)
```

Usage:

```
  if (l != NULL) {
    DUPLICATE_WARNING("duplicate license listing: %s", name);
    return (EPKG_OK);
  }
```
