### PR TITLE
Fix a bunch of 'unused parameter' warnings

### DIFF
--- a/libpkg/backup.c
+++ b/libpkg/backup.c
@@ -54,7 +54,7 @@ ps_cb(void *ps, int ncols, char **coltext, __unused char **colnames)
 }
 
 static int
-copy_database(sqlite3 *src, sqlite3 *dst, const char *name)
+copy_database(sqlite3 *src, sqlite3 *dst)
 {
 	sqlite3_backup	*b;
 	char		*errmsg;
@@ -147,7 +147,7 @@ pkgdb_dump(struct pkgdb *db, const char *dest)
 	}
 
 	pkg_emit_backup();
-	ret = copy_database(db->sqlite, backup, dest);
+	ret = copy_database(db->sqlite, backup);
 
 	sqlite3_close(backup);
 
@@ -174,7 +174,7 @@ pkgdb_load(struct pkgdb *db, const char *src)
 	}
 
 	pkg_emit_restore();
-	ret = copy_database(restore, db->sqlite, src);
+	ret = copy_database(restore, db->sqlite);
 
 	sqlite3_close(restore);
 

--- a/libpkg/pkg.h.in
+++ b/libpkg/pkg.h.in
@@ -1086,7 +1086,7 @@ int pkg_solve_sat_to_jobs(struct pkg_solve_problem *problem);
  * Parse SAT solver output and convert it to jobs
  * @return error code
  */
-int pkg_solve_parse_sat_output(FILE *f, struct pkg_solve_problem *problem, struct pkg_jobs *j);
+int pkg_solve_parse_sat_output(FILE *f, struct pkg_solve_problem *problem);
 
 /**
  * Free a SAT problem structure

--- a/libpkg/pkg_add.c
+++ b/libpkg/pkg_add.c
@@ -81,7 +81,7 @@ pkg_add_file_random_suffix(char *buf, int buflen, int suflen)
 }
 
 static void
-attempt_to_merge(bool renamed, const struct pkg_file *rf, struct pkg_config_file *rcf,
+attempt_to_merge(bool renamed, struct pkg_config_file *rcf,
   struct pkg *local, char *pathname, const char *path, struct sbuf *newconf)
 {
 	const struct pkg_file *lf = NULL;
@@ -222,7 +222,7 @@ do_extract(struct archive *a, struct archive_entry *ae, const char *location,
 		 * check if the file is already provided by previous package
 		 */
 		if (!automerge)
-			attempt_to_merge(renamed, rf, rcf, local, pathname, path, newconf);
+			attempt_to_merge(renamed, rcf, local, pathname, path, newconf);
 
 		if (sbuf_len(newconf) == 0 && (rcf == NULL || rcf->content == NULL)) {
 			pkg_debug(1, "Extracting: %s", archive_entry_pathname(ae));

--- a/libpkg/pkg_jobs.c
+++ b/libpkg/pkg_jobs.c
@@ -423,7 +423,7 @@ pkg_jobs_add_req(struct pkg_jobs *j, struct pkg *pkg)
  * reverse - try to upgrade reverse deps as well
  */
 static void
-pkg_jobs_process_add_request(struct pkg_jobs *j, bool top)
+pkg_jobs_process_add_request(struct pkg_jobs *j)
 {
 	bool force = j->flags & PKG_FLAG_FORCE,
 		 reverse = j->flags & PKG_FLAG_RECURSIVE,
@@ -496,7 +496,7 @@ pkg_jobs_process_add_request(struct pkg_jobs *j, bool top)
 				pkg_jobs_add_req_from_universe(&j->request_add, *pun, false, true);
 			}
 			/* Now recursively process all items checked */
-			pkg_jobs_process_add_request(j, false);
+			pkg_jobs_process_add_request(j);
 		}
 		utarray_free(to_process);
 	}
@@ -1506,7 +1506,7 @@ jobs_solve_install_upgrade(struct pkg_jobs *j)
 		}
 	}
 
-	pkg_jobs_process_add_request(j, true);
+	pkg_jobs_process_add_request(j);
 	if (pkg_conflicts_request_resolve(j) != EPKG_OK) {
 		pkg_emit_error("Cannot resolve conflicts in a request");
 		return (EPKG_FATAL);

--- a/libpkg/pkg_jobs.c
+++ b/libpkg/pkg_jobs.c
@@ -1655,7 +1655,7 @@ again:
 					fclose(spipe[1]);
 
 					if (ret == EPKG_OK) {
-						ret = pkg_solve_parse_sat_output(spipe[0], problem, j);
+						ret = pkg_solve_parse_sat_output(spipe[0], problem);
 					}
 
 					fclose(spipe[0]);
@@ -1760,7 +1760,7 @@ pkg_jobs_type(struct pkg_jobs *j)
 }
 
 static int
-pkg_jobs_handle_install(struct pkg_solved *ps, struct pkg_jobs *j, bool handle_rc,
+pkg_jobs_handle_install(struct pkg_solved *ps, struct pkg_jobs *j,
 		struct pkg_manifest_key *keys)
 {
 	struct pkg *new, *old;
@@ -1830,7 +1830,6 @@ pkg_jobs_execute(struct pkg_jobs *j)
 	struct pkg_manifest_key *keys = NULL;
 	int flags = 0;
 	int retcode = EPKG_FATAL;
-	bool handle_rc = false;
 
 	if (j->flags & PKG_FLAG_SKIP_INSTALL)
 		return (EPKG_OK);
@@ -1840,8 +1839,6 @@ pkg_jobs_execute(struct pkg_jobs *j)
 
 	if ((j->flags & PKG_FLAG_NOSCRIPT) == PKG_FLAG_NOSCRIPT)
 		flags |= PKG_DELETE_NOSCRIPT;
-
-	handle_rc = pkg_object_bool(pkg_config_get("HANDLE_RC_SCRIPTS"));
 
 	retcode = pkgdb_upgrade_lock(j->db, PKGDB_LOCK_ADVISORY,
 			PKGDB_LOCK_EXCLUSIVE);
@@ -1881,14 +1878,12 @@ pkg_jobs_execute(struct pkg_jobs *j)
 				goto cleanup;
 			break;
 		case PKG_SOLVED_INSTALL:
-			retcode = pkg_jobs_handle_install(ps,
-					j, handle_rc, keys);
+			retcode = pkg_jobs_handle_install(ps, j, keys);
 			if (retcode != EPKG_OK)
 				goto cleanup;
 			break;
 		case PKG_SOLVED_UPGRADE:
-			retcode = pkg_jobs_handle_install(ps,
-					j, handle_rc, keys);
+			retcode = pkg_jobs_handle_install(ps, j, keys);
 			if (retcode != EPKG_OK)
 				goto cleanup;
 			break;

--- a/libpkg/pkg_ports.c
+++ b/libpkg/pkg_ports.c
@@ -1071,7 +1071,7 @@ flush_script_buffer(struct sbuf *buf, struct pkg *p, int type)
 }
 
 int
-plist_parse_line(struct pkg *pkg, struct plist *plist, char *line)
+plist_parse_line(struct plist *plist, char *line)
 {
 	char *keyword, *buf;
 
@@ -1202,7 +1202,7 @@ ports_parse_plist(struct pkg *pkg, const char *plist, const char *stage)
 	while ((linelen = getline(&line, &linecap, plist_f)) > 0) {
 		if (line[linelen - 1] == '\n')
 			line[linelen - 1] = '\0';
-		ret = plist_parse_line(pkg, pplist, line);
+		ret = plist_parse_line(pplist, line);
 		if (rc == EPKG_OK)
 			rc = ret;
 	}

--- a/libpkg/pkg_solve.c
+++ b/libpkg/pkg_solve.c
@@ -1054,7 +1054,7 @@ pkg_solve_sat_to_jobs(struct pkg_solve_problem *problem)
 }
 
 int
-pkg_solve_parse_sat_output(FILE *f, struct pkg_solve_problem *problem, struct pkg_jobs *j)
+pkg_solve_parse_sat_output(FILE *f, struct pkg_solve_problem *problem)
 {
 	struct pkg_solve_ordered_variable *ordered_variables = NULL, *nord;
 	struct pkg_solve_variable *var;

--- a/libpkg/pkgdb.c
+++ b/libpkg/pkgdb.c
@@ -853,7 +853,7 @@ pkgdb_access(unsigned mode, unsigned database)
 }
 
 static void
-pkgdb_profile_callback(void *ud, const char *req, sqlite3_uint64 nsec)
+pkgdb_profile_callback(void *ud __unused, const char *req, sqlite3_uint64 nsec)
 {
 	/* According to sqlite3 documentation, nsec has milliseconds accuracy */
 	nsec /= 1000000LLU;

--- a/libpkg/private/pkg.h
+++ b/libpkg/private/pkg.h
@@ -646,7 +646,7 @@ void pkg_delete_file(struct pkg *pkg, struct pkg_file *file, unsigned force);
 int pkg_open_root_fd(struct pkg *pkg);
 void pkg_add_dir_to_del(struct pkg *pkg, const char *file, const char *dir);
 struct plist *plist_new(struct pkg *p, const char *stage);
-int plist_parse_line(struct pkg *pkg, struct plist *p, char *line);
+int plist_parse_line(struct plist *p, char *line);
 void plist_free(struct plist *);
 int pkg_appendscript(struct pkg *pkg, const char *cmd, pkg_script type);
 

--- a/libpkg/repo/binary/update.c
+++ b/libpkg/repo/binary/update.c
@@ -356,7 +356,7 @@ pkg_repo_binary_register_conflicts(const char *origin, char **conflicts,
 
 static int
 pkg_repo_binary_add_from_manifest(char *buf, sqlite3 *sqlite, size_t len,
-		struct pkg_manifest_key **keys, struct pkg **p __unused, bool is_legacy,
+		struct pkg_manifest_key **keys, struct pkg **p __unused,
 		struct pkg_repo *repo)
 {
 	int rc = EPKG_OK;
@@ -441,7 +441,7 @@ pkg_repo_binary_update_proceed(const char *name, struct pkg_repo *repo,
 	struct pkg_manifest_key *keys = NULL;
 	unsigned char *map = MAP_FAILED;
 	size_t len = 0;
-	bool in_trans = false, legacy_repo = false;
+	bool in_trans = false;
 
 	pkg_debug(1, "Pkgrepo, begin update of '%s'", name);
 
@@ -500,7 +500,7 @@ pkg_repo_binary_update_proceed(const char *name, struct pkg_repo *repo,
 		if ((cnt % 10 ) == 0)
 			pkg_emit_progress_tick(next - map, len);
 		rc = pkg_repo_binary_add_from_manifest(walk, sqlite, next - walk,
-		    &keys, &pkg, legacy_repo, repo);
+		    &keys, &pkg, repo);
 		if (rc != EPKG_OK) {
 			pkg_emit_progress_tick(len, len);
 			break;

--- a/src/check.c
+++ b/src/check.c
@@ -56,7 +56,7 @@ static int check_deps(struct pkgdb *db, struct pkg *pkg, struct deps_head *dh,
     bool noinstall, struct sbuf *out);
 static void add_missing_dep(struct pkg_dep *d, struct deps_head *dh, int *nbpkgs);
 static void deps_free(struct deps_head *dh);
-static int fix_deps(struct pkgdb *db, struct deps_head *dh, int nbpkgs, bool yes);
+static int fix_deps(struct pkgdb *db, struct deps_head *dh, int nbpkgs);
 static void check_summary(struct pkgdb *db, struct deps_head *dh);
 
 static int
@@ -127,7 +127,7 @@ deps_free(struct deps_head *dh)
 }
 
 static int
-fix_deps(struct pkgdb *db, struct deps_head *dh, int nbpkgs, bool yes)
+fix_deps(struct pkgdb *db, struct deps_head *dh, int nbpkgs)
 {
 	struct pkg_jobs *jobs = NULL;
 	struct deps_entry *e = NULL;
@@ -493,7 +493,7 @@ exec_check(int argc, char **argv)
 			printf(">>> Found %d issue(s) in the package database.\n\n", nbpkgs);
 			if (pkgdb_upgrade_lock(db, PKGDB_LOCK_ADVISORY,
 					PKGDB_LOCK_EXCLUSIVE) == EPKG_OK) {
-				ret = fix_deps(db, &dh, nbpkgs, yes);
+				ret = fix_deps(db, &dh, nbpkgs);
 				if (ret == EPKG_OK)
 					check_summary(db, &dh);
 				else if (ret == EPKG_ENODB) {

--- a/src/utils.c
+++ b/src/utils.c
@@ -726,8 +726,7 @@ set_jobs_summary_pkg(struct pkg_jobs *jobs,
 }
 
 static void
-display_summary_item (struct pkg_solved_display_item *it, int64_t total_size,
-		int64_t dlsize)
+display_summary_item(struct pkg_solved_display_item *it, int64_t dlsize)
 {
 	const char *why;
 	int64_t pkgsize;
@@ -852,7 +851,7 @@ print_jobs_summary(struct pkg_jobs *jobs, const char *msg, ...)
 			}
 			printf("%s:\n", pkg_display_messages[type]);
 			DL_FOREACH_SAFE(disp[type], cur, tmp) {
-				display_summary_item(cur, newsize, dlsize);
+				display_summary_item(cur, dlsize);
 				displayed ++;
 				free(cur);
 			}


### PR DESCRIPTION
The only one left is `pkg_checksum_get_type()` in `pkg_checksum.c` but this one is a work in progress as per @bapt .