### PR TITLE
Explicitly limit ELF hints to DragonFly and FreeBSD

### DIFF
--- a/libpkg/elfhints.c
+++ b/libpkg/elfhints.c
@@ -310,7 +310,7 @@ int shlib_list_from_rpath(const char *rpath_str, const char *dirpath)
 int 
 shlib_list_from_elf_hints(const char *hintsfile)
 {
-#if !(defined __linux__ || defined __NetBSD__)
+#if defined __FreeBSD__ || defined __DragonFly__
 	read_elf_hints(hintsfile, 1);
 #endif
 


### PR DESCRIPTION
It is believed that only these two platforms can leverage them.
It's better to specify the valid platforms rather than exclude the rest.