### PR TITLE
Fix corruption with @config files due to a c-string vs buffer error.

### DIFF
--- a/libpkg/pkg_add.c
+++ b/libpkg/pkg_add.c
@@ -216,8 +216,9 @@ do_extract(struct archive *a, struct archive_entry *ae, const char *location,
 		if (pkg_is_config_file(pkg, path, &rf, &rcf)) {
 			pkg_debug(1, "Populating config_file %s", pathname);
 			size_t len = archive_entry_size(ae);
-			rcf->content = malloc(len);
+			rcf->content = malloc(len + 1);
 			archive_read_data(a, rcf->content, len);
+			rcf->content[len] = '\0';
 			if (renamed && (!automerge || local == NULL))
 				strlcat(pathname, ".pkgnew", sizeof(pathname));
 		}


### PR DESCRIPTION
Without this fix, pkg appends random garbage to files with the @config tag.