### PR TITLE
in the zsh completion handle query formats

### DIFF
--- a/scripts/completion/_pkg.in
+++ b/scripts/completion/_pkg.in
@@ -2,19 +2,19 @@
 
 _pkg_installed() {
 	local expl
-	_wanted packages expl Packages \
+	_wanted packages expl package \
 	compadd "$@" - $(@prefix@/sbin/pkg query "%n-%v")
 }
 
 _pkg_available_name() {
 	local expl
-	_wanted packages expl Packages \
+	_wanted packages expl package \
 	compadd "$@" - $(@prefix@/sbin/pkg rquery "%n")
 }
 
 _pkg_aliases() {
 	local expl
-	_wanted aliases expl Aliases \
+	_wanted aliases expl alias \
 	compadd "$@" - $(@prefix@/sbin/pkg alias -ql)
 }
 
@@ -34,99 +34,100 @@ _pkg_available() {
 }
 
 _pkg() {
+	local curcontext="$curcontext" state state_descr line ret=1
 	local earlyargs subcmd
 	local subcmd_list cmd
 	earlyargs=(
-	'-d[Increment debug level]'
-	'-j[Execute pkg(8) inside a jail(8)]:jail:_jails'
-	'-c[Execute pkg(8) inside a chroot(8)]:chroot:_files -/'
-	'-C[Use the specified configuration file]'
-	'-l[List available command and exit]'
-	'-v[Display pkg(8) version]'
-	'-N[Test if pkg(8) is activated and avoid auto-activation]'
+	'-d[increment debug level]'
+	'-j[execute pkg(8) inside a jail(8)]:jail:_jails'
+	'-c[execute pkg(8) inside a chroot(8)]:chroot:_files -/'
+	'-C[use the specified configuration file]'
+	'-l[list available command and exit]'
+	'-v[display pkg(8) version]'
+	'-N[test if pkg(8) is activated and avoid auto-activation]'
 	)
 
 	subcmd=(
-		'add[Compatibility interface to install a package]'
-		'alias[List the command line aliases]'
-		'annotate[Add, modify or delete tag-value style annotations on packages]'
-		'audit[Reports vulnerable packages]'
-		'autoremove[Removes orphan packages]'
-		'backup[Backs-up and restores the local package database]'
-		'check[Checks for missing dependencies and database consistency]'
-		'clean[Cleans old packages from the cache]'
-		'config[Display the value of the configuration options]'
-		'convert[Convert database from/to pkgng]'
-		'create[Creates software package distributions]'
-		'delete[Deletes packages from the database and the system]'
-		'fetch[Fetches packages from a remote repository]'
-		'help[Displays help information]'
-		'info[Displays information about installed packages]'
-		'install[Installs packages from remote package repositories]'
-		'lock[Locks package against modifications or deletion]'
-		'query[Queries information about installed packages]'
-		'register[Registers a package into the local database]'
-		'remove[Deletes packages from the database and the system]'
-		'repo[Creates a package repository catalogue]'
-		'rquery[Queries information in repository catalogues]'
-		'search[Performs a search of package repository catalogues]'
-		'set[Modifies information about packages in the local database]'
-		'shell[Opens a debug shell]'
-		'shlib[Displays which packages link against a specific shared library]'
-		'stats[Displays package database statistics]'
-		'unlock[Unlocks a package, allowing modification or deletion]'
-		'update[Updates package repository catalogues]'
-		'updating[Displays UPDATING information for a package]'
-		'upgrade[Performs upgrades of packaged software distributions]'
-		'version[Displays the versions of installed packages]'
-		'which[Displays which package installed a specific file]'
+		'add[compatibility interface to install a package]'
+		'alias[list the command line aliases]'
+		'annotate[add, modify or delete tag-value style annotations on packages]'
+		'audit[report vulnerable packages]'
+		'autoremove[remove orphaned packages]'
+		'backup[back-up and restore the local package database]'
+		'check[check for missing dependencies and database consistency]'
+		'clean[clean old packages from the cache]'
+		'config[display value of a configuration option]'
+		'convert[convert database from/to pkgng]'
+		'create[create software package distributions]'
+		'delete[delete packages from the database and the system]'
+		'fetch[fetch packages from a remote repository]'
+		'help[display help information]'
+		'info[display information about installed packages]'
+		'install[install packages from remote package repositories]'
+		'lock[lock package against modifications or deletion]'
+		'query[query information about installed packages]'
+		'register[register a package with the local database]'
+		'remove[delete packages from the database and the system]'
+		'repo[create a package repository catalogue]'
+		'rquery[query information in repository catalogues]'
+		'search[perform a search of package repository catalogues]'
+		'set[modify information about packages in the local database]'
+		'shell[open a debug shell]'
+		'shlib[list packages that link against a specific shared library]'
+		'stats[display package database statistics]'
+		'unlock[unlock a package, allowing modification or deletion]'
+		'update[update package repository catalogues]'
+		'updating[display UPDATING information for a package]'
+		'upgrade[perform upgrades of packaged software distributions]'
+		'version[display versions of installed packages]'
+		'which[display which package installed a specific file]'
 	)
 
 	if [[ $service = "pkg" ]]; then
 
 		_arguments -C -A "-*" \
 			$earlyargs \
-			'*::command:->subcmd' && return 0
+			'*::command:->subcmd' && return
 
 		if (( CURRENT == 1 )); then
 			_values 'pkg subcommands' \
-				$subcmd && return 0
-			return 0
+				$subcmd
+			return
 		fi
 		service="$words[1]"
-		curcontext="${curcontext%:*}=$service:"
+		curcontext="${curcontext%:*}-$service:"
 	fi
 
 	case $service in
 		(add) _arguments -A 'package' \
-			'*:package:_files -g "*.t?z"' && return 0
+			'*:package:_files -g "*.t?z"' && return
 			;;
 		(alias)
 			_arguments -s \
-				'-q[Quiet]' \
-				'*:aliases:_pkg_aliases' \
-				&& return 0
+				'-q[quiet]' \
+				'*:alias:_pkg_aliases' \
+				&& return
 			;;
 		(audit)
 			_arguments -s \
-				'-F[Fetch the database before checking.]' \
-				'-q[Quiet]' \
-				'-r[Prints packages that depend on vulnerable packages]' \
+				'-F[fetch database before checking]' \
+				'-q[quiet]' \
+				'-r[print packages that depend on vulnerable packages]' \
 				'-f[local copy of the vulnerability database]:audit file:_files' \
 				'*:package:_pkg_installed' \
-				&& return 0
+				&& return
 			;;
 		(autoremove)
 			_arguments -s \
-				'(-n)-y[Assume yes when asked for confirmation]' \
-				'(-y)-n[Assume no (dry run) when asked for confirmation]' \
-				&& return 0
+				'(-n)-y[assume yes when asked for confirmation]' \
+				'(-y)-n[assume no (dry run) when asked for confirmation]' \
+				&& return
 			;;
 		(backup)
 			_arguments -s \
-				'(-r)-d[Dumps the local package database]:destination:_files' \
-				'(-d)-r[Restore the local package database]:destination:_files' \
-				&& return 0
+				'(-r)-d[dump local package database]:destination:_files' \
+				'(-d)-r[restore local package database]:destination:_files' \
+				&& return
 			;;
 		(check)
 			_arguments -s \
@@ -134,105 +135,106 @@ _pkg() {
 				'-d[check for and install missing dependencies]' \
 				'-r[recompute sizes and checksums of installed]' \
 				'-s[find invalid checksums]' \
-				'-v[Be verbose]' \
-				'(-g -x -X)-a[Process all packages]' \
-				'(-x -X -a)-g[Process packages that match the glob pattern]:glob pattern:' \
-				'(-g -X -a)-x[Process packages that match the regex pattern]:regex pattern:' \
-				'(-g -x -a)-X[Process packages that match the extended regex pattern]:extended regex pattern:' \
-				&& return 0
+				'-v[be verbose]' \
+				'(-g -x -X)-a[process all packages]' \
+				'(-x -X -a)-g[process packages that match a glob pattern]:glob pattern' \
+				'(-g -X -a)-x[process packages that match a regex pattern]:regex pattern' \
+				'(-g -x -a)-X[process packages that match an extended regex pattern]:extended regex pattern' \
+				&& return
 			;;
 		(clean)
 			return 0
 			;;
 		(convert)
 			_arguments -s \
-				'-r[Revert conversion]' \
-				&& return 0
+				'-r[revert conversion]' \
+				&& return
 			;;
 		(create)
 			_arguments -s \
-				'-r[Root directory]:rootdir:_files -/' \
-				'-m[Manifest directory]:manifestdir:_files -/' \
+				'-r[specify root directory]:rootdir:_files -/' \
+				'-m[specify manifest directory]:manifestdir:_files -/' \
 				'-f[format]:format:((tar tgz tbz txz))' \
-				'-o[Ouput directory]:outdir:_files -/' \
-				'(-g -x -X)-a[Process all packages]' \
-				'(-x -X -a)-g[Process packages that match the glob pattern]:glob pattern:' \
-				'(-g -X -a)-x[Process packages that match the regex pattern]:regex pattern:' \
-				'(-g -x -a)-X[Process packages that match the extended regex pattern]:extended regex pattern:' \
-				'*:Package:_pkg_installed' \
-				&& return 0
+				'-o[output directory]:outdir:_files -/' \
+				'(-g -x -X)-a[process all packages]' \
+				'(-x -X -a)-g[process packages that match a glob pattern]:glob pattern' \
+				'(-g -X -a)-x[process packages that match a regex pattern]:regex pattern' \
+				'(-g -x -a)-X[process packages that match an extended regex pattern]:extended regex pattern' \
+				'*:package:_pkg_installed' \
+				&& return
 			;;
 		(delete|remove)
 			_arguments -s \
-				'(-n)-y[Assume yes when asked for confirmation]' \
-				'(-y)-n[Assume no (dry run) when asked for confirmation]' \
-				'-f[Force the package(s) to be removed]' \
-				'(-g -x -X)-a[Process all packages]' \
-				'(-x -X -a)-g[Process packages that match the glob pattern]:glob pattern:' \
-				'(-g -X -a)-x[Process packages that match the regex pattern]:regex pattern:' \
-				'(-g -x -a)-X[Process packages that match the extended regex pattern]:extended regex pattern:' \
-				'*:Package:_pkg_installed' \
-				&& return 0
+				'(-n)-y[assume yes when asked for confirmation]' \
+				'(-y)-n[assume no (dry run) when asked for confirmation]' \
+				'-f[force the package(s) to be removed]' \
+				'(-g -x -X)-a[process all packages]' \
+				'(-x -X -a)-g[process packages that match a glob pattern]:glob pattern' \
+				'(-g -X -a)-x[process packages that match a regex pattern]:regex pattern' \
+				'(-g -x -a)-X[process packages that match an extended regex pattern]:extended regex pattern' \
+				'*:package:_pkg_installed' \
+				&& return
 			;;
 		(fetch)
 			_arguments -s \
-				'-y[Assume yes when asked for confirmation]' \
-				'-L[Do not try to update the repository metadata]' \
-				'-q[Be quiet]' \
-				'(-g -x -X)-a[Process all packages]' \
-				'(-x -X -a)-g[Process packages that match the glob pattern]:glob pattern:' \
-				'(-g -X -a)-x[Process packages that match the regex pattern]:regex pattern:' \
-				'(-g -x -a)-X[Process packages that match the extended regex pattern]:extended regex pattern:' \
-				'*:Available packages:_pkg_available' \
-				&& return 0
+				'-y[assume yes when asked for confirmation]' \
+				"-L[don't try to update the repository metadata]" \
+				'-q[be quiet]' \
+				'(-g -x -X)-a[process all packages]' \
+				'(-x -X -a)-g[process packages that match a glob pattern]:glob pattern' \
+				'(-g -X -a)-x[process packages that match a regex pattern]:regex pattern' \
+				'(-g -x -a)-X[process packages that match an extended regex pattern]:extended regex pattern' \
+				'*:available package:_pkg_available' \
+				&& return
 			;;
 		(help)
 			_arguments -s \
-				':command:_values -S " " -w "pkg subcommands" ${subcmd/\[*/}'
+				':command:_values -S " " -w "pkg subcommand" ${subcmd/\[*/}'
 			return 0
 			;;
 		(info)
 			_arguments -s \
-				'(-e -d -r -l -o -p -D)-f[Displays full information]' \
-				'(-f -d -r -l -o -p -D)-e[Returns 0 if <pkg-name> is installed]' \
-				'(-e -f -r -l -o -p -D)-d[Displays the dependencies]' \
-				'(-e -d -f -l -o -p -D)-r[Displays the reverse dependencies]' \
-				'(-e -d -r -f -o -p -D)-l[Displays all files]' \
-				'(-e -d -r -l -f -p -D)-o[Displays origin]' \
-				'(-e -d -r -l -o -f -D)-p[Displays prefix]' \
-				'(-e -d -r -l -o -p -f)-D[Displays message]' \
-				'-q[Be quiet]' \
-				'(-g -x -X -F)-a[Process all packages]' \
-				'(-x -X -a -F)-g[Process packages that match the glob pattern]:glob pattern:' \
-				'(-g -X -a -F)-x[Process packages that match the regex pattern]:regex pattern:' \
-				'(-g -x -a -F)-X[Process packages that match the extended regex pattern]:extended regex pattern:' \
-				'(-g -x -X -a)-F[Process the specified package]:package:_files -g "*.t?z"' \
-				'*:Package:_pkg_installed' \
-				&& return 0
+				'(-e -d -r -l -o -p -D)-f[display full information]' \
+				'(-f -d -r -l -o -p -D)-e[return 0 if specified package is installed]' \
+				'(-e -f -r -l -o -p -D)-d[display the dependencies]' \
+				'(-e -d -f -l -o -p -D)-r[display the reverse dependencies]' \
+				'(-e -d -r -f -o -p -D)-l[display all files]' \
+				'(-e -d -r -l -f -p -D)-o[display origin]' \
+				'(-e -d -r -l -o -f -D)-p[display prefix]' \
+				'(-e -d -r -l -o -p -f)-D[display message]' \
+				'-q[be quiet]' \
+				'(-g -x -X -F)-a[process all packages]' \
+				'(-x -X -a -F)-g[process packages that match a glob pattern]:glob pattern' \
+				'(-g -X -a -F)-x[process packages that match a regex pattern]:regex pattern' \
+				'(-g -x -a -F)-X[process packages that match an extended regex pattern]:extended regex pattern' \
+				'(-g -x -X -a)-F[process the specified package]:package:_files -g "*.t?z"' \
+				'*:package:_pkg_installed' \
+				&& return
 			;;
 		(install)
 			_arguments -s \
-				'(-n)-y[Assume yes when asked for confirmation]' \
-				'(-y)-n[Assume no (dry run) when asked for confirmation]' \
-				'-f[Force reinstallation if needed]' \
-				'-R[Reinstall every package depending on matching expressions]' \
-				'-L[Do not try to update the repository metadata]' \
-				'(-x -X)-g[Process packages that match the glob pattern]:glob pattern:' \
-				'(-g -X)-x[Process packages that match the regex pattern]:regex pattern:' \
-				'(-g -x)-X[Process packages that match the extended regex pattern]:extended regex pattern:' \
-				'*:Available packages:_pkg_available' \
-				&& return 0
+				'(-n)-y[assume yes when asked for confirmation]' \
+				'(-y)-n[assume no (dry run) when asked for confirmation]' \
+				'-f[force reinstallation if needed]' \
+				'-R[reinstall every package depending on matching expressions]' \
+				"-L[don't try to update the repository metadata]" \
+				'(-x -X)-g[process packages that match a glob pattern]:glob pattern' \
+				'(-g -X)-x[process packages that match a regex pattern]:regex pattern' \
+				'(-g -x)-X[process packages that match an extended regex pattern]:extended regex pattern' \
+				'*:available packages:_pkg_available' \
+				&& return
 			;;
 		(query)
-			_arguments -s \
-				'(-g -x -X -F -e)-a[Process all packages]' \
-				'(-x -X -a -F -e)-g[Process packages that match the glob pattern]:glob pattern:' \
-				'(-g -X -a -F -e)-x[Process packages that match the regex pattern]:regex pattern:' \
-				'(-g -x -a -F -e)-X[Process packages that match the extended regex pattern]:extended regex pattern:' \
-				'(-g -x -X -a -F)-e[Process packages that match the evaluation]:evaluation:' \
-				'(-g -x -X -a -e)-F[Process the specified package]:package:_files -g "*.t?z"' \
-				':Ouput format:' \
-				&& return 0
+			_arguments -C -s \
+				'(-g -x -X -F -e)-a[process all packages]' \
+				'-C[case-insensitive regex matching]' \
+				'(-x -X -a -F -e)-g[process packages that match a glob pattern]:glob pattern' \
+				'(-g -X -a -F -e)-x[process packages that match a regex pattern]:regex pattern' \
+				'(-g -x -a -F -e)-X[process packages that match an extended regex pattern]:extended regex pattern' \
+				'(-g -x -X -a -F)-e[process packages that match an evaluation]:evaluation:->evaluation' \
+				'(-g -x -X -a -e)-F[process the specified package]:package:_files -g "*.t?z"' \
+				':output format:->query' \
+				&& ret=0
 			;;
 		(register)
 			_arguments -s \
@@ -240,103 +242,157 @@ _pkg() {
 				'-d[mark the package as an automatic dependency]' \
 				'-f[packing list file]:packing list file:_files' \
 				'-m[metadata directory]:metadatadir:_files -/' \
-				'-a[ABI]:abi:' \
+				'-a[ABI]:abi' \
 				'-i[input path (aka root directory)]:input path:_files -/' \
-				&& return 0
+				&& return
 			;;
 		(repo)
 			_arguments -s \
-				':Repository path:_files -/' \
+				':repository path:_files -/' \
 				':RSA key:_files' \
-				&& return 0
+				&& return
 			;;
 		(rquery)
-			_arguments -s \
-				'(-g -x -X -e)-a[Process all packages]' \
-				'(-x -X -a -e)-g[Process packages that match the glob pattern]:glob pattern:' \
-				'(-g -X -a -e)-x[Process packages that match the regex pattern]:regex pattern:' \
-				'(-g -x -a -e)-X[Process packages that match the extended regex pattern]:extended regex pattern:' \
-				'(-g -x -X -a)-e[Process packages that match the evaluation]:evaluation:' \
-				':Ouput format:' \
-				&& return 0
+			_arguments -C -s \
+				'(-g -x -X -e)-a[process all packages]' \
+				'(-x -X -a -e)-g[process packages that match the glob pattern]:glob pattern' \
+				'(-g -X -a -e)-x[process packages that match a regex pattern]:regex pattern' \
+				'(-g -x -a -e)-X[process packages that match a extended regex pattern]:extended regex pattern' \
+				'(-g -x -X -a)-e[process packages that match an evaluation]:evaluation:->evaluation' \
+				':output format:->query' \
+				&& ret=0
 			;;
 		(search)
 			_arguments -s \
-				'(-x -X)-g[Process packages that match the glob pattern]:glob pattern:' \
-				'(-g -X)-x[Process packages that match the regex pattern]:regex pattern:' \
-				'(-g -x)-X[Process packages that match the extended regex pattern]:extended regex pattern:' \
-				'*:Available packages:_pkg_available_name' \
-				&& return 0
+				'(-x -X)-g[process packages that match the glob pattern]:glob pattern' \
+				'(-g -X)-x[process packages that match the regex pattern]:regex pattern' \
+				'(-g -x)-X[process packages that match the extended regex pattern]:extended regex pattern' \
+				'*:available package:_pkg_available_name' \
+				&& return
 			;;
 		(set)
 			_arguments -s \
-				'(-o)-A[Mark as automatic or not]:flag:((1\:automatic 0\:not\ automatic))' \
-				'(-A)-o[Change the origin]:oldorigin\:neworigin:' \
-				'-y[Assume yes when asked for confirmation]' \
-				'(-g -x -X)-a[Process all packages]' \
-				'(-x -X -a)-g[Process packages that match the glob pattern]:glob pattern:' \
-				'(-g -X -a)-x[Process packages that match the regex pattern]:regex pattern:' \
-				'(-g -x -a)-X[Process packages that match the extended regex pattern]:extended regex pattern:' \
-				'*:Package:_pkg_installed'
+				'(-o)-A[mark as automatic or not]:flag:((1\:automatic 0\:not\ automatic))' \
+				'(-A)-o[change the origin]:oldorigin\:neworigin' \
+				'-y[assume yes when asked for confirmation]' \
+				'(-g -x -X)-a[process all packages]' \
+				'(-x -X -a)-g[process packages that match the glob pattern]:glob pattern' \
+				'(-g -X -a)-x[process packages that match the regex pattern]:regex pattern' \
+				'(-g -x -a)-X[process packages that match the extended regex pattern]:extended regex pattern' \
+				'*:package:_pkg_installed'
 			return 0
 			;;
 		(shell)
 			_arguments -s \
 				':database:_files' \
-				&& return 0
+				&& return
 			;;
 		(shlib)
 			_arguments -s \
-				':Library:' \
-				&& return 0
+				':library:' \
+				&& return
 			;;
 		(stats)
 			_arguments -s \
-				'-q[Be quiet]' \
-				'(-l)-r[Display stats only for the local package database]' \
-				'(-r)-l[Display stats only for the remote package database(s)]' \
-				&& return 0
+				'-q[be quiet]' \
+				'(-l)-r[display stats only for the local package database]' \
+				'(-r)-l[display stats only for the remote package database(s)]' \
+				&& return
 			;;
 		(update)
 			_arguments -s \
-				'-f[Force update]' \
-				'-q[Be quiet]' \
-				&& return 0
+				'-f[force update]' \
+				'-q[be quiet]' \
+				&& return
 			;;
 		(updating)
 			_arguments -s \
-				'-d[Only entries newer than date are shown]:date:' \
-				'-f[Defines a alternative location of the UPDATING file]:UPDATING file:_files' \
-				'*:Package:_pkg_installed' \
-				&& return 0
+				'-d[only entries newer than date are shown]:date' \
+				'-f[specify alternative location of the UPDATING file]:UPDATING file:_files' \
+				'*:package:_pkg_installed' \
+				&& return
 			;;
 		(upgrade)
 			_arguments -s \
-				'(-y)-n[Assume no (dry run) when asked for confirmation]' \
-				'(-n)-y[Assume yes when asked for confirmation]' \
-				'-f[Upgrade/Reinstall everything]' \
-				'-L[Do not try to update the repository metadata]' \
-				&& return 1
+				"-F[don't install packages, merely fetch them]" \
+				'(-y)-n[assume no (dry run) when asked for confirmation]' \
+				'(-n)-y[assume yes when asked for confirmation]' \
+				'-f[upgrade/reinstall everything]' \
+				'-L[do not try to update the repository metadata]' \
+				&& return
 			;;
 		(version)
 			#TODO: complete
 			_arguments -s \
-				'(-P -R)-I[Use INDEX file]' \
-				'(-R -I)-P[Force checking against the ports tree]' \
-				'(-I -P)-R[Use remote repository]' \
-				'-o[Display package origin, instead of package name]' \
-				'-q[Be quiet]' \
-				'-v[Be verbose]' \
-				'(-L)-l[Display only the packages with a given status flag]:flag:((\< = \>))' \
-				'(-l)-L[Display only the packages without a given status flag]:flag:((\< = \>))' \
-				&& return 0
+				'(-P -R)-I[use INDEX file]' \
+				'(-R -I)-P[force checking against the ports tree]' \
+				'(-I -P)-R[use remote repository]' \
+				'-o[display package origin, instead of package name]' \
+				'-q[be quiet]' \
+				'-v[be verbose]' \
+				'(-L)-l[display only the packages with a given status flag]:flag:((\< = \>))' \
+				'(-l)-L[display only the packages without a given status flag]:flag:((\< = \>))' \
+				&& return
 			;;
 		(which)
 			_arguments -s \
 				':file:_files' \
-			&& return 0
+			&& return
 			;;
 	esac
+
+	[[ -z $state ]] && return ret
+	local -a specs elements
+	elements=(
+		'd:dependencies' 'r:reverse dependencies' 'C:categories'
+		'O:options' 'L:licenses' 'A:annotations'
+		'B:required share libraries' 'b:provided shared libraries'
+	)
+	specs=(
+		'n:package name' 'o:origin' 'p:prefix' 'm:maintainer'
+		'c:comment' 'e:description' 'w:home page' 's:size'
+		'q:architecture' 'M:message'
+		'?:if info exists' '#:no of elements'
+	)
+	if [[ $service = query ]]; then
+		specs+=( 'a:automatic' 'k:locked' 't:timestamp' )
+		elements+=( 'F:files' 'D:directories'  'U:users' 'G:groups' )
+  fi
+	if [[ $state = query ]]; then
+    specs+=( 'v:version' 'l:license' 'R:repository' )
+		compset -P '(%[^sOFdrA?#]|%?[^%]|[^%])#'
+  else
+		compset -P '(%[^OFdrA?#]|%?[^%]|[^%])#'
+  fi
+	if compset -P '%s'; then
+		_describe -t units unit '( b:bytes h:human\ readable )' -S '' && ret=0
+	elif compset -P '%F'; then
+		_describe -t properties property '( p:path s:sum )' -S '' && ret=0
+	elif compset -P '%O'; then
+		_describe -t properties property '( k:key v:value d:default D:description )' -S '' && ret=0
+	elif compset -P '%[dr]'; then
+		_describe -t properties 'dependency property' '( n:name o:origin v:version )' -S '' && ret=0
+	elif compset -P '%A'; then
+		_describe -t properties property '( t:tag s:value )' -S '' && ret=0
+	elif compset -P '%(|\\)[?#]'; then
+		_describe -t lists list elements -S '' && ret=0
+	else
+		[[ $IPREFIX = *%(#b)([${(j..)elements%%:*}])* ]] &&
+			elements=( ${(M)elements:#$match[1]:*} )
+		if [[ $state = evaluation ]]; then
+		  _tags variables operators
+		else
+		  _tags patterns elements
+		fi
+		while _tags; do
+			_requested elements && _describe -t elements 'list element' elements -p % -S '' && ret=0
+			_requested variables && _describe -t variables 'variable' specs -p % -S '' && ret=0
+			_requested patterns && _describe -t patterns 'query specifier' specs -p % -S '' && ret=0
+			_requested operators expl operator compadd -S '' \~ {,\!,\>,\<}= \> \< \&\& \|\| && ret=0
+		  (( ret )) || break
+		done
+	fi
+	return ret
 }
 
 _pkg "$@"


### PR DESCRIPTION
This adds support for all the % formats/variables for pkg query/rquery to the zsh completion function. It'd be great if you could include this with pkg.

I also changed descriptions to follow the zsh convention of starting with a lowercase letter. That results in most lines changing when viewing the differences.
