### PR TITLE
pkg-version: New configuration option VERSION_SOURCE

### DIFF
--- a/docs/pkg-version.8
+++ b/docs/pkg-version.8
@@ -15,7 +15,7 @@
 .\"     @(#)pkg.8
 .\" $FreeBSD$
 .\"
-.Dd May 26, 2014
+.Dd August 18, 2014
 .Dt PKG-VERSION 8
 .Os
 .Sh NAME
@@ -59,7 +59,11 @@ installed packages may be chosen by specifying one of
 .Fl P ,
 .Fl R
 or
-.Fl I .
+.Fl I
+or by by setting
+.Cm VERSION_SOURCE
+in
+.Xr pkg.conf 5 .
 If not specified then the ports index file
 will be used if it exists
 .Fl ( I ) .

--- a/docs/pkg.conf.5
+++ b/docs/pkg.conf.5
@@ -15,7 +15,7 @@
 .\"     @(#)pkg.1
 .\" $FreeBSD$
 .\"
-.Dd August 17, 2014
+.Dd August 18, 2014
 .Dt PKG.CONF 5
 .Os
 .Sh NAME
@@ -272,6 +272,19 @@ archive.
 Normally, timestamps are copied from the staging directory the
 package is created from.
 Default: no.
+.It Cm VERSION_SOURCE: string
+Default database for comparing version numbers in
+.Xr pkg-version 8 .
+Valid values are
+.Sy I
+for index,
+.Sy P ,
+for ports,
+.Sy R
+for remote.
+Default: If unset, the algorithm described in
+.Xr pkg-version 8
+is used to determine the version source automatically.
 .It Cm VULNXML_SITE: string
 Specifies the URL to fetch the
 .Pa vuln.xml

--- a/libpkg/pkg_config.c
+++ b/libpkg/pkg_config.c
@@ -323,6 +323,12 @@ static struct config_entry c[] = {
 		"NO",
 		"Use read locking for query database"
 	},
+	{
+		PKG_STRING,
+		"VERSION_SOURCE",
+		NULL,
+		"Version source for pkg-version (I, P, R), default is auto detect"
+	},
 };
 
 static bool parsed = false;

--- a/src/version.c
+++ b/src/version.c
@@ -770,6 +770,7 @@ exec_version(int argc, char **argv)
 	const char	*reponame = NULL;
 	const char	*portsdir;
 	const char	*indexfile;
+	const char	*versionsource;
 	char		 filebuf[MAXPATHLEN];
 	match_t		 match = MATCH_ALL;
 	char		*pattern = NULL;
@@ -897,6 +898,27 @@ exec_version(int argc, char **argv)
 	if (argc > 1) {
 		usage_version();
 		return (EX_USAGE);
+	}
+
+	if ( !(opt & VERSION_SOURCES ) ) {
+		versionsource = pkg_object_string(
+		    pkg_config_get("VERSION_SOURCE"));
+		if (versionsource != NULL) {
+			switch (versionsource[0]) {
+			case 'I':
+				opt |= VERSION_SOURCE_INDEX;
+				break;
+			case 'P':
+				opt |= VERSION_SOURCE_PORTS;
+				break;
+			case 'R':
+				opt |= VERSION_SOURCE_REMOTE;
+				break;
+			default:
+				warnx("Invalid VERSION_SOURCE"
+				    " in configuration.");
+			}
+		}
 	}
 
 	if ( (opt & VERSION_SOURCE_INDEX) == VERSION_SOURCE_INDEX ) {


### PR DESCRIPTION
This allows to set the default database used for version number
comparison.

The need for this came up while deploying package on a group of machines that are connected to a private repo. So usually we want to compare versions to the repo, but without specifying "-R" on the command line explicitly, there will always be an error message about INDEXFILE.

To make matters worse, sometimes you have a INDEXFILE or a ports tree without an INDEXFILE installed, even though packages should always be checked against the remote repository (or the other way round).

The advantage of implementing this instead of using one of the possible workarounds (ALIAS, setting INDEX- and/or PORTSDIR to nonexistent paths) is that it's explicit and won't break calling "pkg version" with I/R/P to override the configured default.
