### PR TITLE
libpkg/pkg_jobs.c: fix `fetch -a` nullpointer

### DIFF
--- a/libpkg/pkg_jobs.c
+++ b/libpkg/pkg_jobs.c
@@ -922,9 +922,10 @@ pkg_jobs_find_upgrade(struct pkg_jobs *j, const char *pattern, match_t m)
 		rc = EPKG_FATAL;
 
 	while (it != NULL && pkgdb_it_next(it, &p, flags) == EPKG_OK) {
-		if (pattern != NULL)
+		if (pattern != NULL) {
 			rc = pkg_jobs_process_remote_pkg(j, p, NULL,
 			    strcmp(p->name, pattern));
+		}
 		else if (m == MATCH_ALL)
 			rc = pkg_jobs_process_remote_pkg(j, p, NULL, 0);
 		else

--- a/libpkg/pkg_jobs.c
+++ b/libpkg/pkg_jobs.c
@@ -922,8 +922,14 @@ pkg_jobs_find_upgrade(struct pkg_jobs *j, const char *pattern, match_t m)
 		rc = EPKG_FATAL;
 
 	while (it != NULL && pkgdb_it_next(it, &p, flags) == EPKG_OK) {
-		rc = pkg_jobs_process_remote_pkg(j, p, NULL,
-		    strcmp(p->name, pattern));
+		if (pattern != NULL)
+			rc = pkg_jobs_process_remote_pkg(j, p, NULL,
+			    strcmp(p->name, pattern));
+		else if (m == MATCH_ALL)
+			rc = pkg_jobs_process_remote_pkg(j, p, NULL, 0);
+		else
+			break;
+
 		if (rc == EPKG_FATAL)
 			break;
 		else if (rc == EPKG_OK)


### PR DESCRIPTION
* `pkg fetch -r <repo> -a` does not contain a pattern
* this makes strcmp fail with a nullponter exception
* instead, check if m == MATCH-ALL and if so, call with 0.