### PR TITLE
Implement availability to display list of all locked packages with lock command

### DIFF
--- a/src/lock.c
+++ b/src/lock.c
@@ -106,7 +106,7 @@ exec_unlock(int argc, char **argv)
 	return (exec_lock_unlock(argc, argv, UNLOCK));
 }
 
-int 
+static int 
 list_locked()
 {
         struct pkgdb *db = NULL;

--- a/src/pkgcli.h
+++ b/src/pkgcli.h
@@ -87,7 +87,6 @@ void usage_plugins(void);
 /* pkg lock */
 int exec_lock(int, char **);
 int exec_unlock(int, char **);
-int list_locked();
 void usage_lock(void);
 
 /* pkg query */


### PR DESCRIPTION
Issue: freebsd/pkg#635
