### PR TITLE
Fix two typos in pkg_vset(), to correspond to pkg_vget()'s code

### DIFF
--- a/libpkg/pkg.c
+++ b/libpkg/pkg.c
@@ -382,8 +382,8 @@ pkg_vset(struct pkg *pkg, va_list ap)
 			pkg->digest = strdup(va_arg(ap, const char *));
 			break;
 		case PKG_REASON:
-			free(pkg->digest);
-			pkg->digest = strdup(va_arg(ap, const char *));
+			free(pkg->reason);
+			pkg->reason = strdup(va_arg(ap, const char *));
 			break;
 		case PKG_FLATSIZE:
 			pkg->flatsize = va_arg(ap, int64_t);
@@ -395,7 +395,7 @@ pkg_vset(struct pkg *pkg, va_list ap)
 			pkg->pkgsize = va_arg(ap, int64_t);
 			break;
 		case PKG_LICENSE_LOGIC:
-			pkg->pkgsize = (bool)va_arg(ap, int);
+			pkg->licenselogic = (lic_t)va_arg(ap, int);
 			break;
 		case PKG_AUTOMATIC:
 			pkg->automatic = (bool)va_arg(ap, int);


### PR DESCRIPTION
The PKG_LICENSE_LOGIC and PKG_REASON cases in pkg_vset() should
apparently access the corresponding field as in pkg_vget().