### PR TITLE
Hide average speed from the progress meter

### DIFF
--- a/pkg/progressmeter.c
+++ b/pkg/progressmeter.c
@@ -165,7 +165,7 @@ refresh_progress_meter(void)
 
 	/* filename */
 	buf[0] = '\0';
-	file_len = win_size - 45;
+	file_len = win_size - 35;
 	if (file_len > 0) {
 		len = snprintf(buf, file_len + 1, "\r%s", file);
 		if (len < 0)
@@ -191,14 +191,9 @@ refresh_progress_meter(void)
 	    cur_pos);
 	strlcat(buf, " ", win_size);
 
-	/* bandwidth usage */
-	format_rate(buf + strlen(buf), win_size - strlen(buf),
-	    (off_t)bytes_per_second);
-	strlcat(buf, "/s ", win_size);
-
 	/* instantaneous rate */
 	format_rate(buf + strlen(buf), win_size - strlen(buf),
-	    delta_pos);
+	    cur_speed);
 	strlcat(buf, "/s ", win_size);
 
 	/* ETA */


### PR DESCRIPTION
Showing two speeds is very confusing. While the average speed can be
interesting at the end of the download, when downloading it's the
current speed which helps identify peaks and stalls. This patch shows
the current speed only, and replaces it with the average when
finished.
As a side point, this leaves more room for package file name.
