### PR TITLE
Fix default path for mandir

### DIFF
--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -35,7 +35,7 @@ dist_man_MANS=	pkg-add.8 \
 		pkg_printf.3 \
 		pkg_repos.3
 
-mandir=	$(prefix)/man
+mandir=	$(datarootdir)/man
 
 EXTRA_DIST=	fix-xrefs
 .PHONY: run-fix-xrefs


### PR DESCRIPTION
According to the GNU Coding Standards, section "7.2.5 Variables for Installation Directories" [1], it should point to $(datarootdir)/man.

This change allows to skip unnecessary --mandir configure reassignment when building pkg with non-default prefix (e.g., /usr).

[1] https://www.gnu.org/prep/standards/html_node/Directory-Variables.html
