### PR TITLE
Replace "configname" with "name"

### DIFF
--- a/docs/pkg-config.8
+++ b/docs/pkg-config.8
@@ -14,7 +14,7 @@
 .\"
 .\"     @(#)pkg.8
 .\"
-.Dd November 29, 2013
+.Dd January 26, 2016
 .Dt PKG-CONFIG 8
 .Os
 .Sh NAME
@@ -22,7 +22,7 @@
 .Nd retrieve the value of a given configuration option
 .Sh SYNOPSIS
 .Nm
-.Ar configname
+.Ar name
 .Sh DESCRIPTION
 .Nm
 retrieve the value of a given configuration option.

--- a/src/config.c
+++ b/src/config.c
@@ -38,7 +38,7 @@ void
 usage_config(void)
 {
 	fprintf(stderr,
-            "Usage: pkg config <configname>\n\n");
+            "Usage: pkg config <name>\n\n");
 	//fprintf(stderr, "For more information see 'pkg help config'.\n");
 }
 


### PR DESCRIPTION
Compare to "git config" (git help config); Other places where simply "name" is used would be sysctl(8), sysrc(8), and similar key/value fetching interfaces.