### PR TITLE
Support compiling on OpenBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ latest release version:
 
 
 <a name="pkggit"></a>
-### Building pkg using sources from Git
+### Building pkg using sources from Git [FreeBSD]
 
 In order to build pkg from source, you will need to have Gnu
 autotools and some other tools installed.
@@ -277,6 +277,37 @@ system and capable of running Gnu autotools.  However, various places
 in the pkg(8) code make assumptions about OS specific behaviour.  If
 you do try anything like this, we'd be very interested to hear how you
 get on.
+
+<a name="pkggit-openbsd"></a>
+### Building pkg using sources from Git [OpenBSD and Bitrig]
+
+	# Install packages
+	pkg_add autoconf automake libtool bitrig-binutils bzip2 git libarchive
+	
+	# set environment variables
+	export AUTOMAKE_VERSION=1.15
+	export AUTOCONF_VERSION=2.69
+	
+	# create a download directory
+	mkdir ~/git
+	
+	# install pkgconf
+	cd ~/git
+	git clone https://github.com/pkgconf/pkgconf
+	cd pkgconf
+	./autogen.sh
+	./configure
+	make
+	sudo make install
+	
+	# install pkg
+	cd ~/git
+	git clone https://github.com/yonas/pkg
+	cd pkg
+	./autogen.sh
+	env LDFLAGS='-L/usr/local/lib' CPPFLAGS='-I/usr/local/include' ./configure
+	env LDFLAGS='-L/usr/local/lib' CPPFLAGS='-I/usr/local/include' make
+	sudo make install
 
 <a name="pkg2ng"></a>
 ### Converting an old-style pkg database

--- a/README.md
+++ b/README.md
@@ -305,8 +305,8 @@ get on.
 	git clone https://github.com/yonas/pkg
 	cd pkg
 	./autogen.sh
-	env LDFLAGS='-L/usr/local/lib' CPPFLAGS='-I/usr/local/include' ./configure
-	env LDFLAGS='-L/usr/local/lib' CPPFLAGS='-I/usr/local/include' make
+	./configure
+	make
 	sudo make install
 
 <a name="pkg2ng"></a>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-pkg - a binary package manager for FreeBSD and OpenBSD
-========================================================
+pkg - a binary package manager for FreeBSD
+============================================
 
 Table of Contents:
 ------------------

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-pkg - a binary package manager for FreeBSD
-============================================
+pkg - a binary package manager for FreeBSD and OpenBSD
+========================================================
 
 Table of Contents:
 ------------------

--- a/compat/bsd_compat.h
+++ b/compat/bsd_compat.h
@@ -30,6 +30,8 @@
 #include "pkg_config.h"
 
 #ifdef __OpenBSD__
+ #include "../external/libelf/_elftc.h"
+
  #ifndef EPROTO
   #define EPROTO EINTR
  #endif

--- a/compat/bsd_compat.h
+++ b/compat/bsd_compat.h
@@ -29,6 +29,12 @@
 
 #include "pkg_config.h"
 
+#ifdef __OpenBSD__
+ #ifndef EPROTO
+  #define EPROTO EINTR
+ #endif
+#endif
+
 #ifdef HAVE_BSD_SYS_CDEFS_H
 #include <bsd/sys/cdefs.h>
 #endif

--- a/configure.ac
+++ b/configure.ac
@@ -336,12 +336,28 @@ AC_CHECK_LIB(c, cap_sandboxed, [
 
 AC_CACHE_CHECK(for arc4random_uniform,
                ac_cv_func_arc4random_uniform,
-               [AC_TRY_COMPILE([#include <stdlib.h>],
+               [ac_save_CFLAGS="$CFLAGS"
+                CFLAGS="-Werror $CFLAGS"
+                AC_TRY_COMPILE([#include <stdlib.h>],
                                [arc4random_uniform(255);],
                                [ac_cv_func_arc4random_uniform=yes],
-                               [ac_cv_func_arc4random_uniform=no])])
+                               [ac_cv_func_arc4random_uniform=no])
+		CFLAGS="$ac_save_CFLAGS"])
 if test "$ac_cv_func_arc4random_uniform" = yes ; then
 	AC_DEFINE(HAVE_ARC4RANDOM, 1, [Define 1 if you have 'arc4random_uniform' function.])
+fi
+
+AC_CACHE_CHECK(for arc4random_stir,
+               ac_cv_func_arc4random_stir,
+               [ac_save_CFLAGS="$CFLAGS"
+                CFLAGS="-Werror $CFLAGS"
+                AC_TRY_COMPILE([#include <stdlib.h>],
+                               [arc4random_stir();],
+                               [ac_cv_func_arc4random_stir=yes],
+                               [ac_cv_func_arc4random_stir=no])
+		CFLAGS="$ac_save_CFLAGS"])
+if test "$ac_cv_func_arc4random_stir" = yes ; then
+   AC_DEFINE(HAVE_ARC4RANDOM_STIR, 1, [Define 1 if you have 'arc4random_stir' function.])
 fi
 
 AC_CACHE_CHECK(for BSD dirname(const char *),

--- a/configure.ac
+++ b/configure.ac
@@ -78,6 +78,12 @@ case $host_os in
         OS_LIBS="-ldl -lrt"
         OS_STATIC="false"
         ;;
+  openbsd*|bitrig*)
+        OS_CFLAGS="-D_BSD_SOURCE -I/usr/local/include"
+        OS_LDFLAGS="-L/usr/local/lib"
+        OS_LIBS=
+        OS_STATIC="true"
+        ;;
   *)
         OS_CFLAGS="-D_BSD_SOURCE"
         OS_LDFLAGS=
@@ -93,6 +99,7 @@ AC_SUBST(OS_STATIC)
 AM_CONDITIONAL([BUILD_STATIC], [test x$OS_STATIC = xtrue])
 
 CFLAGS="$CFLAGS $OS_CFLAGS"
+LDFLAGS="$LDFLAGS $OS_LDFLAGS"
 
 AC_CHECK_HEADERS_ONCE([machine/endian.h])
 AC_CHECK_HEADERS_ONCE([endian.h])

--- a/configure.ac
+++ b/configure.ac
@@ -360,6 +360,19 @@ if test "$ac_cv_func_arc4random_stir" = yes ; then
    AC_DEFINE(HAVE_ARC4RANDOM_STIR, 1, [Define 1 if you have 'arc4random_stir' function.])
 fi
 
+AC_CACHE_CHECK(for humanize_number,
+               ac_cv_func_humanize_number,
+               [ac_save_CFLAGS="$CFLAGS"
+                CFLAGS="-Werror $CFLAGS"
+                AC_TRY_COMPILE([#include <libutil.h>],
+                               [humanize_number(NULL, 0, 0, NULL, 0, 0);],
+                               [ac_cv_func_humanize_number=yes],
+                               [ac_cv_func_humanize_number=no])
+		CFLAGS="$ac_save_CFLAGS"])
+if test "$ac_cv_func_humanize_number" = yes ; then
+   AC_DEFINE(HAVE_HUMANIZE_NUMBER, 1, [Define 1 if you have 'humanize_number' function.])
+fi
+
 AC_CACHE_CHECK(for BSD dirname(const char *),
                ac_cv_func_dirname,
                [ac_save_CFLAGS="$CFLAGS"

--- a/external/libelf/elf.c
+++ b/external/libelf/elf.c
@@ -25,13 +25,13 @@
  */
 
 #include <libelf.h>
-/*
-#include "/usr/include/sys/exec_elf.h"
-*/
-
 #include "_libelf.h"
 
-#define EM_AMD64    62
+#ifdef __OpenBSD__
+ #ifndef EM_AMD64
+  #define EM_AMD64    62
+ #endif
+#endif
 
 ELFTC_VCSID("$Id$");
 

--- a/external/libelf/elf.c
+++ b/external/libelf/elf.c
@@ -25,8 +25,13 @@
  */
 
 #include <libelf.h>
+/*
+#include "/usr/include/sys/exec_elf.h"
+*/
 
 #include "_libelf.h"
+
+#define EM_AMD64    62
 
 ELFTC_VCSID("$Id$");
 

--- a/libpkg/dns_utils.c
+++ b/libpkg/dns_utils.c
@@ -40,6 +40,39 @@
 #endif
 #include <netdb.h>
 
+#ifndef NS_QFIXEDSZ
+#define NS_QFIXEDSZ     4       /*%< #/bytes of fixed data in query */
+#endif
+
+#ifndef NS_INT16SZ
+#define NS_INT16SZ      2       /*%< #/bytes of data in a u_int16_t */
+#endif
+
+#ifndef NS_INT32SZ
+#define NS_INT32SZ      4       /*%< #/bytes of data in a u_int32_t */
+#endif
+
+/*%
+ * Inline versions of get/put short/long.  Pointer is advanced.
+ */
+#define NS_GET16(s, cp) do { \
+        register const u_char *t_cp = (const u_char *)(cp); \
+        (s) = ((u_int16_t)t_cp[0] << 8) \
+            | ((u_int16_t)t_cp[1]) \
+            ; \
+        (cp) += NS_INT16SZ; \
+} while (0)
+
+#define NS_GET32(l, cp) do { \
+        register const u_char *t_cp = (const u_char *)(cp); \
+        (l) = ((u_int32_t)t_cp[0] << 24) \
+            | ((u_int32_t)t_cp[1] << 16) \
+            | ((u_int32_t)t_cp[2] << 8) \
+            | ((u_int32_t)t_cp[3]) \
+            ; \
+        (cp) += NS_INT32SZ; \
+} while (0)
+
 #include <bsd_compat.h>
 #include "private/utils.h"
 #include "pkg.h"

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -40,6 +40,7 @@ pkg_SOURCES=		add.c \
 pkg_LDADD=	@OS_LDFLAGS@ \
 			$(top_builddir)/libpkg/libpkg.la \
 			$(top_builddir)/external/libsbuf.la \
+			$(top_builddir)/compat/libbsd_compat.la \
 			@LIBJAIL_LIB@ \
 			-lutil \
 			-lcrypto

--- a/src/main.c
+++ b/src/main.c
@@ -62,6 +62,22 @@
 
 #include "pkgcli.h"
 
+#ifndef _HUMANIZE_NUMBER
+#define _HUMANIZE_NUMBER
+
+#include <util.h>
+#include <errno.h>
+int humanize_number(char *buf, size_t len, int64_t number, const char *suffix, int scale, int flags) {
+    if (len < FMT_SCALED_STRSIZE) {
+        return -1;
+    }
+    else if (fmt_scaled(number, buf) == 0)
+        return 0;
+    else
+        return errno;
+}
+#endif
+
 /* Used to define why do we show usage message to a user */
 enum pkg_usage_reason {
 	PKG_USAGE_ERROR,
@@ -687,7 +703,7 @@ main(int argc, char **argv)
 	if (debug == 0 && version == 0)
 		start_process_worker(save_argv);
 
-#ifdef HAVE_ARC4RANDOM
+#ifdef HAVE_ARC4RANDOM_STIR
 	/* Ensure that random is stirred after a possible fork */
 	arc4random_stir();
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -62,22 +62,6 @@
 
 #include "pkgcli.h"
 
-#ifndef _HUMANIZE_NUMBER
-#define _HUMANIZE_NUMBER
-
-#include <util.h>
-#include <errno.h>
-int humanize_number(char *buf, size_t len, int64_t number, const char *suffix, int scale, int flags) {
-    if (len < FMT_SCALED_STRSIZE) {
-        return -1;
-    }
-    else if (fmt_scaled(number, buf) == 0)
-        return 0;
-    else
-        return errno;
-}
-#endif
-
 /* Used to define why do we show usage message to a user */
 enum pkg_usage_reason {
 	PKG_USAGE_ERROR,

--- a/src/pkgcli.h
+++ b/src/pkgcli.h
@@ -30,6 +30,7 @@
 
 #include <stdint.h>
 #include <bsd_compat.h>
+#include "external/libelf/_elftc.h"
 
 #define pkg_warnx(fmt, ...) pkg_fprintf(stderr, "%S: " fmt, getprogname(), __VA_ARGS__, -1)
 

--- a/src/pkgcli.h
+++ b/src/pkgcli.h
@@ -30,7 +30,6 @@
 
 #include <stdint.h>
 #include <bsd_compat.h>
-#include "external/libelf/_elftc.h"
 
 #define pkg_warnx(fmt, ...) pkg_fprintf(stderr, "%S: " fmt, getprogname(), __VA_ARGS__, -1)
 


### PR DESCRIPTION
Hi,

I've made a few changes to get pkgng compiling and running on OpenBSD.

Some of this may be hackish, especially with `humanize_number()`, which doesn't exist on OpenBSD.

Cheers,
Yonas