### PR TITLE
periodic/410.pkg-audit.in: make output non-quiet (fix #712)

### DIFF
--- a/scripts/periodic/410.pkg-audit.in
+++ b/scripts/periodic/410.pkg-audit.in
@@ -61,7 +61,7 @@ case "${daily_status_security_pkgaudit_enable:-YES}" in
 		if [ $rc -ne 0 -o \
 			$(( 86400 \* "${daily_status_security_pkgaudit_expiry:-2}" )) \
 			-le $(( ${now} - ${then} + 600 )) ]; then
-			${pkgcmd} audit -Fq || { rc=$?; [ $rc -lt 3 ] && rc=3; }
+			${pkgcmd} audit -F || { rc=$?; [ $rc -lt 3 ] && rc=3; }
 		else
 			echo -n 'Database fetched: '
 			date -r "${then}" || rc=3


### PR DESCRIPTION
Make security script output non-quiet, making it consistent with portaudit and itself when database is not updated during this run.
