### PR TITLE
compat: fix fstatat probing

### DIFF
--- a/compat/bsd_compat.h
+++ b/compat/bsd_compat.h
@@ -99,7 +99,7 @@ void closefrom(int lowfd);
 int faccessat(int fd, const char *path, int mode, int flag);
 #endif
 
-#if !HAVE_FSTATAT
+#if !HAVE_DECL_FSTATAT
 int fstatat(int fd, const char *path, struct stat *buf, int flag);
 #endif
 


### PR DESCRIPTION
When building a bsd_compat-enabled version of pkg on FreeBSD 10.2, fstatat() is not properly declared and linking fails.