### PR TITLE
Set the v flag for libfetch at the highest debug levels

### DIFF
--- a/libpkg/fetch.c
+++ b/libpkg/fetch.c
@@ -572,6 +572,9 @@ pkg_fetch_file_to_fd(struct pkg_repo *repo, const char *url, int dest,
 				sbuf_cat(fetchOpts, "6");
 		}
 
+        if (debug_level >= 4)
+            sbuf_cat(fetchOpts, "v");
+
 		pkg_debug(1,"Fetch: fetching from: %s://%s%s%s%s with opts \"%s\"",
 		    u->scheme,
 		    u->user,


### PR DESCRIPTION
In libfetch, the FTP and HTTP schemes accept an (undocumented) "v" flag to enable verbose output during processing. This patch enables that flag when the pkg debug level is set to 4 or greater.