### PR TITLE
Use https when showing audit result from vuxml.

### DIFF
--- a/libpkg/pkg_audit.c
+++ b/libpkg/pkg_audit.c
@@ -764,7 +764,7 @@ pkg_audit_print_entry(struct pkg_audit_entry *e, struct sbuf *sb,
 			sbuf_printf(sb, "WWW: %s\n\n", e->url);
 		else if (e->id)
 			sbuf_printf(sb,
-				"WWW: http://vuxml.FreeBSD.org/freebsd/%s.html\n\n",
+				"WWW: https://vuxml.FreeBSD.org/freebsd/%s.html\n\n",
 				e->id);
 	}
 }


### PR DESCRIPTION
This is a reduced version of my previous pull request and makes pkg audit to give https://vuxml.f.o results, as it's intended for human consumption.