### PR TITLE
pkg audit -r formatting

### DIFF
--- a/src/audit.c
+++ b/src/audit.c
@@ -287,7 +287,7 @@ exec_audit(int argc, char **argv)
 					sbuf_printf(sb, "Packages that depend on %s: ", name);
 					print_recursive_rdeps(check, pkg , sb, seen, true);
 					sbuf_finish(sb);
-					printf("%s\n", sbuf_data(sb));
+					printf("%s\n\n", sbuf_data(sb));
 
 					kh_destroy_pkgs(seen);
 				}


### PR DESCRIPTION
Add a second newline to leave a complete blank line after printing dependencies. It should make it easier to read as it currently runs into the next entry:

```
  libtasn1-4.2 is vulnerable:
  libtasn1 -- stack-based buffer overflow in asn1_der_decoding
  CVE: CVE-2015-2806
  WWW: http://vuxml.FreeBSD.org/freebsd/82595123-e8b8-11e4-a008-047d7b492d07.html
  
  Packages that depend on libtasn1: p11-kit, gnutls, glib-networking, libsoup, libsoup-gnome, gvfs, Thunar, xfce4-desktop, xfce, ffmpeg, audacity
  chromium-40.0.2214.115 is vulnerable:
```

There should be a space between the Packages and chromium lines, which this patch aims to solve