### PR TITLE
Round the note size up correctly.

### DIFF
--- a/libpkg/pkg_elf.c
+++ b/libpkg/pkg_elf.c
@@ -742,7 +742,7 @@ pkg_get_myarch_elfparse(char *dest, size_t sz)
 		src += sizeof(Elf_Note);
 		if (note.n_type == NT_VERSION)
 			break;
-		src += note.n_namesz + note.n_descsz;
+		src += roundup2(note.n_namesz + note.n_descsz, 4);
 	}
 	if ((uintptr_t)src >= ((uintptr_t)data->d_buf + data->d_size)) {
 		ret = EPKG_FATAL;


### PR DESCRIPTION
ELF notes are 4-byte aligned, this fixes the size, which may not be a
multiple of 4, to round them up correctly. This stops pkg crashing on
armeb.
