### PR TITLE
pkg-(add|install|upgrade): Respect locked packages on forced invocation.

### DIFF
--- a/libpkg/pkg_add.c
+++ b/libpkg/pkg_add.c
@@ -256,6 +256,12 @@ pkg_add_check_pkg_archive(struct pkgdb *db, struct pkg *pkg,
 			pkg_inst = NULL;
 			return (EPKG_INSTALLED);
 		}
+		else if (pkg_is_locked(pkg_inst)) {
+			pkg_emit_locked(pkg_inst);
+			pkg_free(pkg_inst);
+			pkg_inst = NULL;
+			return (EPKG_INSTALLED);
+		}
 		else {
 			pkg_emit_notice("package %s is already installed, forced install",
 				name);

--- a/libpkg/pkg_jobs_universe.c
+++ b/libpkg/pkg_jobs_universe.c
@@ -794,7 +794,14 @@ pkg_jobs_universe_process_upgrade_chains(struct pkg_jobs *j)
 			vercnt ++;
 		}
 
-		if (vercnt > 1) {
+		if (local != NULL && pkg_is_locked(local->pkg)) {
+			LL_FOREACH(unit, cur) {
+				HASH_FIND_PTR(j->request_add, &cur, req);
+				if (req != NULL)
+					HASH_DEL(j->request_add, req);
+			}
+		}
+		else if (vercnt > 1) {
 			/*
 			 * Here we have more than one upgrade candidate,
 			 * if local == NULL, then we have two remote repos,


### PR DESCRIPTION
This re-establishes pkg 1.2 behaviour.

This replaces the previous pull request, this time against master and not the release branch (back porting is trivial and I'd recommend it, assuming this patch is considered sane)
