### PR TITLE
Solve segfault on fetching for NetBSD

### DIFF
--- a/external/libfetch/ftp.c
+++ b/external/libfetch/ftp.c
@@ -55,6 +55,10 @@
  *
  */
 
+#ifdef __NetBSD__
+#define _NETBSD_SOURCE
+#endif
+
 #include <sys/param.h>
 #include <sys/socket.h>
 #include <netinet/in.h>

--- a/external/libfetch/http.c
+++ b/external/libfetch/http.c
@@ -60,6 +60,9 @@
  * SUCH DAMAGE.
  */
 #define _XOPEN_SOURCE
+#ifdef __NetBSD__
+#define _NETBSD_SOURCE
+#endif
 #include <sys/param.h>
 #include <sys/socket.h>
 #include <sys/time.h>


### PR DESCRIPTION
The funopen and vasprintf functions are filtered out during <stdio.h>
inclusion on NetBSD unless the _NETBSD_SOURCE macro is defined earlier.

This solves a preplexing segfault on NetBSD.  The funopen function would
be implicitly defined due to the lack of a prototype and the return type
default to an integer, resulting in an invalid pointer to the FILE
structure.