### PR TITLE
correct typo in pkg.conf(5)

### DIFF
--- a/src/pkg.conf.5
+++ b/src/pkg.conf.5
@@ -320,7 +320,7 @@ Example for pkg.conf
 pkg_dbdir: "/var/db/pkg"
 pkg_cachedir: "/var/cache/pkg"
 portsdir: "/usr/ports"
-handle_rc_cripts: false
+handle_rc_scripts: false
 assume_always_yes: false
 repos_dir: [
      "/etc/pkg",


### PR DESCRIPTION
Correct a small typo in the pkg.conf(5) manpage
