### PR TITLE
Fix typo in pkg-info(8) man page

### DIFF
--- a/docs/pkg-info.8
+++ b/docs/pkg-info.8
@@ -76,7 +76,7 @@ Display the full manifest (raw) for the packages matching
 .It Fl -raw-format Ar format
 Choose the format of the raw output.
 The format can be:
-json, json-conpact, yaml (default).
+json, json-compact, yaml (default).
 .It Fl e , Cm --exists
 If
 .Ar pkg-name


### PR DESCRIPTION
Reported to me by Riccardo Torrini <riccardo@torrini.org>