### PR TITLE
Update the OpenBSD README instructions to use this repository.

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ get on.
 	
 	# install pkg
 	cd ~/git
-	git clone https://github.com/yonas/pkg
+	git clone https://github.com/freebsd/pkg
 	cd pkg
 	./autogen.sh
 	./configure


### PR DESCRIPTION
Update the OpenBSD README instructions to use https://github.com/freebsd/pkg, as the OpenBSD patches have been merged.