### PR TITLE
Actually fix the debugging logic

### DIFF
--- a/libpkg/libpkg.ver
+++ b/libpkg/libpkg.ver
@@ -129,6 +129,7 @@ global:
 	pkg_sbuf_vprintf;
 	pkg_script_get;
 	pkg_set2;
+	pkg_set_debug_level;
 	pkg_set_from_file;
 	pkg_set_from_fileat;
 	pkg_shlibs_provided;

--- a/libpkg/pkg.h.in
+++ b/libpkg/pkg.h.in
@@ -696,6 +696,13 @@ int pkg_set_from_file(struct pkg *pkg, pkg_attr attr, const char *file, bool tri
 int pkg_set_from_fileat(int fd, struct pkg *pkg, pkg_attr attr, const char *file, bool trimcr);
 
 /**
+ * Set a new debug level used inside of pkg.
+ * @param debug_level Debug level between 0 (no debugging) and 4 (max debugging).
+ * @return Previous debug level.
+ */
+int64_t pkg_set_debug_level(int64_t debug_level);
+
+/**
  * Allocate a new struct pkg and add it to the deps of pkg.
  * @return An error code.
  */

--- a/libpkg/pkg_config.c
+++ b/libpkg/pkg_config.c
@@ -1211,3 +1211,11 @@ pkg_repo_find(const char *reponame)
 	HASH_FIND_STR(repos, reponame, r);
 	return (r);
 }
+
+int64_t
+pkg_set_debug_level(int64_t new_debug_level) {
+	int64_t old_debug_level = debug_level;
+
+	debug_level = new_debug_level;
+	return old_debug_level;
+}

--- a/src/main.c
+++ b/src/main.c
@@ -554,7 +554,7 @@ main(int argc, char **argv)
 	const char	 *jail_str = NULL;
 	size_t		  len;
 	signed char	  ch;
-	int		  debug = 0;
+	int64_t		  debug = 0;
 	int		  version = 0;
 	int		  ret = EX_OK;
 	bool		  plugins_enabled = false;
@@ -652,7 +652,7 @@ main(int argc, char **argv)
 	argc -= optind;
 	argv += optind;
 
-	debug_level = debug;
+	pkg_set_debug_level(debug);
 
 	if (version == 1)
 		show_version_info(version);
@@ -708,7 +708,7 @@ main(int argc, char **argv)
 		errx(EX_SOFTWARE, "Cannot parse configuration file!");
 
 	if (debug > 0)
-		debug_level = debug;
+		pkg_set_debug_level(debug);
 
 	if (atexit(&pkg_shutdown) != 0)
 		errx(EX_SOFTWARE, "register pkg_shutdown() to run at exit");


### PR DESCRIPTION
Expose a helper function that allows pkg(1) to set the debug level.

The previous "attempt" at fixing this was waaay too hasty and I didn't even compile test it because the fix looked simple enough that it should be dry-coded successfully.  This fixes the build problem and has been actually tested.  `pkg -ddd` now behaves as expected.

Pointy Hat To: seanc@
