### PR TITLE
Fix #1220: show warning if pkg-delete pattern doesn't match any package

### DIFF
--- a/libpkg/pkg_jobs.c
+++ b/libpkg/pkg_jobs.c
@@ -1399,6 +1399,10 @@ jobs_solve_deinstall(struct pkg_jobs *j)
 		if ((it = pkgdb_query(j->db, jp->pattern, jp->match)) == NULL)
 			return (EPKG_FATAL);
 
+		if (pkgdb_it_count(it) == 0) {
+			pkg_emit_notice("No packages matched for pattern '%s'\n", jp->pattern);
+		}
+
 		while (pkgdb_it_next(it, &pkg,
 				PKG_LOAD_BASIC|PKG_LOAD_RDEPS|PKG_LOAD_DEPS|PKG_LOAD_ANNOTATIONS) == EPKG_OK) {
 			if(pkg->locked) {


### PR DESCRIPTION
Print warning during pkg-delete if delete pattern doesn't match any packages. It's not an error and pkg continues normally.