### PR TITLE
Make libxml part of 'pkg audit' to be done as non-root (user nobody) `ticket #1460`

### DIFF
--- a/libpkg/pkg_audit.c
+++ b/libpkg/pkg_audit.c
@@ -565,7 +565,8 @@ pkg_audit_parse_vulnxml(struct pkg_audit *audit)
 
 			ret = getpwnam_r("nobody", &pwd, pwd_buf, 512, &res);
 			if (res == NULL) {
-				warnx("%s\n", "Error occurred while finding pw entry for user nobody.");
+				warnx("%s\n", "Error occurred while finding pw entry "
+				    "for user nobody.");
 				errno = ret;
 				exit (-1);
 			}
@@ -577,7 +578,8 @@ pkg_audit_parse_vulnxml(struct pkg_audit *audit)
 				warnx("%s\n", "Could not change euid to nobody.");
 		}
 		parser = XML_ParserCreate(NULL);
-		XML_SetElementHandler(parser, vulnxml_start_element, vulnxml_end_element);
+		XML_SetElementHandler(parser, vulnxml_start_element,
+		    vulnxml_end_element);
 		XML_SetCharacterDataHandler(parser, vulnxml_handle_data);
 		XML_SetUserData(parser, &ud);
 
@@ -586,7 +588,8 @@ pkg_audit_parse_vulnxml(struct pkg_audit *audit)
 		ud.range_num = 0;
 		ud.state = VULNXML_PARSE_INIT;
 
-		if (XML_Parse(parser, audit->map, audit->len, XML_TRUE) == XML_STATUS_ERROR) {
+		if (XML_Parse(parser, audit->map, audit->len, XML_TRUE) ==
+		    XML_STATUS_ERROR) {
 			pkg_emit_error("vulnxml parsing error: %s",
 					XML_ErrorString(XML_GetErrorCode(parser)));
 			ret = EPKG_FATAL;

--- a/libpkg/pkg_audit.c
+++ b/libpkg/pkg_audit.c
@@ -551,7 +551,7 @@ pkg_audit_parse_vulnxml(struct pkg_audit *audit)
 	pid_t pid;
 	struct passwd pwd, *res;
 	char pwd_buf[512];
-	int ret = EPKG_OK;
+	int ret;
 
 	uid = getuid();
 	euid = geteuid();
@@ -574,7 +574,7 @@ pkg_audit_parse_vulnxml(struct pkg_audit *audit)
 				warnx("%s\n", "Error occurred while finding pw entry "
 				    "for user nobody.");
 				errno = ret;
-				_exit (-1);
+				_exit(-1);
 			}
 
 			if (setgid(res->pw_gid) != 0)
@@ -602,9 +602,10 @@ pkg_audit_parse_vulnxml(struct pkg_audit *audit)
 		}
 
 		XML_ParserFree(parser);
-		_exit (ret);
+		_exit(ret);
 		break;
 	default:
+		ret = EPKG_OK;
 		while (waitpid(pid, &ret, 0) == -1 && errno == EINTR)
 			;
 


### PR DESCRIPTION
This patch seems to solve `ticket #1460`.