### PR TITLE
pkg_add: do not emit error on installed packages

### DIFF
--- a/libpkg/pkg_add.c
+++ b/libpkg/pkg_add.c
@@ -260,7 +260,7 @@ pkg_add_check_pkg_archive(struct pkgdb *db, struct pkg *pkg,
 			pkg_emit_locked(pkg_inst);
 			pkg_free(pkg_inst);
 			pkg_inst = NULL;
-			return (EPKG_INSTALLED);
+			return (EPKG_LOCKED);
 		}
 		else {
 			pkg_emit_notice("package %s is already installed, forced install",
@@ -423,7 +423,8 @@ pkg_add_common(struct pkgdb *db, const char *path, unsigned flags,
 	if (remote == NULL) {
 		ret = pkg_add_check_pkg_archive(db, pkg, path, flags, keys, location);
 		if (ret != EPKG_OK) {
-			retcode = ret;
+			/* Do not return error on installed package */
+			retcode = (ret == EPKG_INSTALLED ? EPKG_OK : ret);
 			goto cleanup;
 		}
 	}


### PR DESCRIPTION
I have a large directory with packages that need to be installed during image build. Right now pkg-add(8) must be used with the force flag so that no errors are produced for already installed package _dependencies_. This also mutes real problems like checks for clashing files between packages... In contrast, pkg-install(8) neatly confirms the package is already installed and returns successful.

This fixes the issue while retaining the error behaviour for locked packages.
