### PR TITLE
Align fetching progress bars

### DIFF
--- a/src/event.c
+++ b/src/event.c
@@ -524,7 +524,10 @@ draw_progressbar(int64_t current, int64_t total)
 
 			humanize_number(buf, sizeof(buf),
 			    current,"B", HN_AUTOSCALE, HN_IEC_PREFIXES);
-			printf(" %*s", (int)sizeof(buf), buf);
+			if (current < 1000)
+				printf(" %*s  ", (int)sizeof(buf) - 2, buf);
+			else
+				printf(" %*s", (int)sizeof(buf), buf);
 
 			if (bytes_left > 0)
 				format_rate_SI(buf, sizeof(buf), transferred);
@@ -580,6 +583,7 @@ event_callback(void *data, struct pkg_event *ev)
 	int *debug = data, i;
 	struct pkg_event_conflict *cur_conflict;
 	const char *filename, *reponame;
+	char trunc_filename[42] = { 0 };
 
 	if (msg_buf == NULL) {
 		msg_buf = sbuf_new_auto();
@@ -637,9 +641,12 @@ event_callback(void *data, struct pkg_event *ev)
 			 */
 			filename = ev->e_fetching.url;
 		}
+		strncpy(trunc_filename, filename, 41);
+		if (strnlen(filename,42) > 41)
+			trunc_filename[40] = '*';
 		job_status_begin(msg_buf);
 		progress_debit = true;
-		sbuf_printf(msg_buf, "Fetching %s", filename);
+		sbuf_printf(msg_buf, "%-41s", trunc_filename);
 
 		break;
 	case PKG_EVENT_FETCH_FINISHED:


### PR DESCRIPTION
Most of this patch has been run in DPorts for a year now.  It works well
and subjectively the alignment makes it much easier to absorb the
information as its dynamically updated.

Here's an example of the current behavior:
```
Fetching minecraft-client-1.7.9_4.txz: 100%  259 KiB 265.3kB/s    00:01
Fetching lwjgl-2.9.3.txz: 100%    1 MiB 761.9kB/s    00:02
Fetching jinput-20110801.r247.txz: 100%  191 KiB 195.4kB/s    00:01
Fetching openjdk8-8.102.14_1.txz: 100%   56 MiB   4.0MB/s    00:15
Fetching libXt-1.1.5,1.txz: 100%  450 KiB 460.7kB/s    00:01
Fetching xproto-7.0.28.txz: 100%   58 KiB  59.7kB/s    00:01
Fetching libSM-1.2.2_3,1.txz: 100%   22 KiB  22.8kB/s    00:01
Fetching libICE-1.0.9_1,1.txz: 100%   90 KiB  92.3kB/s    00:01
Fetching libX11-1.6.4,1.txz: 100%    2 MiB   1.7MB/s    00:01
Fetching libXdmcp-1.1.2.txz: 100%   14 KiB  14.1kB/s    00:01
Fetching libxcb-1.11.1.txz: 100%  970 KiB 993.8kB/s    00:01
Fetching libxml2-2.9.4.txz: 100%  797 KiB 816.0kB/s    00:01
Fetching libpthread-stubs-0.3_6.txz: 100%    3 KiB   2.9kB/s    00:01
Fetching libXau-1.0.8_3.txz: 100%   11 KiB  11.3kB/s    00:01
Fetching kbproto-1.0.7.txz: 100%  122 KiB 125.1kB/s    00:01
Fetching libXtst-1.2.3.txz: 100%   19 KiB  19.4kB/s    00:01
Fetching recordproto-1.14.2.txz: 100%    3 KiB   3.2kB/s    00:01
Fetching inputproto-2.3.1.txz: 100%   14 KiB  14.8kB/s    00:01
Fetching libXext-1.3.3_1,1.txz: 100%   90 KiB  92.6kB/s    00:01
Fetching xextproto-7.3.0.txz: 100%   21 KiB  21.9kB/s    00:01
Fetching libXi-1.7.7,1.txz: 100%  117 KiB 120.3kB/s    00:01
Fetching libXfixes-5.0.3.txz: 100%   14 KiB  14.2kB/s    00:01
Fetching fixesproto-5.0.txz: 100%   10 KiB  10.2kB/s    00:01
Fetching giflib-5.1.4.txz: 100%   73 KiB  74.6kB/s    00:01
Fetching java-zoneinfo-2016.g.txz: 100%   71 KiB  73.1kB/s    00:01
Fetching libXrender-0.9.10.txz: 100%   26 KiB  26.9kB/s    00:01
Fetching renderproto-0.11.1.txz: 100%   15 KiB  15.4kB/s    00:01
Fetching freetype2-2.6.3.txz: 100%  478 KiB 489.4kB/s    00:01
Fetching fontconfig-2.12.1,1.txz: 100%  345 KiB 353.5kB/s    00:01
Fetching expat-2.2.0.txz: 100%  100 KiB 102.0kB/s    00:01
Fetching alsa-lib-1.1.2.txz: 100%  413 KiB 422.9kB/s    00:01
Fetching dejavu-2.35.txz: 100%    2 MiB   2.3MB/s    00:01
Fetching mkfontdir-1.0.7.txz: 100%    3 KiB   3.5kB/s    00:01
Fetching mkfontscale-1.1.2.txz: 100%   15 KiB  15.4kB/s    00:01
Fetching libfontenc-1.1.3.txz: 100%   18 KiB  17.9kB/s    00:01
Fetching javavmwrapper-2.5_2.txz: 100%   16 KiB  16.4kB/s    00:01
Fetching jutils-20070610.r26.txz: 100%    8 KiB   8.3kB/s    00:01
Fetching libXcursor-1.1.14_3.txz: 100%   34 KiB  34.7kB/s    00:01
Fetching libXrandr-1.5.1.txz: 100%   29 KiB  29.8kB/s    00:01
Fetching randrproto-1.5.0.txz: 100%   27 KiB  27.9kB/s    00:01
Fetching libXxf86vm-1.1.4_1.txz: 100%   16 KiB  16.8kB/s    00:01
Fetching xf86vidmodeproto-2.3.1.txz: 100%    3 KiB   3.5kB/s    00:01
Fetching openal-soft-1.16.0_4.txz: 100%  258 KiB 263.7kB/s    00:01
```

The following is an example with this patch.  Note that a few origins require more than 41 characters and these are truncated with an asterisk.  This is both visually okay (see below) and functionally okay because the full origin is used after the fetch during the installation.  There's no confusion about matching the name of the fetched package and the installed package.  Therefore having the width dynamic based on the width of the screen isn't necessary in my opinion (the added complexity doesn't really improve much because these ports are rare).

```
Number of packages to be fetched: 207

The process will require 107 MiB more space.
107 MiB to be downloaded.

Proceed with fetching packages? [y/N]: y
xorg-apps-7.7_2.txz                      : 100%    1 KiB   1.2kB/s    00:01
mkfontdir-1.0.7.txz                      : 100%    3 KiB   3.5kB/s    00:01
mkfontscale-1.1.2.txz                    : 100%   15 KiB  15.7kB/s    00:01
xproto-7.0.28.txz                        : 100%   58 KiB  59.7kB/s    00:01
freetype2-2.6.3.txz                      : 100%  503 KiB 514.9kB/s    00:01
libfontenc-1.1.3.txz                     : 100%   19 KiB  19.2kB/s    00:01
x11perf-1.6.0.txz                        : 100%   55 KiB  56.4kB/s    00:01
libXrender-0.9.9.txz                     : 100%   28 KiB  29.1kB/s    00:01
renderproto-0.11.1.txz                   : 100%   15 KiB  15.4kB/s    00:01
libX11-1.6.3,1.txz                       : 100%    2 MiB 566.4kB/s    00:03
libXdmcp-1.1.2.txz                       : 100%   14 KiB  14.4kB/s    00:01
libxcb-1.11.1.txz                        : 100%  979 KiB 501.1kB/s    00:02
libxml2-2.9.4.txz                        : 100%  792 KiB 405.6kB/s    00:02
libpthread-stubs-0.3_6.txz               : 100%    3 KiB   2.9kB/s    00:01
libXau-1.0.8_3.txz                       : 100%   11 KiB  11.6kB/s    00:01
kbproto-1.0.7.txz                        : 100%  122 KiB 125.0kB/s    00:01
libXft-2.3.2_1.txz                       : 100%   61 KiB  62.8kB/s    00:01
fontconfig-2.12.1,1.txz                  : 100%  349 KiB 357.4kB/s    00:01
expat-2.2.0.txz                          : 100%  109 KiB 111.2kB/s    00:01
libXmu-1.1.2_3,1.txz                     : 100%   99 KiB 101.8kB/s    00:01
libXt-1.1.5,1.txz                        : 100%  474 KiB 485.3kB/s    00:01
libSM-1.2.2_3,1.txz                      : 100%   23 KiB  23.6kB/s    00:01
libICE-1.0.9_1,1.txz                     : 100%   94 KiB  96.0kB/s    00:01
libXext-1.3.3_1,1.txz                    : 100%   91 KiB  93.0kB/s    00:01
xextproto-7.3.0.txz                      : 100%   21 KiB  22.0kB/s    00:01
xkbutils-1.0.4.txz                       : 100%   15 KiB  15.8kB/s    00:01
libXaw-1.0.13,2.txz                      : 100%  468 KiB 479.1kB/s    00:01
libXpm-3.5.11_4.txz                      : 100%   65 KiB  66.1kB/s    00:01
gettext-runtime-0.19.8.1.txz             : 100%  145 KiB 148.9kB/s    00:01
indexinfo-0.2.5.txz                      : 100%    5 KiB   4.9kB/s    00:01
printproto-1.0.5.txz                     : 100%   14 KiB  14.2kB/s    00:01
libXp-1.0.3,1.txz                        : 100%   83 KiB  84.7kB/s    00:01
libxkbfile-1.0.9.txz                     : 100%  107 KiB 109.7kB/s    00:01
xcursorgen-1.0.6_1.txz                   : 100%    7 KiB   7.1kB/s    00:01
libXcursor-1.1.14_3.txz                  : 100%   35 KiB  36.0kB/s    00:01
libXfixes-5.0.1_3.txz                    : 100%   14 KiB  14.2kB/s    00:01
fixesproto-5.0.txz                       : 100%   10 KiB  10.2kB/s    00:01
png-1.6.23.txz                           : 100%  273 KiB 280.0kB/s    00:01
xwd-1.0.6.txz                            : 100%   14 KiB  14.7kB/s    00:01
xinit-1.3.4,1.txz                        : 100%   14 KiB  14.4kB/s    00:01
twm-1.0.9.txz                            : 100%   89 KiB  91.1kB/s    00:01
xsetroot-1.1.1.txz                       : 100%    8 KiB   8.4kB/s    00:01
xbitmaps-1.1.1.txz                       : 100%   21 KiB  21.1kB/s    00:01
xsetmode-1.0.0.txz                       : 100%    4 KiB   3.7kB/s    00:01
libXi-1.7.6,1.txz                        : 100%  119 KiB 121.6kB/s    00:01
inputproto-2.3.1.txz                     : 100%   14 KiB  14.8kB/s    00:01
xwud-1.0.4.txz                           : 100%   12 KiB  12.7kB/s    00:01
xmessage-1.0.4.txz                       : 100%   10 KiB  10.1kB/s    00:01
xcmsdb-1.0.5.txz                         : 100%   14 KiB  13.9kB/s    00:01
xdriinfo-1.0.5.txz                       : 100%    4 KiB   4.3kB/s    00:01
libGL-11.2.2.txz                         : 100%  226 KiB 230.9kB/s    00:01
dri2proto-2.8.txz                        : 100%    9 KiB   9.0kB/s    00:01
libXdamage-1.1.4_3.txz                   : 100%    6 KiB   6.5kB/s    00:01
damageproto-1.2.1.txz                    : 100%    5 KiB   5.2kB/s    00:01
libdevq-0.0.2_1.txz                      : 100%    8 KiB   8.1kB/s    00:01
libXxf86vm-1.1.4_1.txz                   : 100%   16 KiB  16.6kB/s    00:01
xf86vidmodeproto-2.3.1.txz               : 100%    3 KiB   3.5kB/s    00:01
libdrm-2.4.66,1.txz                      : 100%  192 KiB 196.3kB/s    00:01
libpciaccess-0.13.4.txz                  : 100%   21 KiB  21.5kB/s    00:01
pciids-20160621.txz                      : 100%  182 KiB 186.6kB/s    00:01
libxshmfence-1.2.txz                     : 100%    6 KiB   5.7kB/s    00:01
libelf-0.8.13_1.txz                      : 100%   57 KiB  57.9kB/s    00:01
libglapi-11.2.2.txz                      : 100%   54 KiB  55.6kB/s    00:01
libXvMC-1.0.9.txz                        : 100%   24 KiB  24.5kB/s    00:01
libXv-1.0.10_3,1.txz                     : 100%   35 KiB  35.5kB/s    00:01
videoproto-2.3.2.txz                     : 100%    7 KiB   6.9kB/s    00:01
xwininfo-1.1.3_1.txz                     : 100%   18 KiB  18.9kB/s    00:01
xmodmap-1.0.9.txz                        : 100%   19 KiB  19.3kB/s    00:01
xgc-1.0.5.txz                            : 100%   26 KiB  26.5kB/s    00:01
xinput-1.6.2.txz                         : 100%   22 KiB  22.2kB/s    00:01
libXinerama-1.1.3_3,1.txz                : 100%    9 KiB   9.6kB/s    00:01
xineramaproto-1.2.1.txz                  : 100%    2 KiB   2.2kB/s    00:01
libXrandr-1.5.0.txz                      : 100%   30 KiB  30.4kB/s    00:01
randrproto-1.5.0.txz                     : 100%   27 KiB  27.9kB/s    00:01
xkill-1.0.4.txz                          : 100%    7 KiB   6.9kB/s    00:01
xcalc-1.0.6_2.txz                        : 100%   19 KiB  19.8kB/s    00:01
font-adobe-100dpi-1.0.3_3.txz            : 100%    6 MiB   1.0MB/s    00:06
font-util-1.3.1.txz                      : 100%   27 KiB  27.2kB/s    00:01
font-alias-1.0.3_3.txz                   : 100%    3 KiB   2.6kB/s    00:01
font-misc-misc-1.1.2_3.txz               : 100%    3 MiB 701.9kB/s    00:05
xf86dga-1.0.3_1.txz                      : 100%    5 KiB   5.3kB/s    00:01
libXxf86dga-1.1.4_3.txz                  : 100%   19 KiB  19.6kB/s    00:01
xf86dgaproto-2.1.txz                     : 100%    4 KiB   4.0kB/s    00:01
setxkbmap-1.3.1.txz                      : 100%   11 KiB  10.8kB/s    00:01
xbacklight-1.2.1_1.txz                   : 100%    6 KiB   6.6kB/s    00:01
xcb-util-0.4.0_1,1.txz                   : 100%   12 KiB  12.4kB/s    00:01
xprop-1.2.2.txz                          : 100%   21 KiB  21.8kB/s    00:01
xclock-1.0.7_1.txz                       : 100%   24 KiB  24.1kB/s    00:01
xkbcomp-1.3.1.txz                        : 100%   77 KiB  78.6kB/s    00:01
xconsole-1.0.6_1.txz                     : 100%    9 KiB   8.9kB/s    00:01
xhost-1.0.7.txz                          : 100%    9 KiB   9.2kB/s    00:01
xauth-1.0.9_1.txz                        : 100%   21 KiB  21.3kB/s    00:01
sessreg-1.1.0.txz                        : 100%    6 KiB   6.2kB/s    00:01
xrefresh-1.0.5.txz                       : 100%    6 KiB   6.2kB/s    00:01
xterm-326.txz                            : 100%  286 KiB 292.9kB/s    00:01
ncurses-6.0_5.txz                        : 100%    1 MiB 636.9kB/s    00:02
xkbevd-1.1.4.txz                         : 100%   15 KiB  15.8kB/s    00:01
xlsatoms-1.1.2.txz                       : 100%    6 KiB   6.1kB/s    00:01
xlsclients-1.1.3.txz                     : 100%    8 KiB   8.2kB/s    00:01
xset-1.2.3_1.txz                         : 100%   17 KiB  17.2kB/s    00:01
libXfontcache-1.0.5_3.txz                : 100%    6 KiB   6.6kB/s    00:01
fontcacheproto-0.1.3.txz                 : 100%    3 KiB   2.7kB/s    00:01
xvinfo-1.1.3.txz                         : 100%    6 KiB   5.9kB/s    00:01
xdpyinfo-1.3.2.txz                       : 100%   15 KiB  14.9kB/s    00:01
libXtst-1.2.2_3.txz                      : 100%   19 KiB  19.1kB/s    00:01
recordproto-1.14.2.txz                   : 100%    3 KiB   3.2kB/s    00:01
libXcomposite-0.4.4_3,1.txz              : 100%   11 KiB  10.9kB/s    00:01
compositeproto-0.4.2.txz                 : 100%    7 KiB   7.1kB/s    00:01
libdmx-1.1.3_3.txz                       : 100%   34 KiB  35.2kB/s    00:01
dmxproto-2.3.1.txz                       : 100%    3 KiB   3.2kB/s    00:01
libXxf86misc-1.0.3_3.txz                 : 100%   10 KiB  10.1kB/s    00:01
xf86miscproto-0.9.3.txz                  : 100%    3 KiB   2.8kB/s    00:01
appres-1.0.4.txz                         : 100%    5 KiB   5.4kB/s    00:01
xgamma-1.0.6.txz                         : 100%    6 KiB   5.8kB/s    00:01
smproxy-1.0.6.txz                        : 100%   10 KiB   9.8kB/s    00:01
bitmap-1.0.8.txz                         : 100%   48 KiB  49.6kB/s    00:01
xev-1.2.2.txz                            : 100%   11 KiB  11.7kB/s    00:01
luit-1.1.1_1.txz                         : 100%   18 KiB  18.4kB/s    00:01
xrandr-1.4.3.txz                         : 100%   33 KiB  33.9kB/s    00:01
iceauth-1.0.7.txz                        : 100%   14 KiB  14.0kB/s    00:01
xrdb-1.1.0.txz                           : 100%   16 KiB  15.9kB/s    00:01
xpr-1.0.4.txz                            : 100%   29 KiB  30.1kB/s    00:01
xorg-fonts-7.7_1.txz                     : 100%  552 B     0.6kB/s    00:01
xorg-fonts-cyrillic-7.7.txz              : 100%  512 B     0.5kB/s    00:01
encodings-1.0.4_3,1.txz                  : 100%  558 KiB 571.1kB/s    00:01
font-cronyx-cyrillic-1.0.3_3.txz         : 100%  298 KiB 304.9kB/s    00:01
font-screen-cyrillic-1.0.4_3.txz         : 100%   10 KiB  10.1kB/s    00:01
font-misc-cyrillic-1.0.3_3.txz           : 100%   65 KiB  67.1kB/s    00:01
font-winitzki-cyrillic-1.0.3_3.txz       : 100%    6 KiB   5.7kB/s    00:01
xorg-fonts-truetype-7.7_1.txz            : 100%  516 B     0.5kB/s    00:01
font-misc-meltho-1.0.3_3.txz             : 100%  718 KiB 367.5kB/s    00:02
font-bh-ttf-1.0.3_3.txz                  : 100%  269 KiB 275.0kB/s    00:01
font-misc-ethiopic-1.0.3_3.txz           : 100%  126 KiB 129.2kB/s    00:01
dejavu-2.35.txz                          : 100%    2 MiB 459.2kB/s    00:05
xorg-fonts-75dpi-7.7.txz                 : 100%  528 B     0.5kB/s    00:01
font-bitstream-75dpi-1.0.3_3.txz         : 100%  139 KiB 141.9kB/s    00:01
font-adobe-75dpi-1.0.3_3.txz             : 100%    5 MiB   1.1MB/s    00:05
font-bh-lucidatypewriter-75dpi-1.0.3_3.t*: 100%  733 KiB 751.0kB/s    00:01
font-bh-75dpi-1.0.3_3.txz                : 100%    3 MiB 650.8kB/s    00:05
font-adobe-utopia-75dpi-1.0.4_3.txz      : 100%    1 MiB 611.0kB/s    00:02
xorg-fonts-100dpi-7.7.txz                : 100%  528 B     0.5kB/s    00:01
font-bitstream-100dpi-1.0.3_3.txz        : 100%  158 KiB 162.2kB/s    00:01
font-bh-100dpi-1.0.3_3.txz               : 100%    4 MiB 629.7kB/s    00:06
font-adobe-utopia-100dpi-1.0.4_3.txz     : 100%    1 MiB 489.3kB/s    00:03
font-bh-lucidatypewriter-100dpi-1.0.3_3.*: 100%  836 KiB 428.1kB/s    00:02
xorg-fonts-type1-7.7.txz                 : 100%  516 B     0.5kB/s    00:01
font-ibm-type1-1.0.3_3.txz               : 100%  274 KiB 280.5kB/s    00:01
font-bitstream-type1-1.0.3_3.txz         : 100%  294 KiB 301.1kB/s    00:01
font-adobe-utopia-type1-1.0.4_3.txz      : 100%  167 KiB 171.1kB/s    00:01
font-xfree86-type1-1.0.4_3.txz           : 100%   28 KiB  28.2kB/s    00:01
font-bh-type1-1.0.3_3.txz                : 100%  524 KiB 536.2kB/s    00:01
xorg-fonts-miscbitmaps-7.7.txz           : 100%  644 B     0.6kB/s    00:01
font-jis-misc-1.0.3_3.txz                : 100%  527 KiB 540.0kB/s    00:01
font-cursor-misc-1.0.3_3.txz             : 100%    6 KiB   6.1kB/s    00:01
font-sun-misc-1.0.3_3.txz                : 100%   26 KiB  26.9kB/s    00:01
font-daewoo-misc-1.0.3_3.txz             : 100%  645 KiB 660.5kB/s    00:01
font-arabic-misc-1.0.3_3.txz             : 100%   14 KiB  14.2kB/s    00:01
font-micro-misc-1.0.3_3.txz              : 100%    2 KiB   2.5kB/s    00:01
font-sony-misc-1.0.3_3.txz               : 100%   20 KiB  20.8kB/s    00:01
font-dec-misc-1.0.3_3.txz                : 100%    4 KiB   4.2kB/s    00:01
font-mutt-misc-1.0.3_3.txz               : 100%  204 KiB 209.0kB/s    00:01
font-schumacher-misc-1.1.2_3.txz         : 100%  152 KiB 155.4kB/s    00:01
font-isas-misc-1.0.3_3.txz               : 100%  781 KiB 399.7kB/s    00:02
xorg-libraries-7.7_2.txz                 : 100%  944 B     0.9kB/s    00:01
libXevie-1.0.3_3.txz                     : 100%    8 KiB   7.8kB/s    00:01
libXTrap-1.0.1_3.txz                     : 100%   20 KiB  20.6kB/s    00:01
trapproto-3.4.3.txz                      : 100%   13 KiB  13.0kB/s    00:01
libXfont-1.5.1,2.txz                     : 100%  148 KiB 151.7kB/s    00:01
fontsproto-2.1.3,1.txz                   : 100%   35 KiB  35.6kB/s    00:01
libXres-1.0.7_3.txz                      : 100%    8 KiB   7.8kB/s    00:01
libFS-1.0.7.txz                          : 100%   37 KiB  37.6kB/s    00:01
liboldX-1.0.1_3.txz                      : 100%    8 KiB   8.4kB/s    00:01
pixman-0.34.0.txz                        : 100%  284 KiB 290.7kB/s    00:01
xtrans-1.3.5.txz                         : 100%   35 KiB  36.3kB/s    00:01
libXScrnSaver-1.2.2_3.txz                : 100%   13 KiB  13.5kB/s    00:01
scrnsaverproto-1.2.2.txz                 : 100%    2 KiB   2.5kB/s    00:01
libxkbui-1.0.2_4.txz                     : 100%   10 KiB   9.8kB/s    00:01
xcursor-themes-1.0.4_1.txz               : 100%  309 KiB 316.9kB/s    00:01
xorg-drivers-7.7_3.txz                   : 100%  776 B     0.8kB/s    00:01
xf86-video-vesa-2.3.4.txz                : 100%   12 KiB  12.6kB/s    00:01
xorg-server-1.17.4,1.txz                 : 100%    1 MiB 505.9kB/s    00:03
libepoxy-1.3.1.txz                       : 100%  257 KiB 263.5kB/s    00:01
libglesv2-11.2.2.txz                     : 100%   41 KiB  42.0kB/s    00:01
libEGL-11.2.2.txz                        : 100%   55 KiB  56.6kB/s    00:01
gbm-11.2.2.txz                           : 100%   12 KiB  12.4kB/s    00:01
llvm37-3.7.1_3.txz                       : 100%   28 MiB   1.9MB/s    00:16
python27-2.7.12.txz                      : 100%   10 MiB   1.5MB/s    00:07
readline-6.3.8.txz                       : 100%  323 KiB 330.7kB/s    00:01
libressl-2.4.3.txz                       : 100%    2 MiB 506.8kB/s    00:04
libffi-3.2.1.txz                         : 100%   25 KiB  25.9kB/s    00:01
perl5-5.20.3_15.txz                      : 100%   13 MiB   1.5MB/s    00:09
libedit-3.1.20150325_2,1.txz             : 100%  132 KiB 135.5kB/s    00:01
dri-11.2.2,2.txz                         : 100%    4 MiB 780.0kB/s    00:05
libvdpau-1.1.1.txz                       : 100%   53 KiB  54.5kB/s    00:01
xkeyboard-config-2.17.txz                : 100%  604 KiB 618.9kB/s    00:01
xf86-input-mouse-1.9.1_1.txz             : 100%   32 KiB  32.4kB/s    00:01
xf86-video-intel-2.99.2016.06.01,2.txz   : 100%  635 KiB 650.5kB/s    00:01
xf86-video-ati-7.7.0.txz                 : 100%  130 KiB 133.6kB/s    00:01
xf86-video-openchrome-0.3.3_6.txz        : 100%  133 KiB 135.9kB/s    00:01
xf86-video-nv-2.1.20_7.txz               : 100%   67 KiB  68.9kB/s    00:01
xf86-input-keyboard-1.8.1.txz            : 100%    9 KiB   9.1kB/s    00:01
xorg-docs-1.7.1,1.txz                    : 100%   91 KiB  93.5kB/s    00:01
aspell-ispell-0.60.6.1.txz               : 100%   10 KiB  10.2kB/s    00:01
aspell-0.60.6.1_5.txz                    : 100%  744 KiB 381.0kB/s    00:02
```
