### PR TITLE
Fix 'pkg add -M -'.

### DIFF
--- a/libpkg/pkg_add.c
+++ b/libpkg/pkg_add.c
@@ -411,7 +411,7 @@ pkg_add_check_pkg_archive(struct pkgdb *db, struct pkg *pkg,
 					goto cleanup;
 			}
 		} else {
-			if ((flags & PKG_ADD_FORCE_MISSING) == 0)
+			if ((flags & PKG_ADD_FORCE_MISSING) == 0) {
 				pkg_emit_missing_dep(pkg, dep);
 				goto cleanup;
 			}

--- a/libpkg/pkg_add.c
+++ b/libpkg/pkg_add.c
@@ -411,8 +411,10 @@ pkg_add_check_pkg_archive(struct pkgdb *db, struct pkg *pkg,
 					goto cleanup;
 			}
 		} else {
-			pkg_emit_missing_dep(pkg, dep);
-			goto cleanup;
+			if ((flags & PKG_ADD_FORCE_MISSING) == 0)
+				pkg_emit_missing_dep(pkg, dep);
+				goto cleanup;
+			}
 		}
 	}
 


### PR DESCRIPTION
When the PKG_ADD_FORCE_MISSING flag is set, we should ignore missing dependencies even when we have no directory to search for them in.