### PR TITLE
fix pkg_warnx macro

### DIFF
--- a/src/pkgcli.h
+++ b/src/pkgcli.h
@@ -31,7 +31,7 @@
 #include <stdint.h>
 #include <bsd_compat.h>
 
-#define pkg_warnx(fmt, ...) pkg_fprintf(stderr, "%s" fmt, getprogname(), __VA_ARGS__, -1)
+#define pkg_warnx(fmt, ...) pkg_fprintf(stderr, "%S: " fmt, getprogname(), __VA_ARGS__, -1)
 
 extern bool quiet;
 extern int nbactions;


### PR DESCRIPTION
before:
```
# pkg-static annotate -A perl5 foo bar
perl5-5.18.4_11: Add annotation tagged: foo with value: bar? [y/N]: y
6071772925249143647perl5-5.18.4_11: Cannot add annotation tagged: foo
```

after:
```
# pkg-static annotate -A perl5 foo bar
perl5-5.18.4_11: Add annotation tagged: foo with value: bar? [y/N]: y
pkg-static: perl5-5.18.4_11: Cannot add annotation tagged: foo
```

But also we can remove usage of getprogname() from pkg_warnx, but i'm not sure about compatibility.