### PR TITLE
Add another useful example: unmaintained packages

### DIFF
--- a/docs/pkg-query.8
+++ b/docs/pkg-query.8
@@ -354,6 +354,9 @@ List non-automatic packages:
 .Pp
 List automatic packages:
 .Dl $ pkg query -e '%a = 1' %o
+.Pp
+List unmaintaned packages:
+.Dl $ pkg query -e '%m = ports@FreeBSD.org' %o
 .Sh SEE ALSO
 .Xr pkg_printf 3 ,
 .Xr pkg_repos 3 ,


### PR DESCRIPTION
In times before pkg(8) you had to jump through loops to get a list of unmaintained packages on your system.
