### PR TITLE
Fix progress output for pkg_add

### DIFF
--- a/libpkg/pkg_add.c
+++ b/libpkg/pkg_add.c
@@ -405,9 +405,6 @@ pkg_add_common(struct pkgdb *db, const char *path, unsigned flags,
 		retcode = ret;
 		goto cleanup;
 	}
-	if ((flags & PKG_ADD_UPGRADE) == 0)
-		pkg_emit_install_begin(pkg);
-
 	if (pkg_is_valid(pkg) != EPKG_OK) {
 		pkg_emit_error("the package is not valid");
 		return (EPKG_FATAL);
@@ -445,6 +442,9 @@ pkg_add_common(struct pkgdb *db, const char *path, unsigned flags,
 
 	if (location != NULL)
 		pkg_addannotation(pkg, "relocated", location);
+
+	if ((flags & PKG_ADD_UPGRADE) == 0)
+		pkg_emit_install_begin(pkg);
 
 	/* register the package before installing it in case there are
 	 * problems that could be caught here. */


### PR DESCRIPTION
Reported by andrew clarke:
http://lists.freebsd.org/pipermail/freebsd-ports/2014-August/094883.html

Before:

pkg add tmux-1.8.txz
[pkgtest] Installing libevent-1.4.14b_2: 100%
[pkgtest] Installing libevent-1.4.14b_2: 100%

After:
pkg add tmux-1.8.txz
[pkgtest] Installing libevent-1.4.14b_2: 100%
[pkgtest] Installing tmux-1.8: 100%
