### PR TITLE
Let the default LOCALBASE variable be overridden at compile-time

### DIFF
--- a/libpkg/pkg_status.c
+++ b/libpkg/pkg_status.c
@@ -38,7 +38,9 @@
 #include "pkg.h"
 
 
+#ifndef _LOCALBASE
 #define _LOCALBASE	"/usr/local"
+#endif
 
 static bool is_exec_at_localbase(const char *progname);
 


### PR DESCRIPTION
On platforms other than FreeBSD LOCALBASE may have to be different by default - like "/usr/pkg" on NetBSD with pkgsrc. This change lets the _LOCALBASE pre-processing variable be easily overridden at compile-time through the CPPFLAGS.