### PR TITLE
Remove all mention of +MTREE_DIRS.

### DIFF
--- a/docs/GOALS
+++ b/docs/GOALS
@@ -82,8 +82,7 @@ Table of Contents:
 
 	- Will delete a package. To be able to remove the empty directories
 	  cleanly it will delete every directory (found in the path of the 
-	  files), which are not in the package +MTREE (mtree contains the 
-	  official hier(7)).
+	  files), which are not in the package's manifest.
 
 - upgrade:
 

--- a/docs/pkg-create.8
+++ b/docs/pkg-create.8
@@ -163,17 +163,9 @@ displayed on package installation,
 .Pa +DISPLAY .
 Another containing the description for the package,
 .Pa +DESC .
-The last containing an mtree specification,
-.Pa +MTREE_DIRS ,
-for the directory tree the package will use.
-See
-.Xr mtree 5
-for the format of the mtree file.
 If specified, only a single package will be created.
 .Pa +DISPLAY
-,
-.Pa +MTREE_DIRS
-, and
+and
 .Pa +DESC
 are not required; the
 .Pa +MANIFEST

--- a/docs/pkg-register.8
+++ b/docs/pkg-register.8
@@ -71,10 +71,9 @@ but the more usual approach is to provide selected items via the
 manifest, and fill in the rest, either from legacy files such as
 .Fa pkg-plist ,
 .Fa +DESC,
-.Fa +DISPLAY,
-.Fa +MESSAGE
+.Fa +DISPLAY
 or
-.Fa +MTREE_DIRS
+.Fa +MESSAGE
 which are optional and mostly located in the
 .Ar metadatadir
 given as the argument to the


### PR DESCRIPTION
pkg has not supported `+MTREE_DIRS` at all for almost a year, but the documentation still mentions it.  This led me astray, so here's an update.
