### PR TITLE
Fix NetBSD ABI and suppress major version change warning

### DIFF
--- a/libpkg/pkg.h.in
+++ b/libpkg/pkg.h.in
@@ -74,7 +74,7 @@ extern "C" {
 #endif
 
 #ifdef __NetBSD_Version__
-#define OSMAJOR __NetBSD_Version__
+#define OSMAJOR ((__NetBSD_Version__ + 1000000) / 100000000)
 #endif
 
 #ifndef __DECONST

--- a/libpkg/pkg_elf.c
+++ b/libpkg/pkg_elf.c
@@ -787,6 +787,8 @@ pkg_get_myarch_elfparse(char *dest, size_t sz)
 #if defined(__DragonFly__)
 	snprintf(dest, sz, "%s:%d.%d",
 	    osname, version / 100000, (((version / 100 % 1000)+1)/2)*2);
+#elif defined(__NetBSD__)
+	snprintf(dest, sz, "%s:%d", osname, (version + 1000000) / 100000000);
 #else
 	snprintf(dest, sz, "%s:%d", osname, version / 100000);
 #endif


### PR DESCRIPTION
Previously the ABI on NetBSD was reported as "NetBSD:7000:amd64"
Now pkg -vv returns:
ABI = "NetBSD:7:amd64"
ALTABI = "NetBSD:7:x86_64"

This also fixes the "Major OS version upgrade detected" warning that
NetBSD has been suffering from since the beginning.  Note that
development branches like 7.99 should return "NetBSD:8:amd64" for the
ABI.