### PR TITLE
Fix segfault when HTTP_USER_AGENT is empty

### DIFF
--- a/libpkg/pkg_config.c
+++ b/libpkg/pkg_config.c
@@ -1107,7 +1107,8 @@ pkg_ini(const char *path, const char *reposdir, pkg_init_flags flags)
 
 	/* Set user-agent */
 	useragent = pkg_object_string(pkg_config_get("HTTP_USER_AGENT"));
-	setenv("HTTP_USER_AGENT", useragent, 1);
+	if (useragent != NULL)
+		setenv("HTTP_USER_AGENT", useragent, 1);
 
 	/* load the repositories */
 	load_repositories(reposdir, flags);

--- a/libpkg/pkg_config.c
+++ b/libpkg/pkg_config.c
@@ -1109,6 +1109,8 @@ pkg_ini(const char *path, const char *reposdir, pkg_init_flags flags)
 	useragent = pkg_object_string(pkg_config_get("HTTP_USER_AGENT"));
 	if (useragent != NULL)
 		setenv("HTTP_USER_AGENT", useragent, 1);
+	else
+		setenv("HTTTP_USER_AGENT", "pkg/"PKGVERSION, 1);
 
 	/* load the repositories */
 	load_repositories(reposdir, flags);

--- a/libpkg/pkg_config.c
+++ b/libpkg/pkg_config.c
@@ -1110,7 +1110,7 @@ pkg_ini(const char *path, const char *reposdir, pkg_init_flags flags)
 	if (useragent != NULL)
 		setenv("HTTP_USER_AGENT", useragent, 1);
 	else
-		setenv("HTTTP_USER_AGENT", "pkg/"PKGVERSION, 1);
+		setenv("HTTP_USER_AGENT", "pkg/"PKGVERSION, 1);
 
 	/* load the repositories */
 	load_repositories(reposdir, flags);


### PR DESCRIPTION
See https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=206003

Problem is reproducible by e.g. running `env HTTP_USER_AGENT="" pkg upgrade`

Backtrace:
```
#0  0x000000080275a4db in strlen () from /lib/libc.so.7
#1  0x00000008027576c4 in setenv () from /lib/libc.so.7
#2  0x0000000800a3840d in pkg_ini (path=0x800c149c2 "/usr/local/etc/pkg.conf", 
    reposdir=0x0, flags=0) at pkg_config.c:1110
#3  0x0000000000413f9f in main (argc=2, argv=0x7fffffffe6b8) at main.c:732
```