### PR TITLE
Remove reference to EOL FreeBSD version.

### DIFF
--- a/docs/pkg.8
+++ b/docs/pkg.8
@@ -220,8 +220,6 @@ If invoked with the
 flag an attempt will be made to reinstall
 .Nm
 from remote repository.
-This is not supported on FreeBSD 8.3 as it did not have
-.Xr pkg 7 .
 .It Ic check
 Sanity checks installed packages.
 .It Ic clean


### PR DESCRIPTION
Just a small documentation change I thought about while reading the man page.