### PR TITLE
pkg-repo: Follow symlinks and ignore directories starting with '.'.

### DIFF
--- a/docs/pkg-repo.8
+++ b/docs/pkg-repo.8
@@ -15,7 +15,7 @@
 .\"     @(#)pkg.8
 .\" $FreeBSD$
 .\"
-.Dd April 9, 2014
+.Dd April 9, 2015
 .Dt PKG-REPO 8
 .Os
 .Sh NAME

--- a/docs/pkg-repo.8
+++ b/docs/pkg-repo.8
@@ -15,7 +15,7 @@
 .\"     @(#)pkg.8
 .\" $FreeBSD$
 .\"
-.Dd November 18, 2014
+.Dd April 9, 2014
 .Dt PKG-REPO 8
 .Os
 .Sh NAME
@@ -57,7 +57,9 @@ top-level directory where all the packages are stored as
 will search the filesystem beneath
 .Ar repo-path
 to find all the packages it contains.
-Symbolic links are ignored.
+Directories starting with
+.Qq . Qc
+are not traversed.
 .Pp
 The repository will be created in the package directory unless the
 .Fl o Ar output-dir

--- a/docs/pkg-repo.8
+++ b/docs/pkg-repo.8
@@ -59,6 +59,9 @@ will search the filesystem beneath
 to find all the packages it contains.
 Directories starting with
 .Qq . Qc
+or
+named
+.Pa Latest
 are not traversed.
 .Pp
 The repository will be created in the package directory unless the

--- a/libpkg/pkg_repo_create.c
+++ b/libpkg/pkg_repo_create.c
@@ -220,6 +220,17 @@ pkg_create_repo_read_fts(struct pkg_fts_item **items, FTS *fts,
 			fts_set(fts, fts_ent, FTS_SKIP);
 			continue;
 		}
+		/*
+		 * Ignore 'Latest' directory as it is just symlinks back to
+		 * already-processed packages.
+		 */
+		if ((fts_ent->fts_info == FTS_D ||
+		    fts_ent->fts_info == FTS_DP ||
+		    fts_ent->fts_info == FTS_SL) &&
+		    strcmp(fts_ent->fts_name, "Latest") == 0) {
+			fts_set(fts, fts_ent, FTS_SKIP);
+			continue;
+		}
 		/* Follow symlinks. */
 		if (fts_ent->fts_info == FTS_SL) {
 			fts_set(fts, fts_ent, FTS_FOLLOW);

--- a/libpkg/pkg_repo_create.c
+++ b/libpkg/pkg_repo_create.c
@@ -209,6 +209,23 @@ pkg_create_repo_read_fts(struct pkg_fts_item **items, FTS *fts,
 	errno = 0;
 
 	while ((fts_ent = fts_read(fts)) != NULL) {
+		/*
+		 * Skip directories starting with '.' to avoid Poudriere
+		 * symlinks.
+		 */
+		if ((fts_ent->fts_info == FTS_D ||
+		    fts_ent->fts_info == FTS_DP) &&
+		    fts_ent->fts_namelen > 2 &&
+		    fts_ent->fts_name[0] == '.') {
+			fts_set(fts, fts_ent, FTS_SKIP);
+			continue;
+		}
+		/* Follow symlinks. */
+		if (fts_ent->fts_info == FTS_SL) {
+			fts_set(fts, fts_ent, FTS_FOLLOW);
+			/* Restart. Next entry will be the resolved file. */
+			continue;
+		}
 		/* Skip everything that is not a file */
 		if (fts_ent->fts_info != FTS_F)
 			continue;


### PR DESCRIPTION
This fixes running 'pkg repo' in a Poudriere-made directory that
would result in several different versions of packages being added
to the packagesite. Each of them would refer to some .real_* directory.
Poudriere uses these directories to manage multiple previous builds
and to have a "build in progress" directory that does not conflict
with currently served packages.

See also https://github.com/freebsd/poudriere/issues/293
See also Issue #1200