### PR TITLE
Deletion of unnecessary checks before specific function calls by a SmPL script

### DIFF
--- a/tests/cocci/delete_if1.cocci
+++ b/tests/cocci/delete_if1.cocci
@@ -1,0 +1,121 @@
+@Remove_unnecessary_pointer_checks1@
+expression x;
+identifier release =~ "^(?x)
+(?:(?:(?:pkg(?:db_(?:sqlite_)?it
+            |  _(?:audit
+                |  conflict
+                |  deb
+                |  file
+                |  manifest_keys
+                |  option
+                |  provide
+                |  repo_binary_update_item
+                |  shlib
+                )
+            )?
+      | rsa
+      | sbuf
+      )_)?free
+| free_(?:file_attr|percent_esc)
+| load_repositories
+| pkg(?:_reset
+     |  db_(?:close|sqlite_it_reset)
+     )
+| sbuf_(?:delete|reset)
+)$";
+@@
+-if (\(x != 0 \| x != NULL\))
+    release(x);
+
+@Remove_unnecessary_pointer_checks2@
+expression x;
+identifier release =~ "^(?x)
+(?:(?:(?:pkg(?:db_(?:sqlite_)?it
+            |  _(?:audit
+                |  conflict
+                |  deb
+                |  file
+                |  manifest_keys
+                |  option
+                |  provide
+                |  repo_binary_update_item
+                |  shlib
+                )
+            )?
+      | rsa
+      | sbuf
+      )_)?free
+| free_(?:file_attr|percent_esc)
+| load_repositories
+| pkg(?:_reset
+     |  db_(?:close|sqlite_it_reset)
+     )
+| sbuf_(?:delete|reset)
+)$";
+@@
+-if (\(x != 0 \| x != NULL\)) {
+    release(x);
+    x = \(0 \| NULL\);
+-}
+
+@Remove_unnecessary_pointer_checks3@
+expression a, b;
+identifier release =~ "^(?x)
+(?:(?:(?:pkg(?:db_(?:sqlite_)?it
+            |  _(?:audit
+                |  conflict
+                |  deb
+                |  file
+                |  manifest_keys
+                |  option
+                |  provide
+                |  repo_binary_update_item
+                |  shlib
+                )
+            )?
+      | rsa
+      | sbuf
+      )_)?free
+| free_(?:file_attr|percent_esc)
+| load_repositories
+| pkg(?:_reset
+     |  db_(?:close|sqlite_it_reset)
+     )
+| sbuf_(?:delete|reset)
+)$";
+@@
+-if (\(a != 0 \| a != NULL\) && \(b != 0 \| b != NULL\))
++if (a)
+    release(b);
+
+@Remove_unnecessary_pointer_checks4@
+expression a, b;
+identifier release =~ "^(?x)
+(?:(?:(?:pkg(?:db_(?:sqlite_)?it
+            |  _(?:audit
+                |  conflict
+                |  deb
+                |  file
+                |  manifest_keys
+                |  option
+                |  provide
+                |  repo_binary_update_item
+                |  shlib
+                )
+            )?
+      | rsa
+      | sbuf
+      )_)?free
+| free_(?:file_attr|percent_esc)
+| load_repositories
+| pkg(?:_reset
+     |  db_(?:close|sqlite_it_reset)
+     )
+| sbuf_(?:delete|reset)
+)$";
+@@
+-if (\(a != 0 \| a != NULL\) && \(b != 0 \| b != NULL\)) {
++if (a) {
+    release(b);
+    b = \(0 \| NULL\);
+ }


### PR DESCRIPTION
This [semantic patch approach](http://coccinelle.lip6.fr/) tries to find source code places where a check is performed for an expression that is passed to a function (like "free") which checks this single parameter itself for usability.
Redundant value or pointer checks can be avoided here.
