### PR TITLE
Fix of the failure to report shlib-to-shlib missing dependencies for 'pkg check -B'

### DIFF
--- a/libpkg/pkg_elf.c
+++ b/libpkg/pkg_elf.c
@@ -114,10 +114,13 @@ add_shlibs_to_pkg(__unused void *actdata, struct pkg *pkg, const char *fpath,
 	case EPKG_END:		/* A system library */
 		return (EPKG_OK);
 	default:
-		/* Ignore link resolution errors if we're analysing a
-		   shared library. */
-		if (is_shlib)
+		/* Report link resolution errors in shared library. */
+		if (is_shlib) {
+			pkg_get(pkg, PKG_NAME, &pkgname, PKG_VERSION, &pkgversion);
+			warnx("(%s-%s) %s - shared library %s not found",
+			      pkgname, pkgversion, fpath, name);
 			return (EPKG_OK);
+		}
 
 		while (pkg_files(pkg, &file) == EPKG_OK) {
 			filepath = file->path;


### PR DESCRIPTION
Re-posting the patch that went unanswered: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=192606
