### PR TITLE
load manifestdigest for pkgdb_query_shlib_provide

### DIFF
--- a/libpkg/pkgdb_query.c
+++ b/libpkg/pkgdb_query.c
@@ -237,7 +237,7 @@ pkgdb_query_shlib_provide(struct pkgdb *db, const char *shlib)
 		"SELECT p.id, p.origin, p.name, p.name as uniqueid, "
 			"p.version, p.comment, p.desc, "
 			"p.message, p.arch, p.maintainer, p.www, "
-			"p.prefix, p.flatsize, p.time "
+			"p.prefix, p.flatsize, p.manifestdigest, p.time "
 			"FROM packages AS p, pkg_shlibs_provided AS ps, shlibs AS s "
 			"WHERE p.id = ps.package_id "
 				"AND ps.shlib_id = s.id "


### PR DESCRIPTION
pkg_jobs_universe_handle_provide can call pkg_jobs_universe_process_item which required pkg->digest to be loaded. That should fix issue with digest == NULL.

P.S. don't merge without review