### PR TITLE
zsh-completion: fixes, more consistent descriptions and add new options

### DIFF
--- a/scripts/completion/_pkg.in
+++ b/scripts/completion/_pkg.in
@@ -125,7 +125,7 @@ _pkg() {
 		'which[display which package installed a specific file]'
 	)
 
-	_arguments -C \
+	_arguments -C -A "-*" \
 		'(-d --debug)'{-d,--debug}'[increment debug level]' \
 		'(-j --jail)'{-j,--jail}'[execute pkg(8) inside a jail(8)]:jail:_jails' \
 		'(-c --chroot)'{-c,--chroot}'[execute pkg(8) inside a chroot(8)]:chroot:_files -/' \


### PR DESCRIPTION
Query formats were sometimes getting in the way of completing package names for pkg query. Some new changes were again using uppercase for match descriptions. Then there are one or two other simplifications, additional options or simple typo corrections.