### PR TITLE
Define new default alias "prime-origins"

### DIFF
--- a/src/pkg.conf.sample
+++ b/src/pkg.conf.sample
@@ -66,6 +66,7 @@ ALIAS              : {
   iinfo: info -ix,
   isearch: search -ix,
   prime-list: "query -e '%a = 0' '%n'",
+  prime-origins: "query -e '%a = 0' '%o'",
   leaf: "query -e '%#r == 0' '%n-%v'",
   list: info -ql,
   noauto = "query -e '%a == 0' '%n-%v'",


### PR DESCRIPTION
This default is similar to prime-list except that it displays the
packages' origin instead of their names.  It is useful for synth and
poudriere users to generate repository build lists.