### PR TITLE
Add --enable-pie flag

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -40,6 +40,11 @@ AC_CHECK_HEADERS_ONCE([fcntl.h unistd.h elf-hints.h])
 AC_TYPE_OFF_T
 AC_FUNC_MMAP
 
+AC_ARG_ENABLE([pie],
+    AS_HELP_STRING([--enable-pie], [Enable Position-Independent Executable support]))
+
+AM_CONDITIONAL([ENABLE_PIE], [test "x$enable_pie" = "xyes"])
+
 if test "$ac_cv_func_mmap_fixed_mapped" = "yes"; then
     FILEMAP=unixfilemap
 else

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -72,6 +72,11 @@ pkg_static_LDADD= @OS_LDFLAGS@ \
 			-lcrypto \
 			-lm
 
+if ENABLE_PIE
+pkg_CFLAGS+=	-fPIE -pie
+pkg_LDFLAGS=	-pie
+endif
+
 if HAVE_ELF_ABI
 if LIBELF_BUNDLED
 pkg_static_LDADD+=	$(top_builddir)/external/libelf_static.la


### PR DESCRIPTION
This gives us a PIEified pkg. pkg-static is left alone. This will be needed to fully apply ASR/ASLR to pkg.

Signed-off-by:	Shawn Webb <shawn.webb@hardenedbsd.org>