### PR TITLE
Fix out-of-tree build of libelf

### DIFF
--- a/external/Makefile.am
+++ b/external/Makefile.am
@@ -157,7 +157,7 @@ libelf_la_SOURCES=	libelf/elf.c \
 nodist_libelf_la_SOURCES=	libelf/libelf_fsize.c \
 				libelf/libelf_msize.c \
 				libelf/libelf_convert.c
-libelf_la_CFLAGS=	-I$(top_srcdir)/external/libelf
+libelf_la_CFLAGS=	-I$(top_srcdir)/external/libelf -I$(top_builddir)/external/libelf
 libelf_static_la_SOURCES=	${libelf_la_SOURCES}
 nodist_libelf_static_la_SOURCES=	$(nodist_libelf_la_SOURCES)
 libelf_static_la_CFLAGS=	$(libelf_la_CFLAGS) -static


### PR DESCRIPTION
native-elf-format.h is auto-generated in the build tree
but only the source tree was on the include path.

Repro steps: "cd build_dir && $(SRC_DIR)/configure && make"