### PR TITLE
Update upgrade.c

### DIFF
--- a/src/upgrade.c
+++ b/src/upgrade.c
@@ -182,7 +182,7 @@ exec_upgrade(int argc, char **argv)
 		rc = yes;
 		if (!quiet || dry_run) {
 			print_jobs_summary(jobs,
-				"The following %d packages will be affected (of %d checked):\n\n",
+				"The following %d package(s) will be affected (of %d checked):\n\n",
 				nbactions, pkg_jobs_total(jobs));
 
 			if (!dry_run)


### PR DESCRIPTION
This is not optimal, but it fixes the typo in the case the number is 1.