### PR TITLE
List FreeBSD as one of the systems fully supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ pkg - a binary package manager for FreeBSD
 
 Known to fully work on (official package manager):
 
+- FreeBSD
 - DragonflyBSD
 
 Known to work on (has been ported to):


### PR DESCRIPTION
When scanning the README, in case one is unaware that pkg is a FreeBSD project, it's easy to miss FreeBSD in the URL of the GitHub repository and in the title of this document and to then think that pkg is not supported on FreeBSD.