### PR TITLE
Prefix jail name before printed output

### DIFF
--- a/libpkg/libpkg.ver
+++ b/libpkg/libpkg.ver
@@ -45,6 +45,7 @@ global:
 	pkg_free;
 	pkg_from_old;
 	pkg_get2;
+	pkg_get_jailname;
 	pkg_get_myarch;
 	pkg_get_myarch_legacy;
 	pkg_groups;
@@ -55,6 +56,7 @@ global:
 	pkg_init;
 	pkg_initialized;
 	pkg_is_installed;
+	pkg_is_jailed;
 	pkg_is_locked;
 	pkg_is_valid;
 	pkg_jobs_add;

--- a/libpkg/pkg.h.in
+++ b/libpkg/pkg.h.in
@@ -1684,6 +1684,9 @@ char *pkg_absolutepath(const char *src, char *dest, size_t dest_len);
 
 void pkg_cache_full_clean(void);
 
+char *pkg_get_jailname(void);
+bool pkg_is_jailed(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/add.c
+++ b/src/add.c
@@ -189,14 +189,15 @@ exec_add(int argc, char **argv)
 	
 	if(failedpkgcount > 0) {
 		sbuf_finish(failedpkgs);
-		printf("\nFailed to install the following %d package(s): %s\n", failedpkgcount, sbuf_data(failedpkgs));
+		printf("\n");
+		printf_pref("Failed to install the following %d package(s): %s\n", failedpkgcount, sbuf_data(failedpkgs));
 		retcode = EPKG_FATAL;
 	}
 	sbuf_delete(failedpkgs);
 
 	if (messages != NULL) {
 		sbuf_finish(messages);
-		printf("%s", sbuf_data(messages));
+		printf_pref("%s", sbuf_data(messages));
 	}
 
 	return (retcode == EPKG_OK ? EX_OK : EX_SOFTWARE);

--- a/src/audit.c
+++ b/src/audit.c
@@ -274,7 +274,7 @@ exec_audit(int argc, char **argv)
 		kh_foreach_value(check, pkg, {
 			if (pkg_audit_is_vulnerable(audit, pkg, quiet, &sb)) {
 				vuln ++;
-				printf("%s", sbuf_data(sb));
+				printf_pref("%s", sbuf_data(sb));
 
 				if (recursive) {
 					const char *name;
@@ -285,7 +285,7 @@ exec_audit(int argc, char **argv)
 					sbuf_printf(sb, "Packages that depend on %s: ", name);
 					print_recursive_rdeps(check, pkg , sb, seen, true);
 					sbuf_finish(sb);
-					printf("%s\n\n", sbuf_data(sb));
+					printf_pref("%s\n\n", sbuf_data(sb));
 
 					kh_destroy_pkgs(seen);
 				}
@@ -299,7 +299,7 @@ exec_audit(int argc, char **argv)
 			ret = EX_OK;
 
 		if (!quiet)
-			printf("%u problem(s) in the installed packages found.\n", vuln);
+			printf_pref("%u problem(s) in the installed packages found.\n", vuln);
 	}
 	else {
 		warnx("cannot process vulnxml");

--- a/src/autoremove.c
+++ b/src/autoremove.c
@@ -127,7 +127,7 @@ exec_autoremove(int argc, char **argv)
 	}
 
 	if ((nbactions = pkg_jobs_count(jobs)) == 0) {
-		printf("Nothing to do.\n");
+		printf_pref("Nothing to do.\n");
 		goto cleanup;
 	}
 

--- a/src/backup.c
+++ b/src/backup.c
@@ -88,14 +88,14 @@ exec_backup(int argc, char **argv)
 
 	if (dump) {
 		if (!quiet)
-			printf("Dumping database:\n");
+			printf_pref("Dumping database:\n");
 		if (pkgdb_dump(db, backup_file) == EPKG_FATAL)
 			return (EX_IOERR);
 	}
 
 	if (restore) {
 		if (!quiet)
-			printf("Restoring database:\n");
+			printf_pref("Restoring database:\n");
 		if (pkgdb_load(db, backup_file) == EPKG_FATAL)
 			return (EX_IOERR);
 	}

--- a/src/check.c
+++ b/src/check.c
@@ -423,7 +423,7 @@ exec_check(int argc, char **argv)
 				if (match == MATCH_ALL)
 					progressbar_start("Checking all packages");
 				else {
-					sbuf_printf(msg, "Checking %s", argv[i]);
+					sbuf_printf_pref(msg, "Checking %s", argv[i]);
 					sbuf_finish(msg);
 					progressbar_start(sbuf_data(msg));
 				}
@@ -514,7 +514,7 @@ exec_check(int argc, char **argv)
 			progressbar_tick(processed, total);
 		if (sbuf_len(out) > 0) {
 			sbuf_finish(out);
-			printf("%s", sbuf_data(out));
+			printf_pref("%s", sbuf_data(out));
 		}
 		sbuf_delete(out);
 		if (msg != NULL) {
@@ -523,8 +523,9 @@ exec_check(int argc, char **argv)
 		}
 
 		if (dcheck && nbpkgs > 0 && !noinstall) {
-			printf("\n>>> Missing package dependencies were detected.\n");
-			printf(">>> Found %d issue(s) in the package database.\n\n", nbpkgs);
+			printf("\n");
+			printf_pref(">>> Missing package dependencies were detected.\n");
+			printf_pref(">>> Found %d issue(s) in the package database.\n\n", nbpkgs);
 			if (pkgdb_upgrade_lock(db, PKGDB_LOCK_ADVISORY,
 					PKGDB_LOCK_EXCLUSIVE) == EPKG_OK) {
 				ret = fix_deps(db, dh, nbpkgs);

--- a/src/clean.c
+++ b/src/clean.c
@@ -75,7 +75,7 @@ add_to_dellist(dl_list *dl,  const char *path)
 	if (!quiet) {
 		if (first_entry) {
 			first_entry = false;
-			printf("The following package files will be deleted:"
+			printf_pref("The following package files will be deleted:"
 			    "\n");
 		}
 		printf("\t%s\n", store_path);
@@ -119,9 +119,9 @@ delete_dellist(dl_list *dl, int total)
 
 	if (!quiet) {
 		if (retcode == EX_OK)
-			printf("All done\n");
+			printf_pref("All done\n");
 		else
-			printf("%d package%s could not be deleted\n",
+			printf_pref("%d package%s could not be deleted\n",
 			      count, count > 1 ? "s" : "");
 	}
 	return (retcode);
@@ -307,7 +307,7 @@ exec_clean(int argc, char **argv)
 
 	if (kv_size(dl) == 0) {
 		if (!quiet)
-			printf("Nothing to do.\n");
+			printf_pref("Nothing to do.\n");
 		retcode = EX_OK;
 		goto cleanup;
 	}
@@ -316,7 +316,7 @@ exec_clean(int argc, char **argv)
 	    HN_AUTOSCALE, HN_IEC_PREFIXES);
 
 	if (!quiet)
-		printf("The cleanup will free %s\n", size);
+		printf_pref("The cleanup will free %s\n", size);
 	if (!dry_run) {
 			if (query_yesno(false,
 			  "\nProceed with cleaning the cache? ")) {

--- a/src/config.c
+++ b/src/config.c
@@ -71,24 +71,24 @@ exec_config(int argc, char **argv)
 	switch (pkg_object_type(conf)) {
 	case PKG_STRING:
 		buf = pkg_object_string(conf);
-		printf("%s\n", buf == NULL ? "" : buf);
+		printf_pref("%s\n", buf == NULL ? "" : buf);
 		break;
 	case PKG_BOOL:
 		b = pkg_object_bool(conf);
-		printf("%s\n", b ? "yes" : "no");
+		printf_pref("%s\n", b ? "yes" : "no");
 		break;
 	case PKG_INT:
 		integer = pkg_object_int(conf);
-		printf("%"PRId64"\n", integer);
+		printf_pref("%"PRId64"\n", integer);
 		break;
 	case PKG_OBJECT:
 		while ((o = pkg_object_iterate(conf, &it))) {
-			printf("%s: %s\n", pkg_object_key(o), pkg_object_string(o));
+			printf_pref("%s: %s\n", pkg_object_key(o), pkg_object_string(o));
 		}
 		break;
 	case PKG_ARRAY:
 		while ((o = pkg_object_iterate(conf, &it))) {
-			printf("%s\n", pkg_object_string(o));
+			printf_pref("%s\n", pkg_object_string(o));
 		}
 		break;
 	default:

--- a/src/convert.c
+++ b/src/convert.c
@@ -101,10 +101,10 @@ convert_from_old(const char *pkg_add_dbdir, bool dry_run)
 			pkg_free(p);
 			if (pkg_new(&p, PKG_OLD_FILE) != EPKG_OK)
 				err(EX_OSERR, "malloc");
-			printf("Converting %s...\n", dp->d_name);
+			printf_pref("Converting %s...\n", dp->d_name);
 			snprintf(path, sizeof(path), "%s/%s", pkg_add_dbdir, dp->d_name);
 			if (pkg_old_load_from_path(p, path) != EPKG_OK) {
-				fprintf(stderr, "Skipping invalid package: %s\n", path);
+				fprintf_pref(stderr, "Skipping invalid package: %s\n", path);
 				continue;
 			}
 			pkg_from_old(p);
@@ -154,7 +154,7 @@ exec_convert(__unused int argc, __unused char **argv)
 		return (EX_USAGE);
 	}
 
-	printf("Converting packages from %s\n", pkg_add_dbdir);
+	printf_pref("Converting packages from %s\n", pkg_add_dbdir);
 
 	return (convert_from_old(pkg_add_dbdir, dry_run));
 }

--- a/src/delete.c
+++ b/src/delete.c
@@ -184,7 +184,7 @@ exec_delete(int argc, char **argv)
 		goto cleanup;
 
 	if (pkg_jobs_solve(jobs) != EPKG_OK) {
-		fprintf(stderr, "Cannot perform request\n");
+		fprintf_pref(stderr, "Cannot perform request\n");
 		retcode = EX_NOPERM;
 		goto cleanup;
 	}
@@ -193,10 +193,10 @@ exec_delete(int argc, char **argv)
 	if ((nbactions = pkg_jobs_count(jobs)) == 0) {
 		if (argc == 0) {
 			if (!quiet)
-				printf("Nothing to do.\n");
+				printf_pref("Nothing to do.\n");
 			retcode = EX_OK;
 		} else {
-			fprintf(stderr, "Package(s) not found!\n");
+			fprintf_pref(stderr, "Package(s) not found!\n");
 			retcode = EX_DATAERR;
 		}
 		goto cleanup;
@@ -224,7 +224,7 @@ exec_delete(int argc, char **argv)
 
 	if (messages != NULL) {
 		sbuf_finish(messages);
-		printf("%s", sbuf_data(messages));
+		printf_pref("%s", sbuf_data(messages));
 	}
 	pkgdb_compact(db);
 

--- a/src/fetch.c
+++ b/src/fetch.c
@@ -206,7 +206,7 @@ exec_fetch(int argc, char **argv)
 			rc = query_yesno(false, "\nProceed with fetching "
 			    "packages? ");
 		else {
-			printf("No packages are required to be fetched.\n");
+			printf_pref("No packages are required to be fetched.\n");
 			rc = query_yesno(false, "Check the integrity of packages "
 							"downloaded? ");
 			csum_only = true;
@@ -220,7 +220,7 @@ exec_fetch(int argc, char **argv)
 		goto cleanup;
 
 	if (csum_only && !quiet)
-		printf("Integrity check was successful.\n");
+		printf_pref("Integrity check was successful.\n");
 
 	retcode = EX_OK;
 

--- a/src/info.c
+++ b/src/info.c
@@ -412,7 +412,7 @@ exec_info(int argc, char **argv)
 		}
 
 		if (match != MATCH_ALL && pkgname[0] == '\0') {
-			fprintf(stderr, "Pattern must not be empty.\n");
+			fprintf_pref(stderr, "Pattern must not be empty.\n");
 			i++;
 			continue;
 		}

--- a/src/install.c
+++ b/src/install.c
@@ -243,7 +243,7 @@ exec_install(int argc, char **argv)
 			retcode = pkg_jobs_apply(jobs);
 			done = 1;
 			if (retcode == EPKG_CONFLICT) {
-				printf("Conflicts with the existing packages "
+				printf_pref("Conflicts with the existing packages "
 				    "have been found.\nOne more solver "
 				    "iteration is needed to resolve them.\n");
 				continue;
@@ -260,7 +260,7 @@ exec_install(int argc, char **argv)
 	}
 
 	if (done == 0 && rc)
-		printf("The most recent version of packages are already installed\n");
+		printf_pref("The most recent version of packages are already installed\n");
 
 	retcode = EX_OK;
 

--- a/src/lock.c
+++ b/src/lock.c
@@ -160,7 +160,7 @@ list_locked(struct pkgdb *db, bool has_locked)
 	}
 
 	if (!quiet && !has_locked)
-		printf("Currently locked packages:\n");
+		printf_pref("Currently locked packages:\n");
 
 	while (pkgdb_it_next(it, &pkg, PKG_LOAD_BASIC) == EPKG_OK) {
 		gotone = true;

--- a/src/main.c
+++ b/src/main.c
@@ -780,19 +780,19 @@ main(int argc, char **argv)
 
 	if (argc >= 1 && strcmp(argv[0], "bootstrap") == 0) {
 		if (argc == 1) {
-			printf("pkg(8) already installed, use -f to force.\n");
+			printf_pref("pkg(8) already installed, use -f to force.\n");
 			exit(EXIT_SUCCESS);
 		} else if (argc == 2 && strcmp(argv[1], "-f") == 0) {
 			if (access("/usr/sbin/pkg", R_OK) == 0) {
 				/* Only 10.0+ supported 'bootstrap -f' */
 #if __FreeBSD_version < 1000502
-				printf("Execute these steps to rebootstrap"
+				printf_pref("Execute these steps to rebootstrap"
 				     " pkg(8):\n");
-				printf("# pkg delete -f pkg\n");
-				printf("# /usr/sbin/pkg -v\n");
+				printf_pref("# pkg delete -f pkg\n");
+				printf_pref("# /usr/sbin/pkg -v\n");
 				exit(EXIT_SUCCESS);
 #endif
-				printf("pkg(8) is already installed. Forcing "
+				printf_pref("pkg(8) is already installed. Forcing "
 				    "reinstallation through pkg(7).\n");
 				execl("/usr/sbin/pkg", "pkg", "bootstrap",
 				    "-f", NULL);

--- a/src/pkgcli.h
+++ b/src/pkgcli.h
@@ -28,6 +28,7 @@
 #ifndef _PKGCLI_H
 #define _PKGCLI_H
 
+#include <stdarg.h>
 #include <stdint.h>
 #include <bsd_compat.h>
 
@@ -277,6 +278,12 @@ void progressbar_tick(int64_t current, int64_t total);
 void progressbar_stop(void);
 
 void sbuf_flush(struct sbuf *buf);
+
+int printf_pref(const char *format, ...);
+int fprintf_pref(FILE *f, const char *format, ...);
+int vfprintf_pref(FILE *f, const char *format, va_list args);
+int sbuf_printf_pref(struct sbuf *s, const char *format, ...);
+int sbuf_vprintf_pref(struct sbuf *s, const char *format, va_list args);
 
 extern struct sbuf *messages;
 

--- a/src/query.c
+++ b/src/query.c
@@ -341,86 +341,86 @@ print_query(struct pkg *pkg, char *qstr, char multiline)
 	case 'd':
 		while (pkg_deps(pkg, &dep) == EPKG_OK) {
 			format_str(pkg, output, qstr, dep);
-			printf("%s\n", sbuf_data(output));
+			printf_pref("%s\n", sbuf_data(output));
 		}
 		break;
 	case 'r':
 		while (pkg_rdeps(pkg, &dep) == EPKG_OK) {
 			format_str(pkg, output, qstr, dep);
-			printf("%s\n", sbuf_data(output));
+			printf_pref("%s\n", sbuf_data(output));
 		}
 		break;
 	case 'C':
 		buf = NULL;
 		while (pkg_categories(pkg, &buf) == EPKG_OK) {
 			format_str(pkg, output, qstr, buf);
-			printf("%s\n", sbuf_data(output));
+			printf_pref("%s\n", sbuf_data(output));
 		}
 		break;
 	case 'O':
 		while (pkg_options(pkg, &option) == EPKG_OK) {
 			format_str(pkg, output, qstr, option);
-			printf("%s\n", sbuf_data(output));
+			printf_pref("%s\n", sbuf_data(output));
 		}
 		break;
 	case 'F':
 		while (pkg_files(pkg, &file) == EPKG_OK) {
 			format_str(pkg, output, qstr, file);
-			printf("%s\n", sbuf_data(output));
+			printf_pref("%s\n", sbuf_data(output));
 		}
 		break;
 	case 'D':
 		while (pkg_dirs(pkg, &dir) == EPKG_OK) {
 			format_str(pkg, output, qstr, dir);
-			printf("%s\n", sbuf_data(output));
+			printf_pref("%s\n", sbuf_data(output));
 		}
 		break;
 	case 'L':
 		buf = NULL;
 		while (pkg_licenses(pkg, &buf) == EPKG_OK) {
 			format_str(pkg, output, qstr, buf);
-			printf("%s\n", sbuf_data(output));
+			printf_pref("%s\n", sbuf_data(output));
 		}
 		break;
 	case 'U':
 		buf = NULL;
 		while (pkg_users(pkg, &buf) == EPKG_OK) {
 			format_str(pkg, output, qstr, buf);
-			printf("%s\n", sbuf_data(output));
+			printf_pref("%s\n", sbuf_data(output));
 		}
 		break;
 	case 'G':
 		buf = NULL;
 		while (pkg_groups(pkg, &buf) == EPKG_OK) {
 			format_str(pkg, output, qstr, buf);
-			printf("%s\n", sbuf_data(output));
+			printf_pref("%s\n", sbuf_data(output));
 		}
 		break;
 	case 'B':
 		buf = NULL;
 		while (pkg_shlibs_required(pkg, &buf) == EPKG_OK) {
 			format_str(pkg, output, qstr, buf);
-			printf("%s\n", sbuf_data(output));
+			printf_pref("%s\n", sbuf_data(output));
 		}
 		break;
 	case 'b':
 		buf = NULL;
 		while (pkg_shlibs_provided(pkg, &buf) == EPKG_OK) {
 			format_str(pkg, output, qstr, buf);
-			printf("%s\n", sbuf_data(output));
+			printf_pref("%s\n", sbuf_data(output));
 		}
 		break;
 	case 'A':
 		pkg_get(pkg, PKG_ANNOTATIONS, &kv);
 		while (kv != NULL) {
 			format_str(pkg, output, qstr, kv);
-			printf("%s\n", sbuf_data(output));
+			printf_pref("%s\n", sbuf_data(output));
 			kv = kv->next;
 		}
 		break;
 	default:
 		format_str(pkg, output, qstr, dep);
-		printf("%s\n", sbuf_data(output));
+		printf_pref("%s\n", sbuf_data(output));
 		break;
 	}
 	sbuf_delete(output);
@@ -568,7 +568,7 @@ format_sql_condition(const char *str, struct sbuf *sqlcond, bool for_remote)
 					break;
 				default:
 bad_option:
-					fprintf(stderr, "malformed evaluation string\n");
+					fprintf_pref(stderr, "malformed evaluation string\n");
 					return (EPKG_FATAL);
 				}
 			} else {
@@ -581,7 +581,7 @@ bad_option:
 				case '\t':
 					break;
 				default:
-					fprintf(stderr, "unexpected character: %c\n", str[0]);
+					fprintf_pref(stderr, "unexpected character: %c\n", str[0]);
 					return (EPKG_FATAL);
 				}
 			}
@@ -589,7 +589,7 @@ bad_option:
 			switch (str[0]) {
 			case ')':
 				if (bracket_level == 0) {
-					fprintf(stderr, "too many closing brackets.\n");
+					fprintf_pref(stderr, "too many closing brackets.\n");
 					return (EPKG_FATAL);
 				}
 				bracket_level--;
@@ -605,7 +605,7 @@ bad_option:
 					sbuf_cat(sqlcond, " OR ");
 					break;
 				} else {
-					fprintf(stderr, "unexpected character %c\n", str[1]);
+					fprintf_pref(stderr, "unexpected character %c\n", str[1]);
 					return (EPKG_FATAL);
 				}
 			case '&':
@@ -615,11 +615,11 @@ bad_option:
 					sbuf_cat(sqlcond, " AND ");
 					break;
 				} else {
-					fprintf(stderr, "unexpected character %c\n", str[1]);
+					fprintf_pref(stderr, "unexpected character %c\n", str[1]);
 					return (EPKG_FATAL);
 				}
 			default:
-				fprintf(stderr, "unexpected character %c\n", str[0]);
+				fprintf_pref(stderr, "unexpected character %c\n", str[0]);
 				return (EPKG_FATAL);
 			}
 		} else if (state == OPERATOR_STRING || state == OPERATOR_INT) {
@@ -628,14 +628,14 @@ bad_option:
 				/* do nothing */
 			} else if (str[0] == '~' ) {
 				if (state != OPERATOR_STRING) {
-					fprintf(stderr, "~ expected only for string testing\n");
+					fprintf_pref(stderr, "~ expected only for string testing\n");
 					return (EPKG_FATAL);
 				}
 				state = NEXT_IS_STRING;
 				sbuf_cat(sqlcond, " GLOB ");
 			} else if (str[0] == '>' || str[0] == '<') {
 				if (state != OPERATOR_INT) {
-					fprintf(stderr, "> expected only for integers\n");
+					fprintf_pref(stderr, "> expected only for integers\n");
 					return (EPKG_FATAL);
 				}
 				state = NEXT_IS_INT;
@@ -657,7 +657,7 @@ bad_option:
 				}
 			} else if (str[0] == '!') {
 				if (str[1] != '=') {
-					fprintf(stderr, "expecting = after !\n");
+					fprintf_pref(stderr, "expecting = after !\n");
 					return (EPKG_FATAL);
 				}
 				if (state == OPERATOR_STRING) {
@@ -669,7 +669,7 @@ bad_option:
 				str++;
 				sbuf_putc(sqlcond, str[0]);
 			} else {
-				fprintf(stderr, "an operator is expected, got %c\n", str[0]);
+				fprintf_pref(stderr, "an operator is expected, got %c\n", str[0]);
 				return (EPKG_FATAL);
 			}
 		} else if (state == NEXT_IS_STRING || state == NEXT_IS_INT) {
@@ -688,7 +688,7 @@ bad_option:
 					sbuf_putc(sqlcond, '\'');
 				} else {
 					if (!isdigit(str[0])) {
-						fprintf(stderr, "a number is expected, got: %c\n", str[0]);
+						fprintf_pref(stderr, "a number is expected, got: %c\n", str[0]);
 						return (EPKG_FATAL);
 					}
 					state = INT;
@@ -724,10 +724,10 @@ bad_option:
 	}
 
 	if (state != POST_EXPR && state != INT) {
-		fprintf(stderr, "unexpected end of expression\n");
+		fprintf_pref(stderr, "unexpected end of expression\n");
 		return (EPKG_FATAL);
 	} else if (bracket_level > 0) {
-		fprintf(stderr, "unexpected end of expression (too many open brackets)\n");
+		fprintf_pref(stderr, "unexpected end of expression (too many open brackets)\n");
 		return (EPKG_FATAL);
 	}
 
@@ -744,7 +744,7 @@ analyse_query_string(char *qstr, struct query_flags *q_flags, const unsigned int
 	j = 0; /* shut up scanbuild */
 
 	if (strchr(qstr, '%') == NULL) {
-		fprintf(stderr, "Invalid query: query should contain a format string\n");
+		fprintf_pref(stderr, "Invalid query: query should contain a format string\n");
 		return (EPKG_FATAL);
 	}
 
@@ -771,10 +771,10 @@ analyse_query_string(char *qstr, struct query_flags *q_flags, const unsigned int
 						}
 
 						if (valid_opts == 0) {
-							fprintf(stderr, "Invalid query: '%%%c' should be followed by:", q_flags[i].flag);
+							fprintf_pref(stderr, "Invalid query: '%%%c' should be followed by:", q_flags[i].flag);
 
 							for (j = 0; j < strlen(q_flags[i].options); j++)
-								fprintf(stderr, " %c%c", q_flags[i].options[j],
+								fprintf_pref(stderr, " %c%c", q_flags[i].options[j],
 										q_flags[i].options[j + 1] == '\0' ?
 										'\n' : ',');
 
@@ -785,7 +785,7 @@ analyse_query_string(char *qstr, struct query_flags *q_flags, const unsigned int
 					/* if this is a multiline flag */
 					if (q_flags[i].multiline == 1) {
 						if (*multiline != 0 && *multiline != q_flags[i].flag) {
-							fprintf(stderr, "Invalid query: '%%%c' and '%%%c' cannot be queried at the same time\n",
+							fprintf_pref(stderr, "Invalid query: '%%%c' and '%%%c' cannot be queried at the same time\n",
 									*multiline, q_flags[i].flag);
 							return (EPKG_FATAL);
 						} else {
@@ -809,7 +809,7 @@ analyse_query_string(char *qstr, struct query_flags *q_flags, const unsigned int
 			}
 
 			if (valid_flag == 0) {
-				fprintf(stderr, "Unknown query format key: '%%%c'\n", qstr[0]);
+				fprintf_pref(stderr, "Unknown query format key: '%%%c'\n", qstr[0]);
 				return (EPKG_FATAL);
 			}
 		}

--- a/src/register.c
+++ b/src/register.c
@@ -334,7 +334,7 @@ exec_register(int argc, char **argv)
 
 	if (!legacy && retcode == EPKG_OK && messages != NULL) {
 		sbuf_finish(messages);
-		printf("%s\n", sbuf_data(messages));
+		printf_pref("%s\n", sbuf_data(messages));
 	}
 
 	pkg_free(pkg);

--- a/src/repo.c
+++ b/src/repo.c
@@ -148,7 +148,7 @@ exec_repo(int argc, char **argv)
 	ret = pkg_create_repo(argv[0], output_dir, filelist, meta_file, legacy);
 
 	if (ret != EPKG_OK) {
-		printf("Cannot create repository catalogue\n");
+		printf_pref("Cannot create repository catalogue\n");
 		return (EX_IOERR);
 	}
 

--- a/src/search.c
+++ b/src/search.c
@@ -370,7 +370,7 @@ exec_search(int argc, char **argv)
 
 	pattern = argv[0];
 	if (pattern[0] == '\0') {
-		fprintf(stderr, "Pattern must not be empty.\n");
+		fprintf_pref(stderr, "Pattern must not be empty.\n");
 		return (EX_USAGE);
 	}
 	if (search == FIELD_NONE) {

--- a/src/shlib.c
+++ b/src/shlib.c
@@ -84,7 +84,7 @@ pkgs_providing_lib(struct pkgdb *db, const char *libname)
 
 	while ((ret = pkgdb_it_next(it, &pkg, PKG_LOAD_BASIC)) == EPKG_OK) {
 		if (count == 0 && !quiet)
-			printf("%s is provided by the following packages:\n",
+			printf_pref("%s is provided by the following packages:\n",
 			       libname);
 		count++;
 		pkg_printf("%n-%v\n", pkg, pkg);
@@ -92,7 +92,7 @@ pkgs_providing_lib(struct pkgdb *db, const char *libname)
 
 	if (ret == EPKG_END) {
 		if (count == 0 && !quiet)
-			printf("No packages provide %s.\n", libname);
+			printf_pref("No packages provide %s.\n", libname);
 		ret = EPKG_OK;
 	}
 
@@ -116,7 +116,7 @@ pkgs_requiring_lib(struct pkgdb *db, const char *libname)
 
 	while ((ret = pkgdb_it_next(it, &pkg, PKG_LOAD_BASIC)) == EPKG_OK) {
 		if (count == 0 && !quiet)
-			printf("%s is linked to by the following packages:\n",
+			printf_pref("%s is linked to by the following packages:\n",
 			       libname);
 		count++;
 		pkg_printf("%n-%v\n", pkg, pkg);
@@ -124,7 +124,7 @@ pkgs_requiring_lib(struct pkgdb *db, const char *libname)
 
 	if (ret == EPKG_END) {
 		if (count == 0 && !quiet)
-			printf("No packages require %s.\n", libname);
+			printf_pref("No packages require %s.\n", libname);
 		ret = EPKG_OK;
 	}
 

--- a/src/stats.c
+++ b/src/stats.c
@@ -107,34 +107,34 @@ exec_stats(int argc, char **argv)
 	}
 
 	if (opt & STATS_LOCAL) {
-		printf("Local package database:\n");
-		printf("\tInstalled packages: %" PRId64 "\n", pkgdb_stats(db, PKG_STATS_LOCAL_COUNT));
+		printf_pref("Local package database:\n");
+		printf_pref("\tInstalled packages: %" PRId64 "\n", pkgdb_stats(db, PKG_STATS_LOCAL_COUNT));
 
 		flatsize = pkgdb_stats(db, PKG_STATS_LOCAL_SIZE);
 
 		if (show_bytes)
-			printf("\tDisk space occupied: %" PRId64 "\n\n", flatsize);
+			printf_pref("\tDisk space occupied: %" PRId64 "\n\n", flatsize);
 		else {
 			humanize_number(size, sizeof(size), flatsize, "B",
 			    HN_AUTOSCALE, HN_IEC_PREFIXES);
-			printf("\tDisk space occupied: %s\n\n", size);
+			printf_pref("\tDisk space occupied: %s\n\n", size);
 		}
 	}
 
 	if ((opt & STATS_REMOTE) && pkg_repos_total_count() > 0) {
-		printf("Remote package database(s):\n");
-		printf("\tNumber of repositories: %" PRId64 "\n", pkgdb_stats(db, PKG_STATS_REMOTE_REPOS));
-		printf("\tPackages available: %" PRId64 "\n", pkgdb_stats(db, PKG_STATS_REMOTE_COUNT));
-		printf("\tUnique packages: %" PRId64 "\n", pkgdb_stats(db, PKG_STATS_REMOTE_UNIQUE));
+		printf_pref("Remote package database(s):\n");
+		printf_pref("\tNumber of repositories: %" PRId64 "\n", pkgdb_stats(db, PKG_STATS_REMOTE_REPOS));
+		printf_pref("\tPackages available: %" PRId64 "\n", pkgdb_stats(db, PKG_STATS_REMOTE_COUNT));
+		printf_pref("\tUnique packages: %" PRId64 "\n", pkgdb_stats(db, PKG_STATS_REMOTE_UNIQUE));
 
 		flatsize = pkgdb_stats(db, PKG_STATS_REMOTE_SIZE);
 
 		if (show_bytes)
-			printf("\tTotal size of packages: %" PRId64 "\n", flatsize);
+			printf_pref("\tTotal size of packages: %" PRId64 "\n", flatsize);
 		else {
 			humanize_number(size, sizeof(size), flatsize, "B",
 			    HN_AUTOSCALE, HN_IEC_PREFIXES);
-			printf("\tTotal size of packages: %s\n", size);
+			printf_pref("\tTotal size of packages: %s\n", size);
 		}
 	}
 

--- a/src/update.c
+++ b/src/update.c
@@ -57,7 +57,7 @@ pkgcli_update(bool force, bool strict, const char *reponame)
 		return (EPKG_OK);
 
 	if (pkg_repos_total_count() == 0) {
-		fprintf(stderr, "No active remote repositories configured.\n");
+		fprintf_pref(stderr, "No active remote repositories configured.\n");
 		return (EPKG_FATAL);
 	}
 
@@ -71,12 +71,12 @@ pkgcli_update(bool force, bool strict, const char *reponame)
 		}
 
 		if (!quiet)
-			printf("Updating %s repository catalogue...\n",
+			printf_pref("Updating %s repository catalogue...\n",
 			    pkg_repo_name(r));
 		retcode = pkg_update(r, force);
 		if (retcode == EPKG_UPTODATE) {
 			if (!quiet)
-				printf("%s repository is up-to-date.\n",
+				printf_pref("%s repository is up-to-date.\n",
 				    pkg_repo_name(r));
 		}
 		else if (retcode != EPKG_OK && strict)
@@ -94,13 +94,13 @@ pkgcli_update(bool force, bool strict, const char *reponame)
 
 	if (total_count == 0) {
 		if (!quiet)
-			printf("No repositories are enabled.\n");
+			printf_pref("No repositories are enabled.\n");
 		retcode = EPKG_FATAL;
 	}
 	else if (update_count == 0) {
 		if (!quiet)
 			if (retcode == EPKG_OK)
-				printf("All repositories are up-to-date.\n");
+				printf_pref("All repositories are up-to-date.\n");
 	}
 
 	return (retcode);

--- a/src/utils.c
+++ b/src/utils.c
@@ -944,3 +944,78 @@ sbuf_flush(struct sbuf *buf)
 	printf("%s", sbuf_data(buf));
 	sbuf_clear(buf);
 }
+
+int
+printf_pref(const char *format, ...)
+{
+	va_list args;
+	int ret;
+
+	va_start(args, format);
+	ret = vfprintf_pref(stdout, format, args);
+	va_end(args);
+
+	return (ret);
+}
+
+int
+fprintf_pref(FILE *f, const char *format, ...)
+{
+	va_list args;
+	int ret;
+
+	va_start(args, format);
+	ret = vfprintf_pref(f, format, args);
+	va_end(args);
+
+	return (ret);
+}
+
+int
+vfprintf_pref(FILE *f, const char *format, va_list args)
+{
+	int ret = 0;
+	int adder;
+
+	if (! pkg_is_jailed())
+		return vfprintf(f, format, args);
+
+	if ((ret = fprintf(f, "[%s] ", pkg_get_jailname())) == -1)
+		return ret;
+
+	if ((adder = vfprintf(f, format, args)) == -1)
+		return adder;
+
+	return (ret + adder);
+}
+
+int
+sbuf_printf_pref(struct sbuf *s, const char *format, ...)
+{
+	int ret;
+	va_list args;
+
+	va_start(args, format);
+	ret = sbuf_vprintf_pref(s, format, args);
+	va_end(args);
+
+	return ret;
+}
+
+int
+sbuf_vprintf_pref(struct sbuf *s, const char *format, va_list args)
+{
+	int ret = 0;
+	int adder;
+
+	if (! pkg_is_jailed())
+		return sbuf_vprintf(s, format, args);
+
+	if ((ret = sbuf_printf(s, "[%s] ", pkg_get_jailname())) == -1)
+		return -1;
+
+	if ((adder = sbuf_vprintf(s, format, args)) == -1)
+		return -1;
+
+	return (ret + adder);
+}

--- a/src/which.c
+++ b/src/which.c
@@ -132,7 +132,7 @@ exec_which(int argc, char **argv)
 
 	if (search_s) {
 		if ((path = getenv("PATH")) == NULL) {
-			printf("$PATH is not set, falling back to non-search behaviour\n");
+			printf_pref("$PATH is not set, falling back to non-search behaviour\n");
 			search_s = false;
 		} else {
 			pathlen = strlen(path) + 1;
@@ -168,7 +168,7 @@ exec_which(int argc, char **argv)
 						break;
 
 					if (res == (EX_USAGE)) {
-						printf("%s was not found in PATH, falling back to non-search behaviour\n", argv[0]);
+						printf_pref("%s was not found in PATH, falling back to non-search behaviour\n", argv[0]);
 						search = false;
 					} else if (res == (EX_OSERR)) {
 						retcode = EX_OSERR;
@@ -217,7 +217,7 @@ exec_which(int argc, char **argv)
 					pkg_printf("%S was installed by package %n-%v\n", kv_A(patterns, i), pkg, pkg);
 			}
 			if (retcode != EX_OK && !quiet)
-				printf("%s was not found in the database\n", kv_A(patterns, i));
+				printf_pref("%s was not found in the database\n", kv_A(patterns, i));
 
 			pkg_free(pkg);
 			pkgdb_it_free(it);


### PR DESCRIPTION
Occasionally, output from `pkg -j $jailname <action>` would include the name of the jail before the actual line of output. This was super useful when performing many `pkg` commands on many different jails.

However, prefixing the jailname was very infrequent. This patch provides some convenience functions for prefixed print statements, as well as prefixes many of the printf statements used throughout `pkg`. I've been running this for awhile, and it's been a huge improvement for me.
