### PR TITLE
prevent double output for yes/no

### DIFF
--- a/libpkg/pkg_jobs.c
+++ b/libpkg/pkg_jobs.c
@@ -806,7 +806,7 @@ pkg_jobs_try_remote_candidate(struct pkg_jobs *j, const char *pattern,
 		}
 
 		sbuf_printf(qmsg, "%s has no direct installation candidates, change it to "
-				"%s? [Y/n]: ", uid, p->uid);
+				"%s? ", uid, p->uid);
 		sbuf_finish(qmsg);
 		if (pkg_emit_query_yesno(true, sbuf_data(qmsg))) {
 			/* Change the origin of the local package */

--- a/libpkg/pkg_solve.c
+++ b/libpkg/pkg_solve.c
@@ -856,7 +856,7 @@ pkg_solve_sat_problem(struct pkg_solve_problem *problem)
 				}
 			}
 
-			sbuf_printf(sb, "cannot %s package %s, remove it from request? [Y/n]: ",
+			sbuf_printf(sb, "cannot %s package %s, remove it from request? ",
 				var->to_install ? "install" : "remove", var->uid);
 			sbuf_finish(sb);
 


### PR DESCRIPTION
https://github.com/freebsd/pkg/commit/eabd4fb09077dbf6bb511193c02c4617987115a0 introduced new behaviour and this part was missed and don't work as expected from visual point of view.

```
cannot install package postgresql92-client, remove it from request? [Y/n]: [Y/n]: 
```
