### PR TITLE
Allow glibc/linux to build without libldns

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ addons:
       - libarchive-dev
       - libssl-dev
       - liblzma-dev
-      - libldns-dev
 
 sudo: false
 

--- a/configure.ac
+++ b/configure.ac
@@ -157,6 +157,7 @@ AC_CHECK_FUNCS_ONCE([strnstr])
 AC_CHECK_FUNCS_ONCE([funopen])
 AC_CHECK_FUNCS_ONCE([fopencookie])
 AC_CHECK_FUNCS_ONCE([sysctlbyname])
+AC_CHECK_FUNCS_ONCE([res_setservers])
 AC_CHECK_DECLS(
 	[[fstatat], [openat], [unlinkat], [readlinkat], [faccessat]],
 	[], [], [
@@ -268,6 +269,7 @@ AC_SEARCH_LIBS([zlibVersion], [z], [], [
 AC_SEARCH_LIBS([archive_read_open], [archive], [], [
   AC_MSG_ERROR([unable to find the archive_read() function])
 ])
+AC_SEARCH_LIBS([__res_query], [resolv], [], [])
 
 AC_CHECK_HEADER([archive.h],
 	[pkg_found_archive_headers=yes])

--- a/libpkg/dns_utils.c
+++ b/libpkg/dns_utils.c
@@ -238,6 +238,9 @@ dns_getsrvinfo(const char *zone)
 
 int
 set_nameserver(const char *nsname) {
+#ifndef HAVE_RES_SETSERVERS
+	return (-1);
+#else
 	struct __res_state res;
 	union res_sockaddr_union u[MAXNS];
 	struct addrinfo *answer = NULL;
@@ -277,6 +280,7 @@ set_nameserver(const char *nsname) {
 	_res = res;
 
 	return (0);
+#endif
 }
 #else
 

--- a/libpkg/pkg_config.c
+++ b/libpkg/pkg_config.c
@@ -1086,8 +1086,12 @@ pkg_ini(const char *path, const char *reposdir, pkg_init_flags flags)
 
 	/* bypass resolv.conf with specified NAMESERVER if any */
 	nsname = pkg_object_string(pkg_config_get("NAMESERVER"));
-	if (nsname != NULL)
-		set_nameserver(ucl_object_tostring_forced(o));
+	if (nsname != NULL) {
+		if (set_nameserver(ucl_object_tostring_forced(o)) != 0) {
+			pkg_emit_error("Unable to set nameserver");
+			return (EPKG_FATAL);
+		}
+	}
 
 	return (EPKG_OK);
 }

--- a/scripts/travis_build.sh
+++ b/scripts/travis_build.sh
@@ -39,8 +39,7 @@ set -e
 if [ $(uname -s) = "Darwin" ]; then
   ./configure
 elif [ $(uname -s) = "Linux" ]; then
-  CFLAGS="-Wno-strict-aliasing -Wno-unused-result -Wno-unused-value" \
-    ./configure --with-ldns
+  CFLAGS="-Wno-strict-aliasing -Wno-unused-result -Wno-unused-value" ./configure
 fi
 
 # Build quietly and in parallel first.  If the build fails re-run


### PR DESCRIPTION
This change allows the glibc/linux build to take advantage
of the non-ldns path in dns_utils.c by making res_setservers
optional (this is not available in glibc) and automatically
detecting the need to -lresolv.