### PR TITLE
need to realpath restricted if it's symlink/amd-automount

### DIFF
--- a/libpkg/ssh.c
+++ b/libpkg/ssh.c
@@ -59,6 +59,7 @@ pkg_sshserve(int fd)
 	int ffd;
 	char buf[BUFSIZ];
 	char fpath[MAXPATHLEN];
+	char rpath[MAXPATHLEN];
 	const char *restricted = NULL;
 
 	restricted = pkg_object_string(pkg_config_get("SSH_RESTRICT_DIR"));
@@ -137,7 +138,8 @@ pkg_sshserve(int fd)
 #endif
 			chdir(restricted);
 			if (realpath(file, fpath) == NULL ||
-					strncmp(fpath, restricted, strlen(restricted)) != 0) {
+					realpath(restricted, rpath) == NULL ||
+					strncmp(fpath, rpath, strlen(rpath)) != 0) {
 				printf("ko: file not found\n");
 				continue;
 			}


### PR DESCRIPTION
If SSH_RESTRICT_DIR has symlinks (amd auto mounted fs) then strncmp() in libpkg/ssh.c will fail.  We need to compare realpath fpath with another realpath rpath.
