### PR TITLE
Test for /etc/ssl/cert.pem existence to avoid masking SSL_CA_CERT_PATH

### DIFF
--- a/external/libfetch/common.c
+++ b/external/libfetch/common.c
@@ -715,7 +715,8 @@ fetch_ssl_setup_peer_verification(SSL_CTX *ctx, int verbose)
 		if (ca_cert_file == NULL &&
 		    access(LOCAL_CERT_FILE, R_OK) == 0)
 			ca_cert_file = LOCAL_CERT_FILE;
-		if (ca_cert_file == NULL)
+		if (ca_cert_file == NULL &&
+		    access(BASE_CERT_FILE, R_OK) == 0)
 			ca_cert_file = BASE_CERT_FILE;
 		ca_cert_path = getenv("SSL_CA_CERT_PATH");
 		if (verbose) {
@@ -726,11 +727,17 @@ fetch_ssl_setup_peer_verification(SSL_CTX *ctx, int verbose)
 			if (ca_cert_path != NULL)
 				fetch_info("Using CA cert path: %s",
 				    ca_cert_path);
+			if (ca_cert_file == NULL && ca_cert_path == NULL)
+				fetch_info("Using OpenSSL default "
+				    "CA cert file and path");
 		}
 		SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER,
 		    fetch_ssl_cb_verify_crt);
-		SSL_CTX_load_verify_locations(ctx, ca_cert_file,
-		    ca_cert_path);
+		if (ca_cert_file != NULL || ca_cert_path != NULL)
+			SSL_CTX_load_verify_locations(ctx, ca_cert_file,
+			    ca_cert_path);
+		else
+			SSL_CTX_set_default_verify_paths(ctx);
 		if ((crl_file = getenv("SSL_CRL_FILE")) != NULL) {
 			if (verbose)
 				fetch_info("Using CRL file: %s", crl_file);


### PR DESCRIPTION
Prior to this patch, unless `SSL_CA_CERT_FILE` is set in the environment, libfetch will set the CA file to "/usr/local/etc/cert.pem" if it exists, and to "/etc/ssl/cert.pem" otherwise. This has the consequence of masking `SSL_CA_CERT_PATH`, because OpenSSL will ignore the CA path if a CA file is set but fails to load (see `X509_STORE_load_locations()`).

While here, fall back to OpenSSL defaults if neither `SSL_CA_CERT_FILE` nor `SSL_CA_CERT_PATH` are set in the environment, and if neither of the libfetch default CA files exists.

This patch is also submitted upstream against [PR 193871](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=193871) as [review D4771](https://reviews.freebsd.org/D4771).