### PR TITLE
If no repo was found pkg stops working without any valuable clue

### DIFF
--- a/pkg/update.c
+++ b/pkg/update.c
@@ -57,7 +57,8 @@ pkgcli_update(bool force) {
 		printf("Updating repository catalogue\n");
 
 	if(pkg_repos_total_count() == 0) {
-		fprintf(stderr, "No valid repository found.");
+		fprintf(stderr, "No valid repository found.\n");
+		return (EPKG_FATAL);
 	}
 
 	while (pkg_repos(&r) == EPKG_OK) {


### PR DESCRIPTION
If for some reasons the configuration file is missing or no repo is defined,
pkg stop working and dies silently with this only log 
"Updating repository catalogue".

An extra error message may help users to debug the issue.
