### PR TITLE
Disable ELF hint checking on NetBSD for now

### DIFF
--- a/libpkg/elfhints.c
+++ b/libpkg/elfhints.c
@@ -310,7 +310,7 @@ int shlib_list_from_rpath(const char *rpath_str, const char *dirpath)
 int 
 shlib_list_from_elf_hints(const char *hintsfile)
 {
-#ifndef __linux__
+#if !(defined __linux__ || defined __NetBSD__)
 	read_elf_hints(hintsfile, 1);
 #endif
 

--- a/libpkg/private/ldconfig.h
+++ b/libpkg/private/ldconfig.h
@@ -55,7 +55,11 @@ struct elfhints_hdr
 
 #define ELFHINTS_MAGIC  0x746e6845
 
+# ifdef __NetBSD__
+#define _PATH_ELF_HINTS "/var/run/ld.so.hints"
+# else
 #define _PATH_ELF_HINTS "/var/run/ld-elf.so.hints"
+# endif
 #endif
 
 extern int	insecure;	/* -i flag, needed here for elfhints.c */


### PR DESCRIPTION
The ELF hints on NetBSD are optionally located at /var/run/ld.so.hints.
If this file doesn't exist, pkg(8) fails (it should check for it rather
than assume it's there).
However, when this file is touched to create a blank version, pkg(8)
segfaults.  Until support for ELF hints is confirmed to work as it does
on FreeBSD and DragonFly, disable the functionality.