### PR TITLE
Always use sqlite3_column_int64 for reading integers from the db

### DIFF
--- a/libpkg/pkg_status.c
+++ b/libpkg/pkg_status.c
@@ -89,7 +89,7 @@ pkg_status(int *count)
 			if (dbsuccess) {
 				dbsuccess = (sqlite3_step(stmt) == SQLITE_ROW);
 				if (dbsuccess) {
-					numpkgs = sqlite3_column_int(stmt, 0);
+					numpkgs = sqlite3_column_int64(stmt, 0);
 				}
 				sqlite3_finalize(stmt);
 			}

--- a/libpkg/pkgdb_iterator.c
+++ b/libpkg/pkgdb_iterator.c
@@ -254,7 +254,7 @@ pkgdb_load_deps(sqlite3 *sqlite, struct pkg *pkg)
 		pkg_adddep(pkg, sqlite3_column_text(stmt, 0),
 			   sqlite3_column_text(stmt, 1),
 			   sqlite3_column_text(stmt, 2),
-			   sqlite3_column_int(stmt, 3));
+			   sqlite3_column_int64(stmt, 3));
 	}
 	sqlite3_finalize(stmt);
 
@@ -303,7 +303,7 @@ pkgdb_load_deps(sqlite3 *sqlite, struct pkg *pkg)
 							}
 
 							sqlite3_bind_int64(opt_stmt, 1,
-									sqlite3_column_int(stmt, 0));
+									sqlite3_column_int64(stmt, 0));
 
 							while ((ret = sqlite3_step(opt_stmt))
 									== SQLITE_ROW) {
@@ -335,7 +335,7 @@ pkgdb_load_deps(sqlite3 *sqlite, struct pkg *pkg)
 							pkg_adddep(pkg, sqlite3_column_text(stmt, 1),
 									sqlite3_column_text(stmt, 2),
 									sqlite3_column_text(stmt, 3),
-									sqlite3_column_int(stmt, 4));
+									sqlite3_column_int64(stmt, 4));
 						}
 					}
 
@@ -386,7 +386,7 @@ pkgdb_load_rdeps(sqlite3 *sqlite, struct pkg *pkg)
 		pkg_addrdep(pkg, sqlite3_column_text(stmt, 0),
 			    sqlite3_column_text(stmt, 1),
 			    sqlite3_column_text(stmt, 2),
-			    sqlite3_column_int(stmt, 3));
+			    sqlite3_column_int64(stmt, 3));
 	}
 	sqlite3_finalize(stmt);
 
@@ -668,7 +668,7 @@ pkgdb_load_scripts(sqlite3 *sqlite, struct pkg *pkg)
 
 	while ((ret = sqlite3_step(stmt)) == SQLITE_ROW) {
 		pkg_addscript(pkg, sqlite3_column_text(stmt, 0),
-		    sqlite3_column_int(stmt, 1));
+		    sqlite3_column_int64(stmt, 1));
 	}
 	sqlite3_finalize(stmt);
 
@@ -882,28 +882,28 @@ populate_pkg(sqlite3_stmt *stmt, struct pkg *pkg) {
 
 			switch (column->type) {
 			case PKG_AUTOMATIC:
-				pkg->automatic = (bool)sqlite3_column_int(stmt, icol);
+				pkg->automatic = (bool)sqlite3_column_int64(stmt, icol);
 				break;
 			case PKG_LOCKED:
-				pkg->locked = (bool)sqlite3_column_int(stmt, icol);
+				pkg->locked = (bool)sqlite3_column_int64(stmt, icol);
 				break;
 			case PKG_FLATSIZE:
-				pkg->flatsize = sqlite3_column_int(stmt, icol);
+				pkg->flatsize = sqlite3_column_int64(stmt, icol);
 				break;
 			case PKG_ROWID:
-				pkg->id = sqlite3_column_int(stmt, icol);
+				pkg->id = sqlite3_column_int64(stmt, icol);
 				break;
 			case PKG_LICENSE_LOGIC:
-				pkg->licenselogic = (lic_t)sqlite3_column_int(stmt, icol);
+				pkg->licenselogic = (lic_t)sqlite3_column_int64(stmt, icol);
 				break;
 			case PKG_OLD_FLATSIZE:
-				pkg->old_flatsize = sqlite3_column_int(stmt, icol);
+				pkg->old_flatsize = sqlite3_column_int64(stmt, icol);
 				break;
 			case PKG_PKGSIZE:
-				pkg->pkgsize = sqlite3_column_int(stmt, icol);
+				pkg->pkgsize = sqlite3_column_int64(stmt, icol);
 				break;
 			case PKG_TIME:
-				pkg->timestamp = sqlite3_column_int(stmt, icol);
+				pkg->timestamp = sqlite3_column_int64(stmt, icol);
 				break;
 			default:
 				pkg_emit_error("Unexpected integer value for %s", colname);

--- a/libpkg/repo/binary/init.c
+++ b/libpkg/repo/binary/init.c
@@ -93,7 +93,7 @@ pkg_repo_binary_get_user_version(sqlite3 *sqlite, int *reposcver)
 	}
 
 	if (sqlite3_step(stmt) == SQLITE_ROW) {
-		*reposcver = sqlite3_column_int(stmt, 0);
+		*reposcver = sqlite3_column_int64(stmt, 0);
 		retcode = EPKG_OK;
 	} else {
 		*reposcver = -1;


### PR DESCRIPTION
sqlite3_bind_int64 was already used for writing any integer values.

This should fix the integer overflow bug #1273 when displaying package size for
packages larger than 2GiB