### PR TITLE
Honor metadata settings in 'repo' command

### DIFF
--- a/libpkg/pkg_repo_create.c
+++ b/libpkg/pkg_repo_create.c
@@ -1032,9 +1032,6 @@ pkg_finish_repo(const char *output_dir, pem_password_cb *password_cb,
 			rsa_free(rsa);
 			return (EPKG_FATAL);
 		}
-		else {
-			meta = pkg_repo_meta_default();
-		}
 		if (pkg_repo_pack_db(repo_meta_file, repo_path, repo_path, rsa, meta,
 			argv, argc) != EPKG_OK) {
 			ret = EPKG_FATAL;


### PR DESCRIPTION
The -m <filename> argument to pkg repo was not
having any effect because it was being replaced
by the default settings immediately after load.

The effect is that any non-default settings in
the metadata file are effectively ignored when
generating repo files.
