### PR TITLE
Fix check_for_hardlink.

### DIFF
--- a/libpkg/pkg.c
+++ b/libpkg/pkg.c
@@ -1737,7 +1737,7 @@ pkg_recompute(struct pkgdb *db, struct pkg *pkg)
 			}
 
 			if (st.st_nlink > 1)
-				regular = !check_for_hardlink(hl, &st);
+				regular = !check_for_hardlink(&hl, &st);
 
 			if (regular)
 				flatsize += st.st_size;

--- a/libpkg/pkg_create.c
+++ b/libpkg/pkg_create.c
@@ -86,7 +86,7 @@ pkg_create_from_dir(struct pkg *pkg, const char *root,
 		if (file->size == 0)
 			file->size = (int64_t)st.st_size;
 
-		if (st.st_nlink == 1 || !check_for_hardlink(hardlinks, &st)) {
+		if (st.st_nlink == 1 || !check_for_hardlink(&hardlinks, &st)) {
 			flatsize += file->size;
 		}
 

--- a/libpkg/pkg_ports.c
+++ b/libpkg/pkg_ports.c
@@ -373,7 +373,7 @@ file(struct plist *p, char *line, struct file_attr *a)
 
 		if (S_ISREG(st.st_mode)) {
 			if (st.st_nlink > 1)
-				regular = !check_for_hardlink(p->hardlinks, &st);
+				regular = !check_for_hardlink(&(p->hardlinks), &st);
 			else
 				regular = true;
 

--- a/libpkg/private/utils.h
+++ b/libpkg/private/utils.h
@@ -109,7 +109,7 @@ int rsa_verify(const char *path, const char *key,
 int rsa_verify_cert(const char *path, unsigned char *cert,
     int certlen, unsigned char *sig, int sig_len, int fd);
 
-bool check_for_hardlink(struct hardlinks *hl, struct stat *st);
+bool check_for_hardlink(struct hardlinks **hl, struct stat *st);
 bool is_valid_abi(const char *arch, bool emit_error);
 
 struct dns_srvinfo *

--- a/libpkg/utils.c
+++ b/libpkg/utils.c
@@ -531,17 +531,17 @@ is_conf_file(const char *path, char *newpath, size_t len)
 }
 
 bool
-check_for_hardlink(struct hardlinks *hl, struct stat *st)
+check_for_hardlink(struct hardlinks **hl, struct stat *st)
 {
 	struct hardlinks *h;
 
-	HASH_FIND_INO(hl, &st->st_ino, h);
+	HASH_FIND_INO(*hl, &st->st_ino, h);
 	if (h != NULL)
 		return (true);
 
 	h = malloc(sizeof(struct hardlinks));
 	h->inode = st->st_ino;
-	HASH_ADD_INO(hl, inode, h);
+	HASH_ADD_INO(*hl, inode, h);
 
 	return (false);
 }


### PR DESCRIPTION
Changes to hl were not propagated to the caller, so it was always empty
and none of the hardlinks was ever detected. This fixes issue #812.
