### PR TITLE
urldecode message when reading it back.

### DIFF
--- a/libpkg/pkg_manifest.c
+++ b/libpkg/pkg_manifest.c
@@ -302,7 +302,10 @@ pkg_string(struct pkg *pkg, const ucl_object_t *obj, int attr)
 		pkg->maintainer = strdup(str);
 		break;
 	case PKG_MESSAGE:
-		pkg->message = strdup(str);
+		urldecode(str, &buf);
+		sbuf_finish(buf);
+		pkg->message = strdup(sbuf_data(buf));
+		sbuf_delete(buf);
 		break;
 	case PKG_NAME:
 		pkg->name = strdup(str);


### PR DESCRIPTION
Currently, if pkg-message contains %, it would become %25 in the resulting package created by pkgng (ports/202343).

Looking at the code, we do an urlencode() when storing package description and message, but only do urldecode() when retrieving package description, not message.  The proposed patch would add the required decode for package message.