### PR TITLE
Fix issue with provides searching.

### DIFF
--- a/libpkg/pkg_jobs_universe.c
+++ b/libpkg/pkg_jobs_universe.c
@@ -320,7 +320,9 @@ pkg_jobs_universe_handle_provide(struct pkg_jobs_universe *universe,
 				PKG_LOAD_ANNOTATIONS|PKG_LOAD_CONFLICTS;
 
 	rpkg = NULL;
-	prhead = NULL;
+
+	HASH_FIND_STR(universe->provides, name, prhead);
+
 	while (pkgdb_it_next(it, &rpkg, flags) == EPKG_OK) {
 		/* Check for local packages */
 		HASH_FIND_STR(universe->items, rpkg->uid, unit);

--- a/libpkg/pkg_jobs_universe.c
+++ b/libpkg/pkg_jobs_universe.c
@@ -376,9 +376,17 @@ pkg_jobs_universe_handle_provide(struct pkg_jobs_universe *universe,
 			DL_APPEND(prhead, pr);
 			HASH_ADD_KEYPTR(hh, universe->provides, pr->provide,
 					strlen(pr->provide), prhead);
+			pkg_debug (4, "universe: add new provide %s-%s(%s) for require %s",
+					pr->un->pkg->name, pr->un->pkg->version,
+					pr->un->pkg->type == PKG_INSTALLED ? "l" : "r",
+					pr->provide);
 		}
 		else {
 			DL_APPEND(prhead, pr);
+			pkg_debug (4, "universe: append provide %s-%s(%s) for require %s",
+					pr->un->pkg->name, pr->un->pkg->version,
+					pr->un->pkg->type == PKG_INSTALLED ? "l" : "r",
+					pr->provide);
 		}
 	}
 

--- a/libpkg/pkg_solve.c
+++ b/libpkg/pkg_solve.c
@@ -326,7 +326,7 @@ pkg_solve_handle_provide (struct pkg_solve_problem *problem,
 			libfound = kh_contains(strings, pkg->shlibs_provided, pr->provide);
 			/* Skip incompatible ABI as well */
 			if (libfound && strcmp(pkg->arch, orig->arch) != 0) {
-				pkg_debug(2, "require %s: package %s-%s(%c) provides wrong ABI %s, "
+				pkg_debug(2, "solver: require %s: package %s-%s(%c) provides wrong ABI %s, "
 					"wanted %s", pr->provide, pkg->name, pkg->version,
 					pkg->type == PKG_INSTALLED ? 'l' : 'r', orig->arch, pkg->arch);
 				continue;
@@ -337,11 +337,14 @@ pkg_solve_handle_provide (struct pkg_solve_problem *problem,
 		}
 
 		if (!providefound && !libfound) {
-			pkg_debug(4, "%s provide is not satisfied by %s-%s(%c)", pr->provide,
+			pkg_debug(4, "solver: %s provide is not satisfied by %s-%s(%c)", pr->provide,
 					pkg->name, pkg->version, pkg->type == PKG_INSTALLED ?
 							'l' : 'r');
 			continue;
 		}
+		pkg_debug(4, "solver: %s provide is satisfied by %s-%s(%c)", pr->provide,
+				pkg->name, pkg->version, pkg->type == PKG_INSTALLED ?
+				'l' : 'r');
 
 		it = pkg_solve_item_new(curvar);
 		if (it == NULL)


### PR DESCRIPTION
Previously, we could replace already added provide with a new one. That caused memory leaks and broken upgrades when local provides were different from the remote ones. Namely, this should fix jpeg->jpeg-turbo upgrade.