### PR TITLE
make sure file in PATH is a regular file and not a symlink.

### DIFF
--- a/src/which.c
+++ b/src/which.c
@@ -210,7 +210,13 @@ exec_which(int argc, char **argv)
 static bool
 is_there(char *candidate)
 {
-	return (access(candidate, F_OK) == 0);
+	struct stat st;
+ 
+	if (lstat(candidate, &st) == 0) {
+		if (S_ISREG(st.st_mode) != 0)
+			return true;
+	}
+	return false;
 }
 
 int


### PR DESCRIPTION
For example /usr/bin/perl5 is a symlink, but since it not in database pkg which -p perl5 will never find /usr/loca/bin/perl5 in this case.