### PR TITLE
query: aggregate license information

### DIFF
--- a/libpkg/pkgdb_iterator.c
+++ b/libpkg/pkgdb_iterator.c
@@ -507,7 +507,7 @@ static int
 pkgdb_load_license(sqlite3 *sqlite, struct pkg *pkg)
 {
 	const char	 sql[] = ""
-		"SELECT name"
+		"SELECT ifnull(group_concat(name, ', '), '') AS name"
 		"  FROM pkg_licenses, licenses AS l"
 		"  WHERE package_id = ?1"
 		"    AND license_id = l.id"


### PR DESCRIPTION
Currently, multiple packages queried with:

    query '%n %L'

will output packages on multiple lines, skewing counts with "wc -l".  Instead,
aggregate all of the licenses of a package and output that.

Additionally, handle printing packages with no license information by using an
empty string.

Fixes #1510