### PR TITLE
Fixed issue with a cached packages which have a wrong size someway.

### DIFF
--- a/libpkg/repo/binary/fetch.c
+++ b/libpkg/repo/binary/fetch.c
@@ -80,7 +80,7 @@ pkg_repo_binary_get_cached_name(struct pkg_repo *repo, struct pkg *pkg,
 		 */
 		pkg_snprintf(dest, destlen, "%S/%n-%v-%z",
 				cachedir, pkg, pkg, pkg);
-		if (stat (dest, &st) != -1)
+		if (stat (dest, &st) != -1 || pkg->pkgsize != st.st_size)
 			return (EPKG_FATAL);
 
 		/*

--- a/libpkg/repo/binary/query.c
+++ b/libpkg/repo/binary/query.c
@@ -372,7 +372,9 @@ pkg_repo_binary_ensure_loaded(struct pkg_repo *repo,
 		 * Try to get that information from fetched package in cache
 		 */
 		pkg_manifest_keys_new(&keys);
-		pkg_repo_cached_name(pkg, path, sizeof(path));
+		
+		if (pkg_repo_cached_name(pkg, path, sizeof(path)) != EPKG_OK)
+			return (EPKG_FATAL);
 
 		pkg_debug(1, "Binary> loading %s", path);
 		if (pkg_open(&cached, path, keys, PKG_OPEN_TRY) != EPKG_OK)


### PR DESCRIPTION
I think this fix will prevent issue (for example) when while fetching package it was interrupted (Ctrl^C) and as in result truncated.
Such scenario is easy repeatable. For example #1149 must be fixed after this patch.

Please review and merge if you are fine with it.

Before patch:
```
root@pkgtest:~/pkg # ./src/pkg-static install perl5
Updating FreeBSD repository catalogue...
FreeBSD repository is up-to-date.
Updating pd10 repository catalogue...
pd10 repository is up-to-date.
All repositories are up-to-date.
The following 1 packages will be affected (of 0 checked):

New packages to be INSTALLED:
        perl5: 5.18.4_11 [FreeBSD]

The process will require 49 MiB more space.
13 MiB to be downloaded.

Proceed with this action? [y/N]: y
Fetching perl5-5.18.4_11.txz:  35%    5 MiB   2.2MB/s    00:04 ETA^C
root@pkgtest:~/pkg # ./src/pkg-static install perl5
Updating FreeBSD repository catalogue...
FreeBSD repository is up-to-date.
Updating pd10 repository catalogue...
pd10 repository is up-to-date.
All repositories are up-to-date.
Checking integrity... done (0 conflicting)
The following 1 packages will be affected (of 0 checked):

New packages to be INSTALLED:
        perl5: 5.18.4_11 [FreeBSD]

The process will require 49 MiB more space.
13 MiB to be downloaded.

Proceed with this action? [y/N]: y
[1/1] Installing perl5-5.18.4_11...
[1/1] Extracting perl5-5.18.4_11:  30%
pkg-static: archive_read_extract(): Lzma library error:  No progress is possible
[1/1] Extracting perl5-5.18.4_11: 100%
[1/1] Deleting files for perl5-5.18.4_11: 100%
```

After patch (package is re-fetched from repo):
```
root@pkgtest:/pkg # ./src/pkg-static install perl5
Updating FreeBSD repository catalogue...
FreeBSD repository is up-to-date.
Updating pd10 repository catalogue...
pd10 repository is up-to-date.
All repositories are up-to-date.
The following 1 packages will be affected (of 0 checked):

New packages to be INSTALLED:
        perl5: 5.18.4_11 [FreeBSD]

The process will require 49 MiB more space.

Proceed with this action? [y/N]: y
Fetching perl5-5.18.4_11.txz: 100%   13 MiB   6.9MB/s    00:02    
Checking integrity... done (0 conflicting)
[1/1] Installing perl5-5.18.4_11...
[1/1] Extracting perl5-5.18.4_11: 100%
```