### PR TITLE
HBSD: fix format specifier in libpkg's pkg_vets(...)

### DIFF
--- a/libpkg/pkg.c
+++ b/libpkg/pkg.c
@@ -303,7 +303,7 @@ pkg_vset(struct pkg *pkg, va_list ap)
 
 	while ((attr = va_arg(ap, int)) > 0) {
 		if (attr >= PKG_NUM_FIELDS || attr <= 0) {
-			pkg_emit_error("Bad argument on pkg_set %s", attr);
+			pkg_emit_error("Bad argument on pkg_set %d", attr);
 			return (EPKG_FATAL);
 		}
 


### PR DESCRIPTION
The attr variables type is int, but the format string in pkg_emit_error
is %s. In some case with enabled ASLR this cause a core dump.

 441     {
 442             int attr;
 443
 444             while ((attr = va_arg(ap, int)) > 0) {
 445                     if (attr >= PKG_NUM_FIELDS || attr <= 0) {
 446                             pkg_emit_error("Bad argument on pkg_set %s", attr);
 447                             return (EPKG_FATAL);
 448                     }
 449
 450                     switch (attr) {

(gdb) bt
 #0  0x00000000007f25ab in strlen ()
 #1  0x00000000007e8062 in __vfprintf ()
 #2  0x00000000007a5747 in vasprintf_l ()
 #3  0x0000000000451e7e in pkg_emit_error (
    fmt=0x84b9f5 "Bad argument on pkg_set %s") at pkg_event.c:418
 #4  0x00000000004264c9 in pkg_vset (pkg=0x22036461600, ap=0x6529128ac3e0)
    at pkg.c:446
 #5  0x0000000000426409 in pkg_set2 (pkg=0x22036461600) at pkg.c:567
 #6  0x00000000004024a2 in exec_audit (argc=1, argv=0x6529128acd00)
    at audit.c:207
 #7  0x000000000040e22e in main (argc=2, argv=0x6529128accf8) at main.c:847

Sponsored-by: HardenedBSD
Found-by: ASLR - stack randomization
Signed-off-by: Oliver Pinter <oliver.pinter@hardenedbsd.org>
CC: Pedro Giffuni <pfg@freebsd.org
CC: Baptiste Daroussin <bapt@freebsd.org>