### PR TITLE
Add missing NULL checks from different memory-allocation functions

### DIFF
--- a/libpkg/diff.c
+++ b/libpkg/diff.c
@@ -25,6 +25,7 @@
 #include <utstring.h>
 
 #include "private/utils.h"
+#include "private/event.h"
 
 /*
 ** Maximum length of a line in a text file, in bytes.  (2**13 = 8192 bytes)
@@ -124,6 +125,8 @@ static DLine *break_into_lines(char *z, int *pnLine){
     return 0;
   }
   a = calloc(nLine, sizeof(a[0]) );
+  if (a == NULL)
+    pkg_emit_errno("calloc", __func__);
   if( n==0 ){
     *pnLine = 0;
     return a;
@@ -319,6 +322,8 @@ static void longestCommonSequence(
 */
 static void expandEdit(DContext *p, int nEdit){
   p->aEdit = realloc(p->aEdit, nEdit*sizeof(int));
+  if (p->aEdit == NULL)
+    pkg_emit_errno("realloc", __func__);
   p->nEditAlloc = nEdit;
 }
 

--- a/libpkg/dns_utils.c
+++ b/libpkg/dns_utils.c
@@ -75,6 +75,7 @@
 
 #include <bsd_compat.h>
 #include "private/utils.h"
+#include "private/event.h"
 #include "pkg.h"
 
 #ifndef HAVE_LDNS
@@ -134,6 +135,10 @@ compute_weight(struct dns_srvinfo **d, int first, int last)
 		return;
 
 	chosen = malloc(sizeof(int) * (last - first + 1));
+	if (chosen == NULL) {
+		pkg_emit_errno("malloc", __func__);
+		return;
+	}
 
 	for (i = 0; i <= last; i++) {
 		for (;;) {
@@ -335,6 +340,10 @@ compute_weight(struct dns_srvinfo *d, int first, int last)
 		return;
 
 	chosen = malloc(sizeof(int) * (last - first + 1));
+	if (chosen == NULL) {
+		pkg_emit_errno("malloc", __func__);
+		return;
+	}
 
 	for (i = 0; i <= last; i++) {
 		for (;;) {

--- a/libpkg/elfhints.c
+++ b/libpkg/elfhints.c
@@ -108,7 +108,7 @@ shlib_list_add(kh_shlib_t **shlib_list, const char *dir,
 
 	sl = calloc(1, sizeof(struct shlib) + path_len);
 	if (sl == NULL) {
-		pkg_emit_errno("calloc", "shlib_list_add");
+		pkg_emit_errno("calloc", __func__);
 		return (EPKG_FATAL);
 	}
 
@@ -279,7 +279,7 @@ int shlib_list_from_rpath(const char *rpath_str, const char *dirpath)
 
 	dirlist = calloc(1, buflen);
 	if (dirlist == NULL) {
-		pkg_emit_errno("calloc", "shlib_free_from_rpath");
+		pkg_emit_errno("calloc", __func__);
 		return (EPKG_FATAL);
 	}
 	buf = (char *)dirlist + numdirs * sizeof(char *);

--- a/libpkg/elfhints.c
+++ b/libpkg/elfhints.c
@@ -44,6 +44,7 @@
 #include <uthash.h>
 
 #include "pkg.h"
+#include "private/event.h"
 #include "private/pkg.h"
 #include "private/ldconfig.h"
 
@@ -107,7 +108,7 @@ shlib_list_add(kh_shlib_t **shlib_list, const char *dir,
 
 	sl = calloc(1, sizeof(struct shlib) + path_len);
 	if (sl == NULL) {
-		warnx("Out of memory");
+		pkg_emit_errno("calloc", "shlib_list_add");
 		return (EPKG_FATAL);
 	}
 
@@ -278,7 +279,7 @@ int shlib_list_from_rpath(const char *rpath_str, const char *dirpath)
 
 	dirlist = calloc(1, buflen);
 	if (dirlist == NULL) {
-		warnx("Out of memory");
+		pkg_emit_errno("calloc", "shlib_free_from_rpath");
 		return (EPKG_FATAL);
 	}
 	buf = (char *)dirlist + numdirs * sizeof(char *);

--- a/libpkg/fetch.c
+++ b/libpkg/fetch.c
@@ -75,8 +75,7 @@ gethttpmirrors(struct pkg_repo *repo, const char *url) {
 			if ((u = fetchParseURL(line)) != NULL) {
 				m = malloc(sizeof(struct http_mirror));
 				if (m == NULL) {
-					pkg_emit_errno("malloc",
-					    "gethttpmirrors");
+					pkg_emit_errno("malloc", __func__);
 				}
 				m->url = u;
 				LL_APPEND(repo->http, m);
@@ -97,7 +96,7 @@ pkg_fetch_file_tmp(struct pkg_repo *repo, const char *url, char *dest,
 	fd = mkstemp(dest);
 
 	if (fd == -1) {
-		pkg_emit_errno("mkstemp", dest);
+		pkg_emit_errno("mkstemp", __func__);
 		return(EPKG_FATAL);
 	}
 
@@ -135,7 +134,7 @@ pkg_fetch_file(struct pkg_repo *repo, const char *url, char *dest, time_t t,
 
 	fd = open(dest, O_CREAT|O_APPEND|O_WRONLY, 00644);
 	if (fd == -1) {
-		pkg_emit_errno("open", dest);
+		pkg_emit_errno("open", __func__);
 		return(EPKG_FATAL);
 	}
 
@@ -352,7 +351,7 @@ start_ssh(struct pkg_repo *repo, struct url *u, off_t *sz)
 
 		repo->sshio.pid = fork();
 		if (repo->sshio.pid == -1) {
-			pkg_emit_errno("Cannot fork", "start_ssh");
+			pkg_emit_errno("Cannot fork", __func__);
 			goto ssh_cleanup;
 		}
 
@@ -361,7 +360,8 @@ start_ssh(struct pkg_repo *repo, struct url *u, off_t *sz)
 			    close(sshin[1]) < 0 ||
 			    close(sshout[0]) < 0 ||
 			    dup2(sshout[1], STDOUT_FILENO) < 0) {
-				pkg_emit_errno("Cannot prepare pipes", "start_ssh");
+				pkg_emit_errno("Cannot prepare pipes",
+					       __func__);
 				goto ssh_cleanup;
 			}
 
@@ -394,7 +394,7 @@ start_ssh(struct pkg_repo *repo, struct url *u, off_t *sz)
 		}
 
 		if (close(sshout[1]) < 0 || close(sshin[0]) < 0) {
-			pkg_emit_errno("Failed to close pipes", "start_ssh");
+			pkg_emit_errno("Failed to close pipes", __func__);
 			goto ssh_cleanup;
 		}
 
@@ -406,7 +406,7 @@ start_ssh(struct pkg_repo *repo, struct url *u, off_t *sz)
 
 		repo->ssh = funopen(repo, ssh_read, ssh_write, NULL, ssh_close);
 		if (repo->ssh == NULL) {
-			pkg_emit_errno("Failed to open stream", "start_ssh");
+			pkg_emit_errno("Failed to open stream", __func__);
 			goto ssh_cleanup;
 		}
 
@@ -654,7 +654,7 @@ pkg_fetch_file_to_fd(struct pkg_repo *repo, const char *url, int dest,
 		left = sz - done;
 	while ((r = fread(buf, 1, left < buflen ? left : buflen, remote)) > 0) {
 		if (write(dest, buf, r) != r) {
-			pkg_emit_errno("write", "");
+			pkg_emit_errno("write", __func__);
 			retcode = EPKG_FATAL;
 			goto cleanup;
 		}

--- a/libpkg/fetch.c
+++ b/libpkg/fetch.c
@@ -74,6 +74,10 @@ gethttpmirrors(struct pkg_repo *repo, const char *url) {
 
 			if ((u = fetchParseURL(line)) != NULL) {
 				m = malloc(sizeof(struct http_mirror));
+				if (m == NULL) {
+					pkg_emit_errno("malloc",
+					    "gethttpmirrors");
+				}
 				m->url = u;
 				LL_APPEND(repo->http, m);
 			}

--- a/libpkg/packing.c
+++ b/libpkg/packing.c
@@ -57,7 +57,7 @@ packing_init(struct packing **pack, const char *path, pkg_formats format)
 	assert(pack != NULL);
 
 	if ((*pack = calloc(1, sizeof(struct packing))) == NULL) {
-		pkg_emit_errno("calloc", "packing");
+		pkg_emit_errno("calloc", __func__);
 		return (EPKG_FATAL);
 	}
 
@@ -82,8 +82,7 @@ packing_init(struct packing **pack, const char *path, pkg_formats format)
 	pkg_debug(1, "Packing to file '%s'", archive_path);
 	if (archive_write_open_filename(
 	    (*pack)->awrite, archive_path) != ARCHIVE_OK) {
-		pkg_emit_errno("archive_write_open_filename",
-		    archive_path);
+		pkg_emit_errno("archive_write_open_filename", __func__);
 		archive_read_close((*pack)->aread);
 		archive_read_free((*pack)->aread);
 		archive_write_close((*pack)->awrite);
@@ -115,13 +114,13 @@ packing_append_buffer(struct packing *pack, const char *buffer,
 	archive_entry_set_pathname(entry, path);
 	archive_entry_set_size(entry, size);
 	if (archive_write_header(pack->awrite, entry) == -1) {
-		pkg_emit_errno("archive_write_header", path);
+		pkg_emit_errno("archive_write_header", __func__);
 		ret = EPKG_FATAL;
 		goto cleanup;
 	}
 
 	if (archive_write_data(pack->awrite, buffer, size) == -1) {
-		pkg_emit_errno("archive_write_data", path);
+		pkg_emit_errno("archive_write_data", __func__);
 		ret = EPKG_FATAL;
 	}
 
@@ -152,7 +151,7 @@ packing_append_file_attr(struct packing *pack, const char *filepath,
 	pkg_debug(2, "Packing file '%s'", filepath);
 
 	if (lstat(filepath, &st) != 0) {
-		pkg_emit_errno("lstat", filepath);
+		pkg_emit_errno("lstat", __func__);
 		retcode = EPKG_FATAL;
 		goto cleanup;
 	}
@@ -219,7 +218,7 @@ packing_append_file_attr(struct packing *pack, const char *filepath,
 
 	if (archive_entry_size(entry) > 0) {
 		if ((fd = open(filepath, O_RDONLY)) < 0) {
-			pkg_emit_errno("open", filepath);
+			pkg_emit_errno("open", __func__);
 			retcode = EPKG_FATAL;
 			goto cleanup;
 		}
@@ -229,13 +228,14 @@ packing_append_file_attr(struct packing *pack, const char *filepath,
 
 			while ((len = read(fd, buf, sizeof(buf))) > 0)
 				if (archive_write_data(pack->awrite, buf, len) == -1) {
-					pkg_emit_errno("archive_write_data", "archive write error");
+					pkg_emit_errno("archive_write_data",
+						       __func__);
 					retcode = EPKG_FATAL;
 					break;
 				}
 
 			if (len == -1) {
-				pkg_emit_errno("read", "file read error");
+				pkg_emit_errno("read", __func__);
 				retcode = EPKG_FATAL;
 			}
 			close(fd);
@@ -245,14 +245,15 @@ packing_append_file_attr(struct packing *pack, const char *filepath,
 					MAP_SHARED, fd, 0)) != MAP_FAILED) {
 				close(fd);
 				if (archive_write_data(pack->awrite, map, st.st_size) == -1) {
-					pkg_emit_errno("archive_write_data", "archive write error");
+					pkg_emit_errno("archive_write_data",
+						       __func__);
 					retcode = EPKG_FATAL;
 				}
 				munmap(map, st.st_size);
 			}
 			else {
 				close(fd);
-				pkg_emit_errno("open", filepath);
+				pkg_emit_errno("open", __func__);
 				retcode = EPKG_FATAL;
 				goto cleanup;
 			}

--- a/libpkg/pkg.c
+++ b/libpkg/pkg.c
@@ -322,24 +322,48 @@ pkg_vset(struct pkg *pkg, va_list ap)
 		case PKG_NAME:
 			free(pkg->name);
 			pkg->name = strdup(va_arg(ap, const char *));
+			if (pkg->name == NULL) {
+				pkg_emit_errno("strdup", __func__);
+				return (EPKG_FATAL);
+			}
 			free(pkg->uid);
 			pkg->uid = strdup(pkg->name);
+			if (pkg->uid == NULL) {
+				pkg_emit_errno("strdup", __func__);
+				return (EPKG_FATAL);
+			}
 			break;
 		case PKG_ORIGIN:
 			free(pkg->origin);
 			pkg->origin = strdup(va_arg(ap, const char *));
+			if (pkg->origin == NULL) {
+				pkg_emit_errno("strdup", __func__);
+				return (EPKG_FATAL);
+			}
 			break;
 		case PKG_VERSION:
 			free(pkg->version);
 			pkg->version = strdup(va_arg(ap, const char *));
+			if (pkg->version == NULL) {
+				pkg_emit_errno("strdup", __func__);
+				return (EPKG_FATAL);
+			}
 			break;
 		case PKG_COMMENT:
 			free(pkg->comment);
 			pkg->comment = strdup(va_arg(ap, const char *));
+			if (pkg->comment == NULL) {
+				pkg_emit_errno("strdup", __func__);
+				return (EPKG_FATAL);
+			}
 			break;
 		case PKG_DESC:
 			free(pkg->desc);
 			pkg->desc = strdup(va_arg(ap, const char *));
+			if (pkg->desc == NULL) {
+				pkg_emit_errno("strdup", __func__);
+				return (EPKG_FATAL);
+			}
 			break;
 		case PKG_MTREE:
 			(void)va_arg(ap, const char *);
@@ -361,50 +385,98 @@ pkg_vset(struct pkg *pkg, va_list ap)
 		case PKG_ARCH:
 			free(pkg->arch);
 			pkg->arch = strdup(va_arg(ap, const char *));
+			if (pkg->arch == NULL) {
+				pkg_emit_errno("strdup", __func__);
+				return (EPKG_FATAL);
+			}
 			break;
 		case PKG_ABI:
 			free(pkg->abi);
 			pkg->abi = strdup(va_arg(ap, const char *));
+			if (pkg->abi == NULL) {
+				pkg_emit_errno("strdup", __func__);
+				return (EPKG_FATAL);
+			}
 			break;
 		case PKG_MAINTAINER:
 			free(pkg->maintainer);
 			pkg->maintainer = strdup(va_arg(ap, const char *));
+			if (pkg->maintainer == NULL) {
+				pkg_emit_errno("strdup", __func__);
+				return (EPKG_FATAL);
+			}
 			break;
 		case PKG_WWW:
 			free(pkg->www);
 			pkg->www = strdup(va_arg(ap, const char *));
+			if (pkg->www == NULL) {
+				pkg_emit_errno("strdup", __func__);
+				return (EPKG_FATAL);
+			}
 			break;
 		case PKG_PREFIX:
 			free(pkg->prefix);
 			pkg->prefix = strdup(va_arg(ap, const char *));
+			if (pkg->prefix == NULL) {
+				pkg_emit_errno("strdup", __func__);
+				return (EPKG_FATAL);
+			}
 			break;
 		case PKG_REPOPATH:
 			free(pkg->repopath);
 			pkg->repopath = strdup(va_arg(ap, const char *));
+			if (pkg->repopath == NULL) {
+				pkg_emit_errno("strdup", __func__);
+				return (EPKG_FATAL);
+			}
 			break;
 		case PKG_CKSUM:
 			free(pkg->sum);
 			pkg->sum = strdup(va_arg(ap, const char *));
+			if (pkg->sum == NULL) {
+				pkg_emit_errno("strdup", __func__);
+				return (EPKG_FATAL);
+			}
 			break;
 		case PKG_OLD_VERSION:
 			free(pkg->old_version);
 			pkg->old_version = strdup(va_arg(ap, const char *));
+			if (pkg->old_version == NULL) {
+				pkg_emit_errno("strdup", __func__);
+				return (EPKG_FATAL);
+			}
 			break;
 		case PKG_REPONAME:
 			free(pkg->reponame);
 			pkg->reponame = strdup(va_arg(ap, const char *));
+			if (pkg->reponame == NULL) {
+				pkg_emit_errno("strdup", __func__);
+				return (EPKG_FATAL);
+			}
 			break;
 		case PKG_REPOURL:
 			free(pkg->repourl);
 			pkg->repourl = strdup(va_arg(ap, const char *));
+			if (pkg->repourl == NULL) {
+				pkg_emit_errno("strdup", __func__);
+				return (EPKG_FATAL);
+			}
 			break;
 		case PKG_DIGEST:
 			free(pkg->digest);
 			pkg->digest = strdup(va_arg(ap, const char *));
+			if (pkg->digest == NULL) {
+				pkg_emit_errno("strdup", __func__);
+				return (EPKG_FATAL);
+			}
 			break;
 		case PKG_REASON:
 			free(pkg->reason);
 			pkg->reason = strdup(va_arg(ap, const char *));
+			if (pkg->reason == NULL) {
+				pkg_emit_errno("strdup", __func__);
+				return (EPKG_FATAL);
+			}
 			break;
 		case PKG_FLATSIZE:
 			pkg->flatsize = va_arg(ap, int64_t);
@@ -433,6 +505,10 @@ pkg_vset(struct pkg *pkg, va_list ap)
 		case PKG_DEP_FORMULA:
 			free(pkg->dep_formula);
 			pkg->dep_formula = strdup(va_arg(ap, const char *));
+			if (pkg->dep_formula == NULL) {
+				pkg_emit_errno("strdup", __func__);
+				return (EPKG_FATAL);
+			}
 			break;
 		case PKG_VITAL:
 			pkg->vital = (bool)va_arg(ap, int);
@@ -594,6 +670,10 @@ pkg_adduser(struct pkg *pkg, const char *name)
 	}
 
 	storename = strdup(name);
+	if (storename == NULL) {
+		pkg_emit_errno("strdup", __func__);
+		return (EPKG_FATAL);
+	}
 	kh_add(strings, pkg->users, storename, storename, free);
 
 	return (EPKG_OK);
@@ -618,6 +698,10 @@ pkg_addgroup(struct pkg *pkg, const char *name)
 	}
 
 	storename = strdup(name);
+	if (storename == NULL) {
+		pkg_emit_errno("strdup", __func__);
+		return (EPKG_FATAL);
+	}
 	kh_add(strings, pkg->groups, storename, storename, free);
 
 	return (EPKG_OK);
@@ -648,10 +732,27 @@ pkg_adddep(struct pkg *pkg, const char *name, const char *origin, const char *ve
 	pkg_dep_new(&d);
 
 	d->origin = strdup(origin);
+	if (d->origin == NULL) {
+		pkg_emit_errno("strdup", __func__);
+		return (EPKG_FATAL);
+	}
 	d->name = strdup(name);
-	if (version != NULL && version[0] != '\0')
+	if (d->name == NULL) {
+		pkg_emit_errno("strdup", __func__);
+		return (EPKG_FATAL);
+	}
+	if (version != NULL && version[0] != '\0') {
 		d->version = strdup(version);
+		if (d->version == NULL) {
+			pkg_emit_errno("strdup", __func__);
+			return (EPKG_FATAL);
+		}
+	}
 	d->uid = strdup(name);
+	if (d->uid == NULL) {
+		pkg_emit_errno("strdup", __func__);
+		return (EPKG_FATAL);
+	}
 	d->locked = locked;
 
 	kh_add(pkg_deps, pkg->depshash, d, d->name, pkg_dep_free);
@@ -673,10 +774,27 @@ pkg_addrdep(struct pkg *pkg, const char *name, const char *origin, const char *v
 	pkg_dep_new(&d);
 
 	d->origin = strdup(origin);
+	if (d->origin == NULL) {
+		pkg_emit_errno("strdup", __func__);
+		return (EPKG_FATAL);
+	}
 	d->name = strdup(name);
-	if (version != NULL && version[0] != '\0')
+	if (d->name == NULL) {
+		pkg_emit_errno("strdup", __func__);
+		return (EPKG_FATAL);
+	}
+	if (version != NULL && version[0] != '\0') {
 		d->version = strdup(version);
+		if (d->version == NULL) {
+			pkg_emit_errno("strdup", __func__);
+			return (EPKG_FATAL);
+		}
+	}
 	d->uid = strdup(name);
+	if (d->uid == NULL) {
+		pkg_emit_errno("strdup", __func__);
+		return (EPKG_FATAL);
+	}
 	d->locked = locked;
 
 	kh_add(pkg_deps, pkg->rdepshash, d, d->name, pkg_dep_free);
@@ -718,8 +836,13 @@ pkg_addfile_attr(struct pkg *pkg, const char *path, const char *sum,
 	pkg_file_new(&f);
 	strlcpy(f->path, path, sizeof(f->path));
 
-	if (sum != NULL)
+	if (sum != NULL) {
 		f->sum = strdup(sum);
+		if (f->sum == NULL) {
+			pkg_emit_errno("strdup", __func__);
+			return (EPKG_FATAL);
+		}
+	}
 
 	if (uname != NULL)
 		strlcpy(f->uname, uname, sizeof(f->uname));
@@ -759,8 +882,13 @@ pkg_addconfig_file(struct pkg *pkg, const char *path, const char *content)
 	pkg_config_file_new(&f);
 	strlcpy(f->path, path, sizeof(f->path));
 
-	if (content != NULL)
+	if (content != NULL) {
 		f->content = strdup(content);
+		if (f->content == NULL) {
+			pkg_emit_errno("strdup", __func__);
+			return (EPKG_FATAL);
+		}
+	}
 
 	kh_add(pkg_config_files, pkg->config_files, f, f->path, pkg_config_file_free);
 
@@ -788,6 +916,10 @@ pkg_addstring(kh_strings_t **list, const char *val, const char *title)
 	}
 
 	store = strdup(val);
+	if (store == NULL) {
+		pkg_emit_errno("strdup", __func__);
+		return (EPKG_FATAL);
+	}
 	kh_add(strings, *list, store, store, free);
 
 	return (EPKG_OK);
@@ -1007,6 +1139,10 @@ pkg_addoption(struct pkg *pkg, const char *key, const char *value)
 	if (o == NULL) {
 		pkg_option_new(&o);
 		o->key = strdup(key);
+		if (o->key == NULL) {
+			pkg_emit_errno("strdup", __func__);
+			return (EPKG_FATAL);
+		}
 	} else if ( o->value != NULL) {
 		if (developer_mode) {
 			pkg_emit_error("duplicate options listing: %s, fatal (developer mode)", key);
@@ -1018,6 +1154,10 @@ pkg_addoption(struct pkg *pkg, const char *key, const char *value)
 	}
 
 	o->value = strdup(value);
+	if (o->value == NULL) {
+		pkg_emit_errno("strdup", __func__);
+		return (EPKG_FATAL);
+	}
 	HASH_ADD_KEYPTR(hh, pkg->options, o->key, strlen(o->key), o);
 
 	return (EPKG_OK);
@@ -1043,6 +1183,10 @@ pkg_addoption_default(struct pkg *pkg, const char *key,
 	if (o == NULL) {
 		pkg_option_new(&o);
 		o->key = strdup(key);
+		if (o->key == NULL) {
+			pkg_emit_errno("strdup", __func__);
+			return (EPKG_FATAL);
+		}
 	} else if ( o->default_value != NULL) {
 		if (developer_mode) {
 			pkg_emit_error("duplicate default value for option: %s, fatal (developer mode)", key);
@@ -1054,6 +1198,10 @@ pkg_addoption_default(struct pkg *pkg, const char *key,
 	}
 
 	o->default_value = strdup(default_value);
+	if (o->default_value == NULL) {
+		pkg_emit_errno("strdup", __func__);
+		return (EPKG_FATAL);
+	}
 	HASH_ADD_KEYPTR(hh, pkg->options, o->default_value,
 	    strlen(o->default_value), o);
 
@@ -1079,6 +1227,10 @@ pkg_addoption_description(struct pkg *pkg, const char *key,
 	if (o == NULL) {
 		pkg_option_new(&o);
 		o->key = strdup(key);
+		if (o->key == NULL) {
+			pkg_emit_errno("strdup", __func__);
+			return (EPKG_FATAL);
+		}
 	} else if ( o->description != NULL) {
 		if (developer_mode) {
 			pkg_emit_error("duplicate description for option: %s, fatal (developer mode)", key);
@@ -1090,6 +1242,10 @@ pkg_addoption_description(struct pkg *pkg, const char *key,
 	}
 
 	o->description = strdup(description);
+	if (o->description == NULL) {
+		pkg_emit_errno("strdup", __func__);
+		return (EPKG_FATAL);
+	}
 	HASH_ADD_KEYPTR(hh, pkg->options, o->description,
 	    strlen(o->description), o);
 
@@ -1109,6 +1265,10 @@ pkg_addshlib_required(struct pkg *pkg, const char *name)
 		return (EPKG_OK);
 
 	storename = strdup(name);
+	if (storename == NULL) {
+		pkg_emit_errno("strdup", __func__);
+		return (EPKG_FATAL);
+	}
 	kh_add(strings, pkg->shlibs_required, storename, storename, free);
 
 	pkg_debug(3, "added shlib deps for %s on %s", pkg->name, name);
@@ -1133,6 +1293,10 @@ pkg_addshlib_provided(struct pkg *pkg, const char *name)
 		return (EPKG_OK);
 
 	storename = strdup(name);
+	if (storename == NULL) {
+		pkg_emit_errno("strdup", __func__);
+		return (EPKG_FATAL);
+	}
 	kh_add(strings, pkg->shlibs_provided, storename, storename, free);
 
 	pkg_debug(3, "added shlib provide %s for %s", name, pkg->name);
@@ -1155,6 +1319,10 @@ pkg_addconflict(struct pkg *pkg, const char *uniqueid)
 
 	pkg_conflict_new(&c);
 	c->uid = strdup(uniqueid);
+	if (c->uid == NULL) {
+		pkg_emit_errno("strdup", __func__);
+		return (EPKG_FATAL);
+	}
 	pkg_debug(3, "Pkg: add a new conflict origin: %s, with %s", pkg->uid, uniqueid);
 
 	HASH_ADD_KEYPTR(hh, pkg->conflicts, c->uid, strlen(c->uid), c);
@@ -1175,6 +1343,10 @@ pkg_addrequire(struct pkg *pkg, const char *name)
 		return (EPKG_OK);
 
 	storename = strdup(name);
+	if (storename == NULL) {
+		pkg_emit_errno("strdup", __func__);
+		return (EPKG_FATAL);
+	}
 
 	kh_add(strings, pkg->requires, storename, storename, free);
 
@@ -1194,6 +1366,10 @@ pkg_addprovide(struct pkg *pkg, const char *name)
 		return (EPKG_OK);
 
 	storename = strdup(name);
+	if (storename == NULL) {
+		pkg_emit_errno("strdup", __func__);
+		return (EPKG_FATAL);
+	}
 
 	kh_add(strings, pkg->provides, storename, storename, free);
 
@@ -1542,6 +1718,10 @@ pkg_validate(struct pkg *pkg, struct pkgdb *db)
 			return (EPKG_FATAL);
 
 		pkg->uid = strdup(pkg->name);
+		if (pkg->uid == NULL) {
+			pkg_emit_errno("strdup", __func__);
+			return (EPKG_FATAL);
+		}
 	}
 
 	if (pkg->digest == NULL || !pkg_checksum_is_valid(pkg->digest,
@@ -1790,6 +1970,10 @@ pkg_message_from_ucl(struct pkg *pkg, const ucl_object_t *obj)
 			return (EPKG_FATAL);
 		}
 		msg->str = strdup(ucl_object_tostring(obj));
+		if (msg->str == NULL) {
+			pkg_emit_errno("strdup", __func__);
+			return (EPKG_FATAL);
+		}
 		msg->type = PKG_MESSAGE_ALWAYS;
 		LL_APPEND(pkg->message, msg);
 		return (EPKG_OK);
@@ -1818,6 +2002,10 @@ pkg_message_from_ucl(struct pkg *pkg, const ucl_object_t *obj)
 		}
 
 		msg->str = strdup(ucl_object_tostring(elt));
+		if (msg->str == NULL) {
+			pkg_emit_errno("strdup", __func__);
+			return (EPKG_FATAL);
+		}
 		msg->type = PKG_MESSAGE_ALWAYS;
 		elt = ucl_object_find_key(cur, "type");
 		if (elt != NULL && ucl_object_type(elt) == UCL_STRING) {
@@ -1839,11 +2027,19 @@ pkg_message_from_ucl(struct pkg *pkg, const ucl_object_t *obj)
 		elt = ucl_object_find_key(cur, "minimum_version");
 		if (elt != NULL && ucl_object_type(elt) == UCL_STRING) {
 			msg->minimum_version = strdup(ucl_object_tostring(elt));
+			if (msg->minimum_version == NULL) {
+				pkg_emit_errno("strdup", __func__);
+				return (EPKG_FATAL);
+			}
 		}
 
 		elt = ucl_object_find_key(cur, "maximum_version");
 		if (elt != NULL && ucl_object_type(elt) == UCL_STRING) {
 			msg->maximum_version = strdup(ucl_object_tostring(elt));
+			if (msg->maximum_version == NULL) {
+				pkg_emit_errno("strdup", __func__);
+				return (EPKG_FATAL);
+			}
 		}
 
 		LL_APPEND(pkg->message, msg);

--- a/libpkg/pkg.c
+++ b/libpkg/pkg.c
@@ -44,7 +44,7 @@ int
 pkg_new(struct pkg **pkg, pkg_t type)
 {
 	if ((*pkg = calloc(1, sizeof(struct pkg))) == NULL) {
-		pkg_emit_errno("calloc", "pkg");
+		pkg_emit_errno("calloc", __func__);
 		return EPKG_FATAL;
 	}
 
@@ -1450,7 +1450,7 @@ pkg_open2(struct pkg **pkg_p, struct archive **a, struct archive_entry **ae,
 			size_t len = archive_entry_size(*ae);
 			buffer = malloc(len);
 			if (buffer == NULL) {
-				pkg_emit_errno("malloc", "pkg_open2");
+				pkg_emit_errno("malloc", __func__);
 				retcode = EPKG_FATAL;
 				/* Allow for archive handle to close. */
 				goto cleanup;
@@ -1472,7 +1472,7 @@ pkg_open2(struct pkg **pkg_p, struct archive **a, struct archive_entry **ae,
 			size_t len = archive_entry_size(*ae);
 			buffer = malloc(len);
 			if (buffer == NULL) {
-				pkg_emit_errno("malloc", "pkg_open2");
+				pkg_emit_errno("malloc", __func__);
 				retcode = EPKG_FATAL;
 				/* Allow for archive handle to close. */
 				goto cleanup;
@@ -1758,7 +1758,7 @@ pkg_open_root_fd(struct pkg *pkg)
 #else
 		if ((pkg->rootfd = dup(rootfd)) == -1 || fcntl(pkg->rootfd, F_SETFD, FD_CLOEXEC) == -1) {
 #endif
-			pkg_emit_errno("dup2", "rootfd");
+			pkg_emit_errno("dup2", __func__);
 			return (EPKG_FATAL);
 		}
 		return (EPKG_OK);
@@ -1770,7 +1770,7 @@ pkg_open_root_fd(struct pkg *pkg)
 		return (EPKG_OK);
 
 	pkg->rootpath[0] = '\0';
-	pkg_emit_errno("open", path);
+	pkg_emit_errno("open", __func__);
 
 	return (EPKG_FATAL);
 }
@@ -1786,7 +1786,7 @@ pkg_message_from_ucl(struct pkg *pkg, const ucl_object_t *obj)
 		msg = calloc(1, sizeof(*msg));
 
 		if (msg == NULL) {
-			pkg_emit_errno("malloc", "struct pkg_message");
+			pkg_emit_errno("malloc", __func__);
 			return (EPKG_FATAL);
 		}
 		msg->str = strdup(ucl_object_tostring(obj));
@@ -1813,7 +1813,7 @@ pkg_message_from_ucl(struct pkg *pkg, const ucl_object_t *obj)
 		msg = calloc(1, sizeof(*msg));
 
 		if (msg == NULL) {
-			pkg_emit_errno("malloc", "struct pkg_message");
+			pkg_emit_errno("malloc", __func__);
 			return (EPKG_FATAL);
 		}
 

--- a/libpkg/pkg.c
+++ b/libpkg/pkg.c
@@ -1449,6 +1449,12 @@ pkg_open2(struct pkg **pkg_p, struct archive **a, struct archive_entry **ae,
 
 			size_t len = archive_entry_size(*ae);
 			buffer = malloc(len);
+			if (buffer == NULL) {
+				pkg_emit_errno("malloc", "pkg_open2");
+				retcode = EPKG_FATAL;
+				/* Allow for archive handle to close. */
+				goto cleanup;
+			}
 			archive_read_data(*a, buffer, archive_entry_size(*ae));
 			ret = pkg_parse_manifest(pkg, buffer, len, keys);
 			free(buffer);
@@ -1465,6 +1471,12 @@ pkg_open2(struct pkg **pkg_p, struct archive **a, struct archive_entry **ae,
 
 			size_t len = archive_entry_size(*ae);
 			buffer = malloc(len);
+			if (buffer == NULL) {
+				pkg_emit_errno("malloc", "pkg_open2");
+				retcode = EPKG_FATAL;
+				/* Allow for archive handle to close. */
+				goto cleanup;
+			}
 			archive_read_data(*a, buffer, archive_entry_size(*ae));
 			ret = pkg_parse_manifest(pkg, buffer, len, keys);
 			free(buffer);

--- a/libpkg/pkg_add.c
+++ b/libpkg/pkg_add.c
@@ -174,6 +174,8 @@ attempt_to_merge(int rootfd, struct pkg_config_file *rcf, struct pkg *local,
 		pkg_emit_error("Impossible to merge configuration file");
 	} else {
 		rcf->newcontent = strdup(utstring_body(newconf));
+		if (rcf->newcontent == NULL)
+			pkg_emit_errno("strdup", __func__);
 		rcf->status = MERGE_SUCCESS;
 	}
 	utstring_free(newconf);
@@ -798,6 +800,8 @@ pkg_globmatch(char *pattern, const char *name)
 			path = g.gl_pathv[i];
 	}
 	path = strdup(path);
+	if (path == NULL)
+		pkg_emit_errno("strdup", __func__);
 	globfree(&g);
 
 	return (path);
@@ -1061,6 +1065,8 @@ pkg_add_common(struct pkgdb *db, const char *path, unsigned flags,
 
 		free(pkg->digest);
 		pkg->digest = strdup(remote->digest);
+		if (pkg->digest == NULL)
+			pkg_emit_errno("strdup", __func__);
 		/* only preserve flags is -A has not been passed */
 		if ((flags & PKG_ADD_AUTOMATIC) == 0)
 			pkg->automatic = remote->automatic;

--- a/libpkg/pkg_add.c
+++ b/libpkg/pkg_add.c
@@ -540,6 +540,10 @@ retry:
 			pkg_debug(1, "Populating config_file %s", f->path);
 			len = archive_entry_size(ae);
 			f->config->content = malloc(len + 1);
+			if (f->config->content == NULL) {
+				pkg_emit_errno("malloc", "create_regfile");
+				return (EPKG_FATAL);
+			}
 			archive_read_data(a, f->config->content, len);
 			f->config->content[len] = '\0';
 			cfdata = f->config->content;

--- a/libpkg/pkg_add.c
+++ b/libpkg/pkg_add.c
@@ -541,7 +541,7 @@ retry:
 			len = archive_entry_size(ae);
 			f->config->content = malloc(len + 1);
 			if (f->config->content == NULL) {
-				pkg_emit_errno("malloc", "create_regfile");
+				pkg_emit_errno("malloc", __func__);
 				return (EPKG_FATAL);
 			}
 			archive_read_data(a, f->config->content, len);

--- a/libpkg/pkg_attributes.c
+++ b/libpkg/pkg_attributes.c
@@ -229,7 +229,11 @@ pkg_kv_new(struct pkg_kv **c, const char *key, const char *val)
 		return (EPKG_FATAL);
 
 	(*c)->key = strdup(key);
+	if ((*c)->key == NULL)
+		pkg_emit_errno("strdup", __func__);
 	(*c)->value = strdup(val);
+	if ((*c)->value == NULL)
+		pkg_emit_errno("strdup", __func__);
 
 	return (EPKG_OK);
 }

--- a/libpkg/pkg_attributes.c
+++ b/libpkg/pkg_attributes.c
@@ -152,7 +152,7 @@ int
 pkg_option_new(struct pkg_option **option)
 {
 	if ((*option = calloc(1, sizeof(struct pkg_option))) == NULL) {
-		pkg_emit_errno("calloc", "pkg_option");
+		pkg_emit_errno("calloc", __func__);
 		return (EPKG_FATAL);
 	}
 	return (EPKG_OK);

--- a/libpkg/pkg_audit.c
+++ b/libpkg/pkg_audit.c
@@ -299,7 +299,7 @@ pkg_audit_fetch(const char *src, const char *dest)
 		    S_IRUSR|S_IRGRP|S_IROTH);
 	}
 	if (outfd == -1) {
-		pkg_emit_errno("pkg_audit_fetch", "open out fd");
+		pkg_emit_errno("pkg_audit_fetch", __func__);
 		goto cleanup;
 	}
 
@@ -341,8 +341,10 @@ pkg_audit_expand_entry(struct pkg_audit_entry *entry, struct pkg_audit_entry **h
 		LL_FOREACH(pcur->names, ncur) {
 			n = calloc(1, sizeof(struct pkg_audit_entry));
 			if (n == NULL) {
-				pkg_emit_errno("calloc", "pkg_audit_expand_entry");
-				return;
+				pkg_emit_errno("calloc", __func__);
+
+				/* Quit; previous logic was to use err() */
+				exit(1);
 			}
 			n->pkgname = ncur->pkgname;
 			/* Set new entry as reference entry */
@@ -392,7 +394,7 @@ vulnxml_start_element(void *data, const char *element, const char **attributes)
 	if (ud->state == VULNXML_PARSE_INIT && strcasecmp(element, "vuln") == 0) {
 		ud->cur_entry = calloc(1, sizeof(struct pkg_audit_entry));
 		if (ud->cur_entry == NULL) {
-			pkg_emit_errno("calloc", "vulnxml_start_element");
+			pkg_emit_errno("calloc", __func__);
 			return;
 		}
 		for (i = 0; attributes[i]; i += 2) {
@@ -410,7 +412,7 @@ vulnxml_start_element(void *data, const char *element, const char **attributes)
 	else if (ud->state == VULNXML_PARSE_VULN && strcasecmp(element, "package") == 0) {
 		pkg_entry = calloc(1, sizeof(struct pkg_audit_package));
 		if (pkg_entry == NULL) {
-			pkg_emit_errno("calloc", "vulnxml_start_element");
+			pkg_emit_errno("calloc", __func__);
 			return;
 		}
 		LL_PREPEND(ud->cur_entry->packages, pkg_entry);
@@ -423,7 +425,7 @@ vulnxml_start_element(void *data, const char *element, const char **attributes)
 		ud->state = VULNXML_PARSE_PACKAGE_NAME;
 		name_entry = calloc(1, sizeof(struct pkg_audit_pkgname));
 		if (name_entry == NULL) {
-			pkg_emit_errno("calloc", "vulnxml_start_element");
+			pkg_emit_errno("calloc", __func__);
 			return;
 		}
 		LL_PREPEND(ud->cur_entry->packages->names, name_entry);
@@ -432,7 +434,7 @@ vulnxml_start_element(void *data, const char *element, const char **attributes)
 		ud->state = VULNXML_PARSE_RANGE;
 		vers = calloc(1, sizeof(struct pkg_audit_versions_range));
 		if (vers == NULL) {
-			pkg_emit_errno("calloc", "vulnxml_start_element");
+			pkg_emit_errno("calloc", __func__);
 			return;
 		}
 		LL_PREPEND(ud->cur_entry->packages->versions, vers);
@@ -542,7 +544,7 @@ vulnxml_handle_data(void *data, const char *content, int length)
 		entry = ud->cur_entry;
 		cve = malloc(sizeof(struct pkg_audit_cve));
 		if (cve == NULL) {
-			pkg_emit_errno("malloc", "vulnxml_handle_data");
+			pkg_emit_errno("malloc", __func__);
 			return;
 		}
 		cve->cvename = strndup(content, length);
@@ -653,7 +655,7 @@ pkg_audit_preprocess(struct pkg_audit_entry *h)
 
 	ret = calloc(n + 1, sizeof(ret[0]));
 	if (ret == NULL) {
-		pkg_emit_errno("malloc", "pkg_audit_preprocess");
+		pkg_emit_errno("malloc", __func__);
 		return (NULL);
 	}
 	bzero((void *)ret, (n + 1) * sizeof(ret[0]));
@@ -873,7 +875,7 @@ pkg_audit_new(void)
 
 	audit = calloc(1, sizeof(struct pkg_audit));
 	if (audit == NULL) {
-		pkg_emit_errno("calloc", "pkg_audit_new");
+		pkg_emit_errno("calloc", __func__);
 		return (NULL);
 	}
 	return (audit);

--- a/libpkg/pkg_audit.c
+++ b/libpkg/pkg_audit.c
@@ -400,6 +400,8 @@ vulnxml_start_element(void *data, const char *element, const char **attributes)
 		for (i = 0; attributes[i]; i += 2) {
 			if (strcasecmp(attributes[i], "vid") == 0) {
 				ud->cur_entry->id = strdup(attributes[i + 1]);
+				if (ud->cur_entry->id == NULL)
+					pkg_emit_errno("strdup", __func__);
 				break;
 			}
 		}

--- a/libpkg/pkg_audit.c
+++ b/libpkg/pkg_audit.c
@@ -340,8 +340,10 @@ pkg_audit_expand_entry(struct pkg_audit_entry *entry, struct pkg_audit_entry **h
 	LL_FOREACH(entry->packages, pcur) {
 		LL_FOREACH(pcur->names, ncur) {
 			n = calloc(1, sizeof(struct pkg_audit_entry));
-			if (n == NULL)
-				err(1, "calloc(audit_entry)");
+			if (n == NULL) {
+				pkg_emit_errno("calloc", "pkg_audit_expand_entry");
+				return;
+			}
 			n->pkgname = ncur->pkgname;
 			/* Set new entry as reference entry */
 			n->ref = true;
@@ -389,8 +391,10 @@ vulnxml_start_element(void *data, const char *element, const char **attributes)
 
 	if (ud->state == VULNXML_PARSE_INIT && strcasecmp(element, "vuln") == 0) {
 		ud->cur_entry = calloc(1, sizeof(struct pkg_audit_entry));
-		if (ud->cur_entry == NULL)
-			err(1, "calloc(audit_entry)");
+		if (ud->cur_entry == NULL) {
+			pkg_emit_errno("calloc", "vulnxml_start_element");
+			return;
+		}
 		for (i = 0; attributes[i]; i += 2) {
 			if (strcasecmp(attributes[i], "vid") == 0) {
 				ud->cur_entry->id = strdup(attributes[i + 1]);
@@ -405,8 +409,10 @@ vulnxml_start_element(void *data, const char *element, const char **attributes)
 	}
 	else if (ud->state == VULNXML_PARSE_VULN && strcasecmp(element, "package") == 0) {
 		pkg_entry = calloc(1, sizeof(struct pkg_audit_package));
-		if (pkg_entry == NULL)
-			err(1, "calloc(audit_package_entry)");
+		if (pkg_entry == NULL) {
+			pkg_emit_errno("calloc", "vulnxml_start_element");
+			return;
+		}
 		LL_PREPEND(ud->cur_entry->packages, pkg_entry);
 		ud->state = VULNXML_PARSE_PACKAGE;
 	}
@@ -416,15 +422,19 @@ vulnxml_start_element(void *data, const char *element, const char **attributes)
 	else if (ud->state == VULNXML_PARSE_PACKAGE && strcasecmp(element, "name") == 0) {
 		ud->state = VULNXML_PARSE_PACKAGE_NAME;
 		name_entry = calloc(1, sizeof(struct pkg_audit_pkgname));
-		if (name_entry == NULL)
-			err(1, "calloc(audit_pkgname_entry)");
+		if (name_entry == NULL) {
+			pkg_emit_errno("calloc", "vulnxml_start_element");
+			return;
+		}
 		LL_PREPEND(ud->cur_entry->packages->names, name_entry);
 	}
 	else if (ud->state == VULNXML_PARSE_PACKAGE && strcasecmp(element, "range") == 0) {
 		ud->state = VULNXML_PARSE_RANGE;
 		vers = calloc(1, sizeof(struct pkg_audit_versions_range));
-		if (vers == NULL)
-			err(1, "calloc(audit_versions)");
+		if (vers == NULL) {
+			pkg_emit_errno("calloc", "vulnxml_start_element");
+			return;
+		}
 		LL_PREPEND(ud->cur_entry->packages->versions, vers);
 		ud->range_num = 0;
 	}
@@ -531,6 +541,10 @@ vulnxml_handle_data(void *data, const char *content, int length)
 	case VULNXML_PARSE_CVE:
 		entry = ud->cur_entry;
 		cve = malloc(sizeof(struct pkg_audit_cve));
+		if (cve == NULL) {
+			pkg_emit_errno("malloc", "vulnxml_handle_data");
+			return;
+		}
 		cve->cvename = strndup(content, length);
 		LL_PREPEND(entry->cve, cve);
 		break;
@@ -637,9 +651,11 @@ pkg_audit_preprocess(struct pkg_audit_entry *h)
 	LL_FOREACH(h, e)
 		n++;
 
-	ret = (struct pkg_audit_item *)calloc(n + 1, sizeof(ret[0]));
-	if (ret == NULL)
-		err(1, "calloc(audit_entry_sorted*)");
+	ret = calloc(n + 1, sizeof(ret[0]));
+	if (ret == NULL) {
+		pkg_emit_errno("malloc", "pkg_audit_preprocess");
+		return (NULL);
+	}
 	bzero((void *)ret, (n + 1) * sizeof(ret[0]));
 
 	n = 0;
@@ -856,7 +872,10 @@ pkg_audit_new(void)
 	struct pkg_audit *audit;
 
 	audit = calloc(1, sizeof(struct pkg_audit));
-
+	if (audit == NULL) {
+		pkg_emit_errno("calloc", "pkg_audit_new");
+		return (NULL);
+	}
 	return (audit);
 }
 

--- a/libpkg/pkg_checksum.c
+++ b/libpkg/pkg_checksum.c
@@ -175,7 +175,7 @@ pkg_checksum_add_entry(const char *key,
 
 	e = malloc(sizeof(*e));
 	if (e == NULL) {
-		pkg_emit_errno("malloc", "pkg_checksum_entry");
+		pkg_emit_errno("malloc", __func__);
 		return;
 	}
 
@@ -381,7 +381,7 @@ pkg_checksum_hash_sha256(struct pkg_checksum_entry *entries,
 	}
 	*out = malloc(SHA256_BLOCK_SIZE);
 	if (*out == NULL) {
-		pkg_emit_errno("malloc", "pkg_checksum_hash_sha256");
+		pkg_emit_errno("malloc", __func__);
 		*outlen = 0;
 		return;
 	}
@@ -398,7 +398,7 @@ pkg_checksum_hash_sha256_bulk(const unsigned char *in, size_t inlen,
 
 	*out = malloc(SHA256_BLOCK_SIZE);
 	if (*out == NULL) {
-		pkg_emit_errno("malloc", "pkg_checksum_hash_sha256_bulk");
+		pkg_emit_errno("malloc", __func__);
 		*outlen = 0;
 		return;
 	}
@@ -417,7 +417,7 @@ pkg_checksum_hash_sha256_file(int fd, unsigned char **out, size_t *outlen)
 	SHA256_CTX sign_ctx;
 	*out = malloc(SHA256_BLOCK_SIZE);
 	if (*out == NULL) {
-		pkg_emit_errno("malloc", "pkg_checksum_hash_sha256_file");
+		pkg_emit_errno("malloc", __func__);
 		*outlen = 0;
 		return;
 	}
@@ -443,7 +443,7 @@ pkg_checksum_hash_blake2(struct pkg_checksum_entry *entries,
 	}
 	*out = malloc(BLAKE2B_OUTBYTES);
 	if (*out == NULL) {
-		pkg_emit_errno("malloc", "pkg_checksum_hash_blake2");
+		pkg_emit_errno("malloc", __func__);
 		*outlen = 0;
 		return;
 	}
@@ -457,7 +457,7 @@ pkg_checksum_hash_blake2_bulk(const unsigned char *in, size_t inlen,
 {
 	*out = malloc(BLAKE2B_OUTBYTES);
 	if (*out == NULL) {
-		pkg_emit_errno("malloc", "pkg_checksum_hash_blake2_bulk");
+		pkg_emit_errno("malloc", __func__);
 		*outlen = 0;
 		return;
 	}
@@ -479,7 +479,7 @@ pkg_checksum_hash_blake2_file(int fd, unsigned char **out, size_t *outlen)
 
 	*out = malloc(BLAKE2B_OUTBYTES);
 	if (*out == NULL) {
-		pkg_emit_errno("malloc", "pkg_checksum_hash_blake2_file");
+		pkg_emit_errno("malloc", __func__);
 		*outlen = 0;
 		return;
 	}
@@ -502,7 +502,7 @@ pkg_checksum_hash_blake2s(struct pkg_checksum_entry *entries,
 	}
 	*out = malloc(BLAKE2S_OUTBYTES);
 	if (*out == NULL) {
-		pkg_emit_errno("malloc", "pkg_checksum_hash_blake2s");
+		pkg_emit_errno("malloc", __func__);
 		*outlen = 0;
 		return;
 	}
@@ -516,7 +516,7 @@ pkg_checksum_hash_blake2s_bulk(const unsigned char *in, size_t inlen,
 {
 	*out = malloc(BLAKE2S_OUTBYTES);
 	if (*out == NULL) {
-		pkg_emit_errno("malloc", "pkg_checksum_hash_blake2s_bulk");
+		pkg_emit_errno("malloc", __func__);
 		*outlen = 0;
 		return;
 	}
@@ -538,7 +538,7 @@ pkg_checksum_hash_blake2s_file(int fd, unsigned char **out, size_t *outlen)
 
 	*out = malloc(BLAKE2S_OUTBYTES);
 	if (*out == NULL) {
-		pkg_emit_errno("malloc", "pkg_checksum_hash_blake2s_file");
+		pkg_emit_errno("malloc", __func__);
 		*outlen = 0;
 		return;
 	}
@@ -674,7 +674,7 @@ pkg_checksum_calculate(struct pkg *pkg, struct pkgdb *db)
 
 	new_digest = malloc(pkg_checksum_type_size(type));
 	if (new_digest == NULL) {
-		pkg_emit_errno("malloc", "pkg_checksum_type_t");
+		pkg_emit_errno("malloc", __func__);
 		return (EPKG_FATAL);
 	}
 
@@ -717,7 +717,7 @@ pkg_checksum_data(const unsigned char *in, size_t inlen,
 		if (cksum->encfunc != NULL) {
 			res = malloc(cksum->hlen);
 			if (res == NULL) {
-				pkg_emit_errno("malloc", "pkg_checksum_data");
+				pkg_emit_errno("malloc", __func__);
 				free(out);
 				return (NULL);
 			}
@@ -739,7 +739,7 @@ pkg_checksum_fileat(int rootfd, const char *path, pkg_checksum_type_t type)
 	unsigned char *ret;
 
 	if ((fd = openat(rootfd, path, O_RDONLY)) == -1) {
-		pkg_emit_errno("open", path);
+		pkg_emit_errno("open", __func__);
 		return (NULL);
 	}
 
@@ -757,7 +757,7 @@ pkg_checksum_file(const char *path, pkg_checksum_type_t type)
 	unsigned char *ret;
 
 	if ((fd = open(path, O_RDONLY)) == -1) {
-		pkg_emit_errno("open", path);
+		pkg_emit_errno("open", __func__);
 		return (NULL);
 	}
 
@@ -784,7 +784,7 @@ pkg_checksum_fd(int fd, pkg_checksum_type_t type)
 		if (cksum->encfunc != NULL) {
 			res = malloc(cksum->hlen);
 			if (res == NULL) {
-				pkg_emit_errno("malloc", "pkg_checksum_data");
+				pkg_emit_errno("malloc", __func__);
 				free(out);
 				return (NULL);
 			}
@@ -820,7 +820,7 @@ pkg_checksum_symlink(const char *path, pkg_checksum_type_t type)
 	int linklen;
 
 	if ((linklen = readlink(path, linkbuf, sizeof(linkbuf) - 1)) == -1) {
-		pkg_emit_errno("pkg_checksum_symlink", "readlink failed");
+		pkg_emit_errno("pkg_checksum_symlink", __func__);
 		return (NULL);
 	}
 	linkbuf[linklen] = '\0';
@@ -835,7 +835,7 @@ pkg_checksum_symlinkat(int fd, const char *path, pkg_checksum_type_t type)
 	int linklen;
 
 	if ((linklen = readlinkat(fd, path, linkbuf, sizeof(linkbuf) - 1)) == -1) {
-		pkg_emit_errno("pkg_checksum_symlinkat", "readlink failed");
+		pkg_emit_errno("pkg_checksum_symlinkat", __func__);
 		return (NULL);
 	}
 	linkbuf[linklen] = '\0';
@@ -889,7 +889,7 @@ pkg_checksum_generate_file(const char *path, pkg_checksum_type_t type)
 	char *cksum;
 
 	if (lstat(path, &st) == -1) {
-		pkg_emit_errno("pkg_checksum_generate_file", "lstat");
+		pkg_emit_errno("pkg_checksum_generate_file", __func__);
 		return (NULL);
 	}
 
@@ -954,7 +954,7 @@ pkg_checksum_generate_fileat(int rootfd, const char *path,
 	char *cksum;
 
 	if (fstatat(rootfd, path, &st, AT_SYMLINK_NOFOLLOW) == -1) {
-		pkg_emit_errno("pkg_checksum_generate_file", "lstat");
+		pkg_emit_errno("pkg_checksum_generate_file", __func__);
 		return (NULL);
 	}
 

--- a/libpkg/pkg_checksum.c
+++ b/libpkg/pkg_checksum.c
@@ -181,6 +181,8 @@ pkg_checksum_add_entry(const char *key,
 
 	e->field = key;
 	e->value = strdup(value);
+	if (e->value == NULL)
+		pkg_emit_errno("strdup", __func__);
 	DL_APPEND(*entries, e);
 }
 

--- a/libpkg/pkg_checksum.c
+++ b/libpkg/pkg_checksum.c
@@ -380,14 +380,14 @@ pkg_checksum_hash_sha256(struct pkg_checksum_entry *entries,
 		entries = entries->next;
 	}
 	*out = malloc(SHA256_BLOCK_SIZE);
-	if (*out != NULL) {
-		sha256_final(&sign_ctx, *out);
-		*outlen = SHA256_BLOCK_SIZE;
-	}
-	else {
+	if (*out == NULL) {
 		pkg_emit_errno("malloc", "pkg_checksum_hash_sha256");
 		*outlen = 0;
+		return;
 	}
+
+	sha256_final(&sign_ctx, *out);
+	*outlen = SHA256_BLOCK_SIZE;
 }
 
 static void
@@ -397,6 +397,11 @@ pkg_checksum_hash_sha256_bulk(const unsigned char *in, size_t inlen,
 	SHA256_CTX sign_ctx;
 
 	*out = malloc(SHA256_BLOCK_SIZE);
+	if (*out == NULL) {
+		pkg_emit_errno("malloc", "pkg_checksum_hash_sha256_bulk");
+		*outlen = 0;
+		return;
+	}
 	sha256_init(&sign_ctx);
 	sha256_update(&sign_ctx, in, inlen);
 	sha256_final(&sign_ctx, *out);
@@ -411,6 +416,11 @@ pkg_checksum_hash_sha256_file(int fd, unsigned char **out, size_t *outlen)
 
 	SHA256_CTX sign_ctx;
 	*out = malloc(SHA256_BLOCK_SIZE);
+	if (*out == NULL) {
+		pkg_emit_errno("malloc", "pkg_checksum_hash_sha256_file");
+		*outlen = 0;
+		return;
+	}
 	sha256_init(&sign_ctx);
 	while ((r = read(fd, buffer, sizeof(buffer))) > 0)
 		sha256_update(&sign_ctx, buffer, r);
@@ -432,14 +442,13 @@ pkg_checksum_hash_blake2(struct pkg_checksum_entry *entries,
 		entries = entries->next;
 	}
 	*out = malloc(BLAKE2B_OUTBYTES);
-	if (*out != NULL) {
-		blake2b_final (&st, *out, BLAKE2B_OUTBYTES);
-		*outlen = BLAKE2B_OUTBYTES;
-	}
-	else {
+	if (*out == NULL) {
 		pkg_emit_errno("malloc", "pkg_checksum_hash_blake2");
 		*outlen = 0;
+		return;
 	}
+	blake2b_final (&st, *out, BLAKE2B_OUTBYTES);
+	*outlen = BLAKE2B_OUTBYTES;
 }
 
 static void
@@ -447,6 +456,11 @@ pkg_checksum_hash_blake2_bulk(const unsigned char *in, size_t inlen,
 				unsigned char **out, size_t *outlen)
 {
 	*out = malloc(BLAKE2B_OUTBYTES);
+	if (*out == NULL) {
+		pkg_emit_errno("malloc", "pkg_checksum_hash_blake2_bulk");
+		*outlen = 0;
+		return;
+	}
 	blake2b(*out, BLAKE2B_OUTBYTES,  in, inlen, NULL, 0);
 	*outlen = BLAKE2B_OUTBYTES;
 }
@@ -464,6 +478,11 @@ pkg_checksum_hash_blake2_file(int fd, unsigned char **out, size_t *outlen)
 		blake2b_update(&st, buffer, r);
 
 	*out = malloc(BLAKE2B_OUTBYTES);
+	if (*out == NULL) {
+		pkg_emit_errno("malloc", "pkg_checksum_hash_blake2_file");
+		*outlen = 0;
+		return;
+	}
 	blake2b_final(&st, *out, BLAKE2B_OUTBYTES);
 	*outlen = BLAKE2B_OUTBYTES;
 }
@@ -482,14 +501,13 @@ pkg_checksum_hash_blake2s(struct pkg_checksum_entry *entries,
 		entries = entries->next;
 	}
 	*out = malloc(BLAKE2S_OUTBYTES);
-	if (*out != NULL) {
-		blake2s_final (&st, *out, BLAKE2S_OUTBYTES);
-		*outlen = BLAKE2S_OUTBYTES;
-	}
-	else {
+	if (*out == NULL) {
 		pkg_emit_errno("malloc", "pkg_checksum_hash_blake2s");
 		*outlen = 0;
+		return;
 	}
+	blake2s_final (&st, *out, BLAKE2S_OUTBYTES);
+	*outlen = BLAKE2S_OUTBYTES;
 }
 
 static void
@@ -497,6 +515,11 @@ pkg_checksum_hash_blake2s_bulk(const unsigned char *in, size_t inlen,
 				unsigned char **out, size_t *outlen)
 {
 	*out = malloc(BLAKE2S_OUTBYTES);
+	if (*out == NULL) {
+		pkg_emit_errno("malloc", "pkg_checksum_hash_blake2s_bulk");
+		*outlen = 0;
+		return;
+	}
 	blake2s(*out, BLAKE2S_OUTBYTES,  in, inlen, NULL, 0);
 	*outlen = BLAKE2S_OUTBYTES;
 }
@@ -514,6 +537,11 @@ pkg_checksum_hash_blake2s_file(int fd, unsigned char **out, size_t *outlen)
 		blake2s_update(&st, buffer, r);
 
 	*out = malloc(BLAKE2S_OUTBYTES);
+	if (*out == NULL) {
+		pkg_emit_errno("malloc", "pkg_checksum_hash_blake2s_file");
+		*outlen = 0;
+		return;
+	}
 	blake2s_final(&st, *out, BLAKE2S_OUTBYTES);
 	*outlen = BLAKE2S_OUTBYTES;
 }
@@ -688,6 +716,11 @@ pkg_checksum_data(const unsigned char *in, size_t inlen,
 	if (out != NULL) {
 		if (cksum->encfunc != NULL) {
 			res = malloc(cksum->hlen);
+			if (res == NULL) {
+				pkg_emit_errno("malloc", "pkg_checksum_data");
+				free(out);
+				return (NULL);
+			}
 			cksum->encfunc(out, outlen, res, cksum->hlen);
 			free(out);
 		}
@@ -750,6 +783,11 @@ pkg_checksum_fd(int fd, pkg_checksum_type_t type)
 	if (out != NULL) {
 		if (cksum->encfunc != NULL) {
 			res = malloc(cksum->hlen);
+			if (res == NULL) {
+				pkg_emit_errno("malloc", "pkg_checksum_data");
+				free(out);
+				return (NULL);
+			}
 			cksum->encfunc(out, outlen, res, cksum->hlen);
 			free(out);
 		} else {

--- a/libpkg/pkg_config.c
+++ b/libpkg/pkg_config.c
@@ -441,13 +441,13 @@ connect_evpipe(const char *evpipe) {
 	if (S_ISFIFO(st.st_mode)) {
 		flag |= O_NONBLOCK;
 		if ((eventpipe = open(evpipe, flag)) == -1)
-			pkg_emit_errno("open event pipe", evpipe);
+			pkg_emit_errno("open event pipe", __func__);
 		return;
 	}
 
 	if (S_ISSOCK(st.st_mode)) {
 		if ((eventpipe = socket(AF_UNIX, SOCK_STREAM, 0)) == -1) {
-			pkg_emit_errno("Open event pipe", evpipe);
+			pkg_emit_errno("Open event pipe", __func__);
 			return;
 		}
 		memset(&sock, 0, sizeof(struct sockaddr_un));
@@ -461,7 +461,7 @@ connect_evpipe(const char *evpipe) {
 		}
 
 		if (connect(eventpipe, (struct sockaddr *)&sock, SUN_LEN(&sock)) == -1) {
-			pkg_emit_errno("Connect event pipe", evpipe);
+			pkg_emit_errno("Connect event pipe", __func__);
 			close(eventpipe);
 			eventpipe = -1;
 			return;

--- a/libpkg/pkg_config.c
+++ b/libpkg/pkg_config.c
@@ -636,11 +636,15 @@ add_repo(const ucl_object_t *obj, struct pkg_repo *r, const char *rname, pkg_ini
 	if (fingerprints != NULL) {
 		free(r->fingerprints);
 		r->fingerprints = strdup(fingerprints);
+		if (r->fingerprints == NULL)
+			pkg_emit_errno("strdup", __func__);
 	}
 
 	if (pubkey != NULL) {
 		free(r->pubkey);
 		r->pubkey = strdup(pubkey);
+		if (r->pubkey == NULL)
+			pkg_emit_errno("strdup", __func__);
 	}
 
 	r->enable = enable;
@@ -1236,13 +1240,19 @@ pkg_repo_new(const char *name, const char *url, const char *type)
 	struct pkg_repo *r;
 
 	r = calloc(1, sizeof(struct pkg_repo));
+	if (r == NULL)
+		pkg_emit_errno("calloc", __func__);
 	r->ops = pkg_repo_find_type(type);
 	r->url = strdup(url);
+	if (r->url == NULL)
+		pkg_emit_errno("strdup", __func__);
 	r->signature_type = SIG_NONE;
 	r->mirror_type = NOMIRROR;
 	r->enable = true;
 	r->meta = pkg_repo_meta_default();
 	r->name = strdup(name);
+	if (r->name == NULL)
+		pkg_emit_errno("strdup", __func__);
 	HASH_ADD_KEYPTR(hh, repos, r->name, strlen(r->name), r);
 
 	return (r);
@@ -1255,9 +1265,13 @@ pkg_repo_overwrite(struct pkg_repo *r, const char *name, const char *url,
 
 	free(r->name);
 	r->name = strdup(name);
+	if (r->name == NULL)
+		pkg_emit_errno("strdup", __func__);
 	if (url != NULL) {
 		free(r->url);
 		r->url = strdup(url);
+		if (r->url == NULL)
+			pkg_emit_errno("strdup", __func__);
 	}
 	r->ops = pkg_repo_find_type(type);
 	HASH_DEL(repos, r);

--- a/libpkg/pkg_create.c
+++ b/libpkg/pkg_create.c
@@ -182,7 +182,7 @@ pkg_create_archive(const char *outdir, struct pkg *pkg, pkg_formats format,
 		return NULL;
 
 	if (pkg_asprintf(&pkg_path, "%S/%n-%v", outdir, pkg, pkg) == -1) {
-		pkg_emit_errno("pkg_asprintf", "");
+		pkg_emit_errno("pkg_asprintf", __func__);
 		return (NULL);
 	}
 
@@ -316,7 +316,7 @@ pkg_load_metadata(struct pkg *pkg, const char *mfile, const char *md_dir,
 
 	if (md_dir != NULL &&
 	    (mfd = open(md_dir, O_DIRECTORY|O_CLOEXEC)) == -1) {
-		pkg_emit_errno("open", md_dir);
+		pkg_emit_errno("open", __func__);
 		goto cleanup;
 	}
 

--- a/libpkg/pkg_create.c
+++ b/libpkg/pkg_create.c
@@ -348,6 +348,8 @@ pkg_load_metadata(struct pkg *pkg, const char *mfile, const char *md_dir,
 	if (pkg->abi == NULL) {
 		pkg_get_myarch(arch, BUFSIZ);
 		pkg->abi = strdup(arch);
+		if (pkg->abi == NULL)
+			pkg_emit_errno("strdup", __func__);
 		defaultarch = true;
 	}
 
@@ -375,6 +377,8 @@ pkg_load_metadata(struct pkg *pkg, const char *mfile, const char *md_dir,
 			pkg->www = strndup(&pkg->desc[pmatch[1].rm_so], size);
 		} else {
 			pkg->www = strdup("UNKNOWN");
+			if (pkg->www == NULL)
+				pkg_emit_errno("strdup", __func__);
 		}
 		regfree(&preg);
 	}

--- a/libpkg/pkg_cudf.c
+++ b/libpkg/pkg_cudf.c
@@ -336,7 +336,7 @@ pkg_jobs_cudf_insert_res_job (struct pkg_solved **target,
 
 	res = calloc(1, sizeof(struct pkg_solved));
 	if (res == NULL) {
-		pkg_emit_errno("calloc", "pkg_solved");
+		pkg_emit_errno("calloc", __func__);
 		return;
 	}
 

--- a/libpkg/pkg_delete.c
+++ b/libpkg/pkg_delete.c
@@ -239,7 +239,7 @@ rmdir_p(struct pkgdb *db, struct pkg *pkg, char *dir, const char *prefix_r)
 
 	if (unlinkat(pkg->rootfd, dir, AT_REMOVEDIR) == -1) {
 		if (errno != ENOTEMPTY && errno != EBUSY)
-			pkg_emit_errno("unlinkat", dir);
+			pkg_emit_errno("unlinkat", __func__);
 		/* If the directory was already removed by a bogus script, continue removing parents */
 		if (errno != ENOENT)
 			return;
@@ -342,7 +342,7 @@ pkg_delete_file(struct pkg *pkg, struct pkg_file *file, unsigned force)
 			if (errno == ENOENT)
 				pkg_emit_file_missing(pkg, file);
 			else
-				pkg_emit_errno("unlinkat", path);
+				pkg_emit_errno("unlinkat", __func__);
 		}
 		return;
 	}

--- a/libpkg/pkg_delete.c
+++ b/libpkg/pkg_delete.c
@@ -169,6 +169,8 @@ pkg_add_dir_to_del(struct pkg *pkg, const char *file, const char *dir)
 			    pkg->dir_to_del[i], path);
 			free(pkg->dir_to_del[i]);
 			pkg->dir_to_del[i] = strdup(path);
+			if (pkg->dir_to_del[i] == NULL)
+				pkg_emit_errno("strdup", __func__);
 			return;
 		}
 	}
@@ -179,9 +181,13 @@ pkg_add_dir_to_del(struct pkg *pkg, const char *file, const char *dir)
 		pkg->dir_to_del_cap += 64;
 		pkg->dir_to_del = realloc(pkg->dir_to_del,
 		    pkg->dir_to_del_cap * sizeof(char *));
+		if (pkg->dir_to_del == NULL)
+			pkg_emit_errno("realloc", __func__);
 	}
 
 	pkg->dir_to_del[pkg->dir_to_del_len++] = strdup(path);
+	if (pkg->dir_to_del[pkg->dir_to_del_len++] == NULL)
+		pkg_emit_errno("strdup", __func__);
 }
 
 static void
@@ -408,8 +414,12 @@ pkg_delete_dir(struct pkg *pkg, struct pkg_dir *dir)
 			pkg->dir_to_del_cap += 64;
 			pkg->dir_to_del = realloc(pkg->dir_to_del,
 			    pkg->dir_to_del_cap * sizeof(char *));
+			if (pkg->dir_to_del == NULL)
+				pkg_emit_errno("realloc", __func__);
 		}
 		pkg->dir_to_del[pkg->dir_to_del_len++] = strdup(path);
+		if (pkg->dir_to_del[pkg->dir_to_del_len++] == NULL)
+			pkg_emit_errno("strdup", __func__);
 	}
 }
 

--- a/libpkg/pkg_deps.c
+++ b/libpkg/pkg_deps.c
@@ -84,14 +84,16 @@ pkg_deps_parse_formula(const char *in)
 					cur_item = calloc(1, sizeof(*cur_item));
 
 					if (cur_item == NULL) {
-						pkg_emit_errno("malloc", "struct pkg_dep_formula_item");
+						pkg_emit_errno("malloc",
+							       __func__);
 
 						return (NULL);
 					}
 					cur_item->name = malloc(p - c + 1);
 
 					if (cur_item->name == NULL) {
-						pkg_emit_errno("malloc", "cur->name");
+						pkg_emit_errno("malloc",
+							       __func__);
 
 						return (NULL);
 					}
@@ -108,14 +110,16 @@ pkg_deps_parse_formula(const char *in)
 					cur_item = calloc(1, sizeof(*cur_item));
 
 					if (cur_item == NULL) {
-						pkg_emit_errno("malloc", "struct pkg_dep_formula_item");
+						pkg_emit_errno("malloc",
+							       __func__);
 
 						return (NULL);
 					}
 					cur_item->name = malloc(p - c + 1);
 
 					if (cur_item->name == NULL) {
-						pkg_emit_errno("malloc", "cur->name");
+						pkg_emit_errno("malloc",
+							       __func__);
 
 						return (NULL);
 					}
@@ -238,14 +242,16 @@ pkg_deps_parse_formula(const char *in)
 					cur_ver = calloc(1, sizeof(*cur_ver));
 
 					if (cur_ver == NULL) {
-						pkg_emit_errno("malloc", "struct pkg_dep_version");
+						pkg_emit_errno("malloc",
+							       __func__);
 
 						return (NULL);
 					}
 					cur_ver->ver = malloc(p - c + 1);
 
 					if (cur_ver->ver == NULL) {
-						pkg_emit_errno("malloc", "cur_ver->ver");
+						pkg_emit_errno("malloc",
+							       __func__);
 
 						return (NULL);
 					}
@@ -266,7 +272,7 @@ pkg_deps_parse_formula(const char *in)
 		case st_parse_option_start:
 			cur_opt = calloc(1, sizeof(*cur_opt));
 			if (cur_opt == NULL) {
-				pkg_emit_errno("malloc", "struct pkg_dep_option");
+				pkg_emit_errno("malloc", __func__);
 
 				return (NULL);
 			}
@@ -292,7 +298,8 @@ pkg_deps_parse_formula(const char *in)
 					cur_opt->opt = malloc(p - c + 1);
 
 					if (cur_opt->opt == NULL) {
-						pkg_emit_errno("malloc", "cur_opt->opt");
+						pkg_emit_errno("malloc",
+							       __func__);
 
 						return (NULL);
 					}
@@ -316,7 +323,7 @@ pkg_deps_parse_formula(const char *in)
 				cur = calloc(1, sizeof(*cur));
 
 				if (cur == NULL) {
-					pkg_emit_errno("malloc", "struct pkg_dep_formula");
+					pkg_emit_errno("malloc", __func__);
 
 					return (NULL);
 				}
@@ -338,7 +345,7 @@ pkg_deps_parse_formula(const char *in)
 				cur = calloc(1, sizeof(*cur));
 
 				if (cur == NULL) {
-					pkg_emit_errno("malloc", "struct pkg_dep_formula");
+					pkg_emit_errno("malloc", __func__);
 
 					return (NULL);
 				}
@@ -489,7 +496,7 @@ pkg_deps_formula_tostring(struct pkg_dep_formula *f)
 	res = malloc(rlen + 1);
 
 	if (res == NULL) {
-		pkg_emit_errno("malloc", "string");
+		pkg_emit_errno("malloc", __func__);
 
 		return (NULL);
 	}
@@ -556,7 +563,7 @@ pkg_deps_formula_tosql(struct pkg_dep_formula_item *f)
 	res = malloc(rlen + 1);
 
 	if (res == NULL) {
-		pkg_emit_errno("malloc", "string");
+		pkg_emit_errno("malloc", __func__);
 
 		return (NULL);
 	}

--- a/libpkg/pkg_elf.c
+++ b/libpkg/pkg_elf.c
@@ -263,7 +263,7 @@ analyse_elf(struct pkg *pkg, const char *fpath)
 
 	pkg_debug(1, "analysing elf %s", fpath);
 	if (lstat(fpath, &sb) != 0)
-		pkg_emit_errno("fstat() failed for", fpath);
+		pkg_emit_errno("fstat() failed for", __func__);
 	/* ignore empty files and non regular files */
 	if (sb.st_size == 0 || !S_ISREG(sb.st_mode))
 		return (EPKG_END); /* Empty file or sym-link: no results */
@@ -724,7 +724,7 @@ pkg_get_myarch_elfparse(char *dest, size_t sz)
 	}
 
 	if ((fd = open(path, O_RDONLY)) < 0) {
-		pkg_emit_errno("open", _PATH_BSHELL);
+		pkg_emit_errno("open", __func__);
 		snprintf(dest, sz, "%s", "unknown");
 		return (EPKG_FATAL);
 	}

--- a/libpkg/pkg_jobs.c
+++ b/libpkg/pkg_jobs.c
@@ -207,6 +207,11 @@ pkg_jobs_maybe_match_file(struct job_pattern *jp, const char *pattern)
 				jp->is_file = true;
 				jp->path = pkg_path;
 				jp->pattern = malloc(len);
+				if (jp->pattern == NULL) {
+					pkg_emit_errno("malloc",
+					    "pkg_jobs_maybe_match_file");
+					return (false);
+				}
 				strlcpy(jp->pattern, pattern, len);
 
 				return (true);
@@ -239,6 +244,10 @@ pkg_jobs_add(struct pkg_jobs *j, match_t match, char **argv, int argc)
 
 	for (i = 0; i < argc; i++) {
 		jp = calloc(1, sizeof(struct job_pattern));
+		if (jp == NULL) {
+			pkg_emit_errno("malloc", "pkg_jobs_add");
+			return (EPKG_FATAL);
+		}
 		if (j->type == PKG_JOBS_DEINSTALL ||
 		    !pkg_jobs_maybe_match_file(jp, argv[i])) {
 			jp->pattern = strdup(argv[i]);
@@ -249,6 +258,10 @@ pkg_jobs_add(struct pkg_jobs *j, match_t match, char **argv, int argc)
 
 	if (argc == 0 && match == MATCH_ALL) {
 		jp = calloc(1, sizeof(struct job_pattern));
+		if (jp == NULL) {
+			pkg_emit_errno("malloc", "pkg_jobs_add");
+			return (EPKG_FATAL);
+		}
 		jp->pattern = NULL;
 		jp->match = match;
 		HASH_ADD_KEYPTR(hh, j->patterns, "all", 3, jp);
@@ -402,6 +415,7 @@ pkg_jobs_add_req(struct pkg_jobs *j, struct pkg *pkg)
 	nit = calloc(1, sizeof(*nit));
 	if (nit == NULL) {
 		pkg_emit_errno("malloc", "struct pkg_job_request_item");
+		free(nit);
 		return (NULL);
 	}
 	nit->pkg = pkg;
@@ -887,6 +901,11 @@ pkg_jobs_guess_upgrade_candidate(struct pkg_jobs *j, const char *pattern)
 	if (olen != len) {
 		/* Try exact pattern without numbers */
 		cpy = malloc(len + 1);
+		if (cpy == NULL) {
+			pkg_emit_errno("malloc",
+			    "pkg_jobs_guess_upgrade_candidate");
+			return (EPKG_FATAL);
+		}
 		strlcpy(cpy, pos, len + 1);
 		if (pkg_jobs_try_remote_candidate(j, cpy, opattern, MATCH_EXACT) != EPKG_OK) {
 			free(cpy);

--- a/libpkg/pkg_jobs.c
+++ b/libpkg/pkg_jobs.c
@@ -223,7 +223,11 @@ pkg_jobs_maybe_match_file(struct job_pattern *jp, const char *pattern)
 		 */
 		jp->is_file = true;
 		jp->path = strdup(pattern);
+		if (jp->path == NULL)
+			pkg_emit_errno("strdup", __func__);
 		jp->pattern = strdup(pattern);
+		if (jp->pattern == NULL)
+			pkg_emit_errno("strdup", __func__);
 	}
 
 	return (false);
@@ -250,6 +254,10 @@ pkg_jobs_add(struct pkg_jobs *j, match_t match, char **argv, int argc)
 		if (j->type == PKG_JOBS_DEINSTALL ||
 		    !pkg_jobs_maybe_match_file(jp, argv[i])) {
 			jp->pattern = strdup(argv[i]);
+			if (jp->pattern == NULL) {
+				pkg_emit_errno("strdup", __func__);
+				return (EPKG_FATAL);
+			}
 			jp->match = match;
 		}
 		HASH_ADD_KEYPTR(hh, j->patterns, jp->pattern, strlen(jp->pattern), jp);
@@ -1180,12 +1188,16 @@ pkg_jobs_need_upgrade(struct pkg *rp, struct pkg *lp)
 		if (ret1 != ret2) {
 			free(rp->reason);
 			rp->reason = strdup("direct conflict changed");
+			if (rp->reason == NULL)
+				pkg_emit_errno("strdup", __func__);
 			return (true);
 		}
 		if (ret1 == EPKG_OK) {
 			if (strcmp(rc->uid, lc->uid) != 0) {
 				free(rp->reason);
 				rp->reason = strdup("direct conflict changed");
+				if (rp->reason == NULL)
+					pkg_emit_errno("strdup", __func__);
 				return (true);
 			}
 		}
@@ -1201,12 +1213,16 @@ pkg_jobs_need_upgrade(struct pkg *rp, struct pkg *lp)
 		if (ret1 != ret2) {
 			free(rp->reason);
 			rp->reason = strdup("provides changed");
+			if (rp->reason == NULL)
+				pkg_emit_errno("strdup", __func__);
 			return (true);
 		}
 		if (ret1 == EPKG_OK) {
 			if (strcmp(rb, lb) != 0) {
 				free(rp->reason);
 				rp->reason = strdup("provides changed");
+				if (rp->reason == NULL)
+					pkg_emit_errno("strdup", __func__);
 				return (true);
 			}
 		}
@@ -1221,12 +1237,16 @@ pkg_jobs_need_upgrade(struct pkg *rp, struct pkg *lp)
 		if (ret1 != ret2) {
 			free(rp->reason);
 			rp->reason = strdup("requires changed");
+			if (rp->reason == NULL)
+				pkg_emit_errno("strdup", __func__);
 			return (true);
 		}
 		if (ret1 == EPKG_OK) {
 			if (strcmp(rb, lb) != 0) {
 				free(rp->reason);
 				rp->reason = strdup("requires changed");
+				if (rp->reason == NULL)
+					pkg_emit_errno("strdup", __func__);
 				return (true);
 			}
 		}
@@ -1242,12 +1262,16 @@ pkg_jobs_need_upgrade(struct pkg *rp, struct pkg *lp)
 		if (ret1 != ret2) {
 			free(rp->reason);
 			rp->reason = strdup("provided shared library changed");
+			if (rp->reason == NULL)
+				pkg_emit_errno("strdup", __func__);
 			return (true);
 		}
 		if (ret1 == EPKG_OK) {
 			if (strcmp(rb, lb) != 0) {
 				free(rp->reason);
 				rp->reason = strdup("provided shared library changed");
+				if (rp->reason == NULL)
+					pkg_emit_errno("strdup", __func__);
 				pkg_debug(1, "provided shlib changed %s -> %s",
 				    lb, rb);
 				return (true);
@@ -1264,12 +1288,16 @@ pkg_jobs_need_upgrade(struct pkg *rp, struct pkg *lp)
 		if (ret1 != ret2) {
 			free(rp->reason);
 			rp->reason = strdup("needed shared library changed");
+			if (rp->reason == NULL)
+				pkg_emit_errno("strdup", __func__);
 			return (true);
 		}
 		if (ret1 == EPKG_OK) {
 			if (strcmp(rb, lb) != 0) {
 				free(rp->reason);
 				rp->reason = strdup("needed shared library changed");
+				if (rp->reason == NULL)
+					pkg_emit_errno("strdup", __func__);
 				pkg_debug(1, "Required shlib changed %s -> %s",
 				    lb, rb);
 				return (true);
@@ -1958,6 +1986,8 @@ pkg_jobs_handle_install(struct pkg_solved *ps, struct pkg_jobs *j,
 		target = req->item->jp->path;
 		free(new->reponame);
 		new->reponame = strdup("local file");
+		if (new->reponame == NULL)
+			pkg_emit_errno("strdup", __func__);
 	}
 	else {
 		pkg_snprintf(path, sizeof(path), "%R", new);
@@ -1966,8 +1996,11 @@ pkg_jobs_handle_install(struct pkg_solved *ps, struct pkg_jobs *j,
 		target = path;
 	}
 
-	if (old != NULL)
+	if (old != NULL) {
 		new->old_version = strdup(old->version);
+		if (new->old_version == NULL)
+			pkg_emit_errno("strdup", __func__);
+	}
 
 	if ((j->flags & PKG_FLAG_FORCE) == PKG_FLAG_FORCE)
 		flags |= PKG_ADD_FORCE;

--- a/libpkg/pkg_jobs.c
+++ b/libpkg/pkg_jobs.c
@@ -78,7 +78,7 @@ pkg_jobs_new(struct pkg_jobs **j, pkg_jobs_t t, struct pkgdb *db)
 	assert(db != NULL);
 
 	if ((*j = calloc(1, sizeof(struct pkg_jobs))) == NULL) {
-		pkg_emit_errno("calloc", "pkg_jobs");
+		pkg_emit_errno("calloc", __func__);
 		return (EPKG_FATAL);
 	}
 
@@ -208,8 +208,7 @@ pkg_jobs_maybe_match_file(struct job_pattern *jp, const char *pattern)
 				jp->path = pkg_path;
 				jp->pattern = malloc(len);
 				if (jp->pattern == NULL) {
-					pkg_emit_errno("malloc",
-					    "pkg_jobs_maybe_match_file");
+					pkg_emit_errno("malloc", __func__);
 					return (false);
 				}
 				strlcpy(jp->pattern, pattern, len);
@@ -245,7 +244,7 @@ pkg_jobs_add(struct pkg_jobs *j, match_t match, char **argv, int argc)
 	for (i = 0; i < argc; i++) {
 		jp = calloc(1, sizeof(struct job_pattern));
 		if (jp == NULL) {
-			pkg_emit_errno("malloc", "pkg_jobs_add");
+			pkg_emit_errno("malloc", __func__);
 			return (EPKG_FATAL);
 		}
 		if (j->type == PKG_JOBS_DEINSTALL ||
@@ -259,7 +258,7 @@ pkg_jobs_add(struct pkg_jobs *j, match_t match, char **argv, int argc)
 	if (argc == 0 && match == MATCH_ALL) {
 		jp = calloc(1, sizeof(struct job_pattern));
 		if (jp == NULL) {
-			pkg_emit_errno("malloc", "pkg_jobs_add");
+			pkg_emit_errno("malloc", __func__);
 			return (EPKG_FATAL);
 		}
 		jp->pattern = NULL;
@@ -311,7 +310,7 @@ pkg_jobs_add_req_from_universe(struct pkg_job_request **head,
 	if (req == NULL) {
 		req = calloc(1, sizeof(*req));
 		if (req == NULL) {
-			pkg_emit_errno("malloc", "struct pkg_job_request");
+			pkg_emit_errno("malloc", __func__);
 			return (NULL);
 		}
 		new_req = true;
@@ -330,7 +329,7 @@ pkg_jobs_add_req_from_universe(struct pkg_job_request **head,
 				(uit->pkg->type != PKG_INSTALLED && !local)) {
 			nit = calloc(1, sizeof(*nit));
 			if (nit == NULL) {
-				pkg_emit_errno("malloc", "struct pkg_job_request_item");
+				pkg_emit_errno("malloc", __func__);
 				free(req);
 				return (NULL);
 			}
@@ -414,7 +413,7 @@ pkg_jobs_add_req(struct pkg_jobs *j, struct pkg *pkg)
 
 	nit = calloc(1, sizeof(*nit));
 	if (nit == NULL) {
-		pkg_emit_errno("malloc", "struct pkg_job_request_item");
+		pkg_emit_errno("malloc", __func__);
 		free(nit);
 		return (NULL);
 	}
@@ -425,7 +424,7 @@ pkg_jobs_add_req(struct pkg_jobs *j, struct pkg *pkg)
 		/* Allocate new unique request item */
 		req = calloc(1, sizeof(*req));
 		if (req == NULL) {
-			pkg_emit_errno("malloc", "struct pkg_job_request");
+			pkg_emit_errno("malloc", __func__);
 			free(nit);
 			return (NULL);
 		}
@@ -598,7 +597,7 @@ pkg_jobs_set_execute_priority(struct pkg_jobs *j, struct pkg_solved *solved)
 			 */
 			ts = calloc(1, sizeof(struct pkg_solved));
 			if (ts == NULL) {
-				pkg_emit_errno("calloc", "pkg_solved");
+				pkg_emit_errno("calloc", __func__);
 				return (EPKG_FATAL);
 			}
 
@@ -902,8 +901,7 @@ pkg_jobs_guess_upgrade_candidate(struct pkg_jobs *j, const char *pattern)
 		/* Try exact pattern without numbers */
 		cpy = malloc(len + 1);
 		if (cpy == NULL) {
-			pkg_emit_errno("malloc",
-			    "pkg_jobs_guess_upgrade_candidate");
+			pkg_emit_errno("malloc", __func__);
 			return (EPKG_FATAL);
 		}
 		strlcpy(cpy, pos, len + 1);
@@ -1480,7 +1478,7 @@ pkg_jobs_new_candidate(struct pkg *pkg)
 
 	n = malloc(sizeof(*n));
 	if (n == NULL) {
-		pkg_emit_errno("malloc", "pkg_jobs_install_candidate");
+		pkg_emit_errno("malloc", __func__);
 		return (NULL);
 	}
 	n->id = pkg->id;
@@ -1825,7 +1823,8 @@ again:
 						dot = fopen(dotfile, "w");
 
 						if (dot == NULL) {
-							pkg_emit_errno("fopen", dotfile);
+							pkg_emit_errno("fopen",
+								       __func__);
 						}
 					}
 
@@ -2219,7 +2218,7 @@ pkg_jobs_fetch(struct pkg_jobs *j)
 			if (mkdirs(cachedir) != EPKG_OK)
 				return (EPKG_FATAL);
 		} else {
-			pkg_emit_errno("statfs", cachedir);
+			pkg_emit_errno("statfs", __func__);
 			return (EPKG_FATAL);
 		}
 	}
@@ -2231,7 +2230,7 @@ pkg_jobs_fetch(struct pkg_jobs *j)
 			if (mkdirs(cachedir) != EPKG_OK)
 				return (EPKG_FATAL);
 		} else {
-			pkg_emit_errno("statvfs", cachedir);
+			pkg_emit_errno("statvfs", __func__);
 			return (EPKG_FATAL);
 		}
 	}

--- a/libpkg/pkg_jobs_conflicts.c
+++ b/libpkg/pkg_jobs_conflicts.c
@@ -185,6 +185,8 @@ pkg_conflicts_register(struct pkg *p1, struct pkg *p2, enum pkg_conflict_type ty
 	HASH_FIND_STR(p1->conflicts, p2->uid, test);
 	if (test == NULL) {
 		c1->uid = strdup(p2->uid);
+		if (c1->uid == NULL)
+			pkg_emit_errno("strdup", __func__);
 		HASH_ADD_KEYPTR(hh, p1->conflicts, c1->uid, strlen(c1->uid), c1);
 		pkg_debug(2, "registering conflict between %s(%s) and %s(%s)",
 				p1->uid, p1->type == PKG_INSTALLED ? "l" : "r",
@@ -196,6 +198,8 @@ pkg_conflicts_register(struct pkg *p1, struct pkg *p2, enum pkg_conflict_type ty
 	HASH_FIND_STR(p2->conflicts, p1->uid, test);
 	if (test == NULL) {
 		c2->uid = strdup(p1->uid);
+		if (c2->uid == NULL)
+			pkg_emit_errno("strdup", __func__);
 		HASH_ADD_KEYPTR(hh, p2->conflicts, c2->uid, strlen(c2->uid), c2);
 		pkg_debug(2, "registering conflict between %s(%s) and %s(%s)",
 				p2->uid, p2->type == PKG_INSTALLED ? "l" : "r",
@@ -277,9 +281,13 @@ pkg_conflicts_register_unsafe(struct pkg *p1, struct pkg *p2,
 		pkg_conflict_new(&c1);
 		c1->type = type;
 		c1->uid = strdup(p2->uid);
+		if (c1->uid == NULL)
+			pkg_emit_errno("strdup", __func__);
 
 		if (use_digest) {
 			c1->digest = strdup(p2->digest);
+			if (c1->digest == NULL)
+				pkg_emit_errno("strdup", __func__);
 		}
 
 		HASH_ADD_KEYPTR(hh, p1->conflicts, c1->uid, strlen(c1->uid), c1);
@@ -290,11 +298,15 @@ pkg_conflicts_register_unsafe(struct pkg *p1, struct pkg *p2,
 		c2->type = type;
 
 		c2->uid = strdup(p1->uid);
+		if (c2->uid == NULL)
+			pkg_emit_errno("strdup", __func__);
 
 		if (use_digest) {
 			/* We also add digest information into account */
 
 			c2->digest = strdup(p1->digest);
+			if (c2->digest == NULL)
+				pkg_emit_errno("strdup", __func__);
 		}
 
 		HASH_ADD_KEYPTR(hh, p2->conflicts, c2->uid, strlen(c2->uid), c2);

--- a/libpkg/pkg_jobs_conflicts.c
+++ b/libpkg/pkg_jobs_conflicts.c
@@ -52,6 +52,10 @@ pkg_conflicts_sipkey_init(void)
 
 	if (kinit == NULL) {
 		kinit = malloc(sizeof(*kinit));
+		if (kinit == NULL) {
+			pkg_emit_errno("malloc", "pkg_conflicts_sipkey_init");
+			return (NULL);
+		}
 		arc4random_buf((unsigned char*)kinit, sizeof(*kinit));
 	}
 
@@ -427,12 +431,11 @@ pkg_conflicts_check_all_paths(struct pkg_jobs *j, const char *path,
 		cit = calloc(1, sizeof(*cit));
 		if (cit == NULL) {
 			pkg_emit_errno("malloc failed", "pkg_conflicts_check_all_paths");
+			return (NULL);
 		}
-		else {
-			cit->hash = hv;
-			cit->item = it;
-			TREE_INSERT(j->conflict_items, pkg_jobs_conflict_item, entry, cit);
-		}
+		cit->hash = hv;
+		cit->item = it;
+		TREE_INSERT(j->conflict_items, pkg_jobs_conflict_item, entry, cit);
 	}
 	else {
 		/* Check the same package */
@@ -532,6 +535,10 @@ pkg_conflicts_append_chain(struct pkg_job_universe_item *it,
 	/* Ensure that we have a tree initialized */
 	if (j->conflict_items == NULL) {
 		j->conflict_items = malloc(sizeof(*j->conflict_items));
+		if (j->conflict_items == NULL) {
+			pkg_emit_errno("malloc", "pkg_conflicts_append_chain");
+			return (EPKG_FATAL);
+		}
 		TREE_INIT(j->conflict_items, pkg_conflicts_item_cmp);
 	}
 

--- a/libpkg/pkg_jobs_conflicts.c
+++ b/libpkg/pkg_jobs_conflicts.c
@@ -53,7 +53,7 @@ pkg_conflicts_sipkey_init(void)
 	if (kinit == NULL) {
 		kinit = malloc(sizeof(*kinit));
 		if (kinit == NULL) {
-			pkg_emit_errno("malloc", "pkg_conflicts_sipkey_init");
+			pkg_emit_errno("malloc", __func__);
 			return (NULL);
 		}
 		arc4random_buf((unsigned char*)kinit, sizeof(*kinit));
@@ -123,7 +123,7 @@ pkg_conflicts_request_add_chain(struct pkg_conflict_chain **chain, struct pkg_jo
 
 	elt = calloc(1, sizeof(struct pkg_conflict_chain));
 	if (elt == NULL) {
-		pkg_emit_errno("resolve_request_conflicts", "calloc: struct pkg_conflict_chain");
+		pkg_emit_errno("resolve_request_conflicts", __func__);
 		return;
 	}
 	elt->req = req;
@@ -430,7 +430,7 @@ pkg_conflicts_check_all_paths(struct pkg_jobs *j, const char *path,
 		/* New entry */
 		cit = calloc(1, sizeof(*cit));
 		if (cit == NULL) {
-			pkg_emit_errno("malloc failed", "pkg_conflicts_check_all_paths");
+			pkg_emit_errno("malloc failed", __func__);
 			return (NULL);
 		}
 		cit->hash = hv;
@@ -536,7 +536,7 @@ pkg_conflicts_append_chain(struct pkg_job_universe_item *it,
 	if (j->conflict_items == NULL) {
 		j->conflict_items = malloc(sizeof(*j->conflict_items));
 		if (j->conflict_items == NULL) {
-			pkg_emit_errno("malloc", "pkg_conflicts_append_chain");
+			pkg_emit_errno("malloc", __func__);
 			return (EPKG_FATAL);
 		}
 		TREE_INIT(j->conflict_items, pkg_conflicts_item_cmp);

--- a/libpkg/pkg_jobs_universe.c
+++ b/libpkg/pkg_jobs_universe.c
@@ -208,7 +208,7 @@ pkg_jobs_universe_add_pkg(struct pkg_jobs_universe *universe, struct pkg *pkg,
 
 	item = calloc(1, sizeof (struct pkg_job_universe_item));
 	if (item == NULL) {
-		pkg_emit_errno("pkg_jobs_pkg_insert_universe", "calloc: struct pkg_job_universe_item");
+		pkg_emit_errno("pkg_jobs_pkg_insert_universe", __func__);
 		return (EPKG_FATAL);
 	}
 
@@ -444,8 +444,7 @@ pkg_jobs_universe_handle_provide(struct pkg_jobs_universe *universe,
 
 		pr = calloc (1, sizeof (*pr));
 		if (pr == NULL) {
-			pkg_emit_errno("pkg_jobs_add_universe", "calloc: "
-					"struct pkg_job_provide");
+			pkg_emit_errno("pkg_jobs_add_universe", __func__);
 			return (EPKG_FATAL);
 		}
 
@@ -841,7 +840,7 @@ pkg_jobs_universe_new(struct pkg_jobs *j)
 
 	universe = calloc(1, sizeof(struct pkg_jobs_universe));
 	if (universe == NULL) {
-		pkg_emit_errno("pkg_jobs_universe_new", "calloc");
+		pkg_emit_errno("pkg_jobs_universe_new", __func__);
 		return (NULL);
 	}
 

--- a/libpkg/pkg_jobs_universe.c
+++ b/libpkg/pkg_jobs_universe.c
@@ -886,6 +886,11 @@ pkg_jobs_universe_change_uid(struct pkg_jobs_universe *universe,
 					if (strcmp(d->uid, unit->pkg->uid) == 0) {
 						free(d->uid);
 						d->uid = strdup(new_uid);
+						if (d->uid == NULL) {
+							pkg_emit_errno("strdup",
+								       __func__);
+							return;
+						}
 					}
 				}
 			}
@@ -895,13 +900,19 @@ pkg_jobs_universe_change_uid(struct pkg_jobs_universe *universe,
 	replacement = calloc(1, sizeof(*replacement));
 	if (replacement != NULL) {
 		replacement->old_uid = strdup(unit->pkg->uid);
+		if (replacement->old_uid == NULL)
+			pkg_emit_errno("strdup", __func__);
 		replacement->new_uid = strdup(new_uid);
+		if (replacement->new_uid == NULL)
+			pkg_emit_errno("strdup", __func__);
 		LL_PREPEND(universe->uid_replaces, replacement);
 	}
 
 	HASH_DELETE(hh, universe->items, unit);
 	free(unit->pkg->uid);
 	unit->pkg->uid = strdup(new_uid);
+	if (unit->pkg->uid == NULL)
+		pkg_emit_errno("strdup", __func__);
 
 	HASH_FIND(hh, universe->items, new_uid, uidlen, found);
 	if (found != NULL)

--- a/libpkg/pkg_macho.c
+++ b/libpkg/pkg_macho.c
@@ -69,7 +69,7 @@ analyse_macho(struct pkg *pkg, const char *fpath,
 	cpu_type = cpu_type & ~CPU_ARCH_MASK;
 
 	if (lstat(fpath, &sb) != 0)
-		pkg_emit_errno("fstat() failed for", fpath);
+		pkg_emit_errno("fstat() failed for", __func__);
 
 	/* ignore empty files and non regular files */
 	if (sb.st_size == 0 || !S_ISREG(sb.st_mode))
@@ -212,7 +212,7 @@ host_cpu_type(cpu_type_t *result)
 	/* Fetch CPU type */
 	len = sizeof(resint);
 	if (sysctlbyname("hw.cputype", &resint, &len, NULL, 0) != 0) {
-		pkg_emit_errno("sysctlbyname", "hw.cputype");
+		pkg_emit_errno("sysctlbyname", __func__);
 		return EPKG_FATAL;
 	}
 
@@ -234,7 +234,7 @@ host_os_info(char *osname, size_t sz, long long *major_version)
 
 	/* Fetch OS info from uname() */
 	if (uname(&ut) != 0) {
-		pkg_emit_errno("uname", "&ut");
+		pkg_emit_errno("uname", __func__);
 		return EPKG_FATAL;
 	}
 

--- a/libpkg/pkg_macho.c
+++ b/libpkg/pkg_macho.c
@@ -178,6 +178,8 @@ parse_major_release(const char *src, long long *release)
 	char *eos;
 
 	parsed = strdup(src);
+	if (parsed == NULL)
+		pkg_emit_errno("strdup", __func__);
 	eos = strchr(parsed, '.');
 	if (eos == NULL) {
 		pkg_emit_error("failed to parse major release version from %s", src);

--- a/libpkg/pkg_manifest.c
+++ b/libpkg/pkg_manifest.c
@@ -225,8 +225,7 @@ pkg_manifest_keys_new(struct pkg_manifest_key **key)
 		if (k == NULL) {
 			k = calloc(1, sizeof(struct pkg_manifest_key));
 			if (k == NULL) {
-				pkg_emit_errno("calloc",
-				    "pkg_manifest_keys_new");
+				pkg_emit_errno("calloc", __func__);
 				return (EPKG_FATAL);
 			}
 			k->key = manifest_keys[i].key;
@@ -1305,12 +1304,12 @@ pkg_emit_manifest_generic(struct pkg *pkg, void *out, short flags,
 	if (pdigest != NULL) {
 		*pdigest = malloc(sizeof(digest) * 2 + 1);
 		if (*pdigest == NULL) {
-			pkg_emit_errno("malloc", "pkg_emit_manifest_generic");
+			pkg_emit_errno("malloc", __func__);
 			return (EPKG_FATAL);
 		}
 		sign_ctx = malloc(sizeof(SHA256_CTX));
 		if (sign_ctx == NULL) {
-			pkg_emit_errno("malloc", "pkg_emit_manifest_generic");
+			pkg_emit_errno("malloc", __func__);
 			return (EPKG_FATAL);
 		}
 		sha256_init(sign_ctx);

--- a/libpkg/pkg_manifest.c
+++ b/libpkg/pkg_manifest.c
@@ -224,6 +224,11 @@ pkg_manifest_keys_new(struct pkg_manifest_key **key)
 		HASH_FIND_STR(*key, manifest_keys[i].key, k);
 		if (k == NULL) {
 			k = calloc(1, sizeof(struct pkg_manifest_key));
+			if (k == NULL) {
+				pkg_emit_errno("calloc",
+				    "pkg_manifest_keys_new");
+				return (EPKG_FATAL);
+			}
 			k->key = manifest_keys[i].key;
 			k->type = manifest_keys[i].type;
 			k->valid_type = manifest_keys[i].valid_type;
@@ -1299,7 +1304,15 @@ pkg_emit_manifest_generic(struct pkg *pkg, void *out, short flags,
 
 	if (pdigest != NULL) {
 		*pdigest = malloc(sizeof(digest) * 2 + 1);
+		if (*pdigest == NULL) {
+			pkg_emit_errno("malloc", "pkg_emit_manifest_generic");
+			return (EPKG_FATAL);
+		}
 		sign_ctx = malloc(sizeof(SHA256_CTX));
+		if (sign_ctx == NULL) {
+			pkg_emit_errno("malloc", "pkg_emit_manifest_generic");
+			return (EPKG_FATAL);
+		}
 		sha256_init(sign_ctx);
 	}
 

--- a/libpkg/pkg_manifest.c
+++ b/libpkg/pkg_manifest.c
@@ -371,6 +371,8 @@ pkg_string(struct pkg *pkg, const ucl_object_t *obj, uint32_t offset)
 		offset &= STRING_FLAG_MASK;
 		dest = (char **) ((unsigned char *)pkg + offset);
 		*dest = strdup(str);
+		if (*dest == NULL)
+			pkg_emit_errno("strdup", __func__);
 
 		if (buf) {
 			utstring_free(buf);
@@ -953,10 +955,15 @@ pkg_emit_object(struct pkg *pkg, short flags)
 	ucl_object_t *map, *seq, *submap;
 	ucl_object_t *top = ucl_object_typed_new(UCL_OBJECT);
 
-	if (pkg->abi == NULL && pkg->arch != NULL)
+	if (pkg->abi == NULL && pkg->arch != NULL) {
 		pkg->abi = strdup(pkg->arch);
+		if (pkg->abi == NULL)
+			pkg_emit_errno("strdup", __func__);
+	}
 	pkg_arch_to_legacy(pkg->abi, legacyarch, BUFSIZ);
 	pkg->arch = strdup(legacyarch);
+	if (pkg->arch == NULL)
+		pkg_emit_errno("strdup", __func__);
 	pkg_debug(4, "Emitting basic metadata");
 	ucl_object_insert_key(top, ucl_object_fromstring_common(pkg->name, 0,
 	    UCL_STRING_TRIM), "name", 4, false);
@@ -1367,6 +1374,8 @@ pkg_emit_manifest(struct pkg *pkg, char **dest, short flags, char **pdigest)
 	}
 
 	*dest = strdup(utstring_body(b));
+	if (*dest == NULL)
+		pkg_emit_errno("strdup", __func__);
 	utstring_free(b);
 
 	return (rc);

--- a/libpkg/pkg_old.c
+++ b/libpkg/pkg_old.c
@@ -30,6 +30,8 @@
 #include <pkg.h>
 #include <private/pkg.h>
 
+#include "private/event.h"
+
 static const char * const scripts[] = {
 	"+INSTALL",
 	"+PRE_INSTALL",
@@ -94,13 +96,19 @@ pkg_old_load_from_path(struct pkg *pkg, const char *path)
 
 	pkg_get_myarch(myarch, BUFSIZ);
 	pkg->arch = strdup(myarch);
+	if (pkg->arch == NULL)
+		pkg_emit_errno("strdup", __func__);
 	pkg->maintainer = strdup("unknown");
+	if (pkg->maintainer == NULL)
+		pkg_emit_errno("strdup", __func__);
 	regcomp(&preg, "^WWW:[[:space:]]*(.*)$", REG_EXTENDED|REG_ICASE|REG_NEWLINE);
 	if (regexec(&preg, pkg->desc, 2, pmatch, 0) == 0) {
 		size = pmatch[1].rm_eo - pmatch[1].rm_so;
 		pkg->www = strndup(&pkg->desc[pmatch[1].rm_so], size);
 	} else {
 		pkg->www = strdup("UNKNOWN");
+		if (pkg->www == NULL)
+			pkg_emit_errno("strdup", __func__);
 	}
 	regfree(&preg);
 

--- a/libpkg/pkg_ports.c
+++ b/libpkg/pkg_ports.c
@@ -244,7 +244,7 @@ dir(struct plist *p, char *line, struct file_attr *a)
 	}
 
 	if (lstat(testpath, &st) == -1) {
-		pkg_emit_errno("lstat", testpath);
+		pkg_emit_errno("lstat", __func__);
 		if (p->stage != NULL)
 			ret = EPKG_FATAL;
 		if (developer_mode) {
@@ -739,13 +739,13 @@ populate_keywords(struct plist *p)
 	for (i = 0; keyacts[i].key != NULL; i++) {
 		k = calloc(1, sizeof(*k));
 		if (k == NULL) {
-			pkg_emit_errno("malloc", "populate_keywords");
+			pkg_emit_errno("malloc", __func__);
 			return;
 		}
 
 		a = malloc(sizeof(*a));
 		if (a == NULL) {
-			pkg_emit_errno("malloc", "populate_keywords");
+			pkg_emit_errno("malloc", __func__);
 			return;
 		}
 		strlcpy(k->keyword, keyacts[i].key, sizeof(k->keyword));
@@ -816,7 +816,7 @@ parse_attributes(const ucl_object_t *o, struct file_attr **a)
 	if (*a == NULL) {
 		*a = calloc(1, sizeof(struct file_attr));
 		if (*a == NULL) {
-			pkg_emit_errno("malloc", "parse_attributes");
+			pkg_emit_errno("malloc", __func__);
 			return;
 		}
 	}
@@ -868,7 +868,7 @@ apply_keyword_file(ucl_object_t *obj, struct plist *p, char *line, struct file_a
 		spaces = pkg_utils_count_spaces(line);
 		args = malloc((spaces + 1)* sizeof(char *));
 		if (args == NULL) {
-			pkg_emit_errno("malloc", "apply_keyword_file");
+			pkg_emit_errno("malloc", __func__);
 			return (EPKG_FATAL);
 		}
 		tofree = buf = strdup(line);
@@ -933,7 +933,7 @@ apply_keyword_file(ucl_object_t *obj, struct plist *p, char *line, struct file_a
 			elt = ucl_object_find_key(cur, "message");
 			msg = calloc(1, sizeof(*msg));
 			if (msg == NULL) {
-				pkg_emit_errno("malloc", "struct pkg_message");
+				pkg_emit_errno("malloc", __func__);
 				goto keywords_cleanup;
 			}
 
@@ -1066,7 +1066,7 @@ parse_keyword_args(char *args, char *keyword)
 
 	attr = calloc(1, sizeof(*attr));
 	if (attr == NULL) {
-		pkg_emit_errno("calloc", "parse_keyword_args");
+		pkg_emit_errno("calloc", __func__);
 		return (NULL);
 	}
 	if (owner != NULL && *owner != '\0')
@@ -1197,7 +1197,7 @@ plist_new(struct pkg *pkg, const char *stage)
 
 	p = calloc(1, sizeof(struct plist));
 	if (p == NULL) {
-		pkg_emit_errno("calloc", "plist_new");
+		pkg_emit_errno("calloc", __func__);
 		return (NULL);
 	}
 

--- a/libpkg/pkg_ports.c
+++ b/libpkg/pkg_ports.c
@@ -176,8 +176,11 @@ setprefix(struct plist *p, char *line, struct file_attr *a)
 	else
 		strlcpy(p->prefix, line, sizeof(p->prefix));
 
-	if (p->pkg->prefix == NULL)
+	if (p->pkg->prefix == NULL) {
 		p->pkg->prefix = strdup(line);
+		if (p->pkg->prefix == NULL)
+			pkg_emit_errno("strdup", __func__);
+	}
 
 	p->slash = p->prefix[strlen(p->prefix) -1] == '/' ? "" : "/";
 
@@ -200,7 +203,11 @@ name_key(struct plist *p, char *line, struct file_attr *a)
 	tmp[0] = '\0';
 	tmp++;
 	p->pkg->name = strdup(line);
+	if (p->pkg->name == NULL)
+		pkg_emit_errno("strdup", __func__);
 	p->pkg->version = strdup(tmp);
+	if (p->pkg->version == NULL)
+		pkg_emit_errno("strdup", __func__);
 
 	return (EPKG_OK);
 }
@@ -211,6 +218,8 @@ pkgdep(struct plist *p, char *line, struct file_attr *a)
 	if (*line != '\0') {
 		free(p->pkgdep);
 		p->pkgdep = strdup(line);
+		if (p->pkgdep == NULL)
+			pkg_emit_errno("strdup", __func__);
 	}
 	return (EPKG_OK);
 }
@@ -431,10 +440,16 @@ static int
 setowner(struct plist *p, char *line, struct file_attr *a)
 {
 	free(p->uname);
-	if (line[0] == '\0')
+	if (line[0] == '\0') {
 		p->uname = strdup("root");
-	else
+		if (p->uname == NULL)
+			pkg_emit_errno("strdup", __func__);
+	}
+	else {
 		p->uname = strdup(line);
+		if (p->uname == NULL)
+			pkg_emit_errno("strdup", __func__);
+	}
 	return (EPKG_OK);
 }
 
@@ -442,10 +457,16 @@ static int
 setgroup(struct plist *p, char *line, struct file_attr *a)
 {
 	free(p->gname);
-	if (line[0] == '\0')
+	if (line[0] == '\0') {
 		p->gname = strdup("wheel");
-	else
+		if (p->gname == NULL)
+			pkg_emit_errno("strdup", __func__);
+	}
+	else {
 		p->gname = strdup(line);
+		if (p->gname == NULL)
+			pkg_emit_errno("strdup", __func__);
+	}
 	return (EPKG_OK);
 }
 
@@ -469,6 +490,8 @@ comment_key(struct plist *p, char *line, struct file_attr *a)
 		line += 7;
 		free(p->pkg->origin);
 		p->pkg->origin = strdup(line);
+		if (p->pkg->origin == NULL)
+			pkg_emit_errno("strdup", __func__);
 	} else if (strncmp(line, "OPTIONS:", 8) == 0) {
 		line += 8;
 		/* OPTIONS:+OPTION -OPTION */
@@ -508,12 +531,18 @@ parse_post(struct plist *p)
 		return;
 
 	p->post_patterns.buf = strdup(env);
+	if (p->post_patterns.buf == NULL)
+		pkg_emit_errno("strdup", __func__);
 	while ((token = strsep(&p->post_patterns.buf, " \t")) != NULL) {
 		if (token[0] == '\0')
 			continue;
 		if (p->post_patterns.len >= p->post_patterns.cap) {
 			p->post_patterns.cap += 10;
 			p->post_patterns.patterns = realloc(p->post_patterns.patterns, p->post_patterns.cap * sizeof (char *));
+			if (p->post_patterns.patterns == NULL) {
+				pkg_emit_errno("realloc", __func__);
+				return;
+			}
 		}
 		p->post_patterns.patterns[p->post_patterns.len++] = token;
 	}
@@ -828,11 +857,19 @@ parse_attributes(const ucl_object_t *o, struct file_attr **a)
 		if (!strcasecmp(key, "owner") && cur->type == UCL_STRING) {
 			free((*a)->owner);
 			(*a)->owner = strdup(ucl_object_tostring(cur));
+			if ((*a)->owner == NULL) {
+				pkg_emit_errno("strdup", __func__);
+				return;
+			}
 			continue;
 		}
 		if (!strcasecmp(key, "group") && cur->type == UCL_STRING) {
 			free((*a)->group);
 			(*a)->group = strdup(ucl_object_tostring(cur));
+			if ((*a)->group == NULL) {
+				pkg_emit_errno("strdup", __func__);
+				return;
+			}
 			continue;
 		}
 		if (!strcasecmp(key, "mode")) {
@@ -938,6 +975,10 @@ apply_keyword_file(ucl_object_t *obj, struct plist *p, char *line, struct file_a
 			}
 
 			msg->str = strdup(ucl_object_tostring(elt));
+			if (msg->str == NULL) {
+				pkg_emit_errno("strdup", __func__);
+				return (EPKG_FATAL);
+			}
 			msg->type = PKG_MESSAGE_ALWAYS;
 			elt = ucl_object_find_key(cur, "type");
 			if (elt != NULL) {
@@ -1069,10 +1110,16 @@ parse_keyword_args(char *args, char *keyword)
 		pkg_emit_errno("calloc", __func__);
 		return (NULL);
 	}
-	if (owner != NULL && *owner != '\0')
+	if (owner != NULL && *owner != '\0') {
 		attr->owner = strdup(owner);
-	if (group != NULL && *group != '\0')
+		if (attr->owner == NULL)
+			pkg_emit_errno("strdup", __func__);
+	}
+	if (group != NULL && *group != '\0') {
 		attr->group = strdup(group);
+		if (attr->group == NULL)
+			pkg_emit_errno("strdup", __func__);
+	}
 	if (set != NULL) {
 		attr->mode = getmode(set, 0);
 		free(set);
@@ -1207,7 +1254,11 @@ plist_new(struct pkg *pkg, const char *stage)
 	p->slash = p->prefix[strlen(p->prefix) - 1] == '/' ? "" : "/";
 	p->stage = stage;
 	p->uname = strdup("root");
+	if (p->uname == NULL)
+		pkg_emit_errno("strdup", __func__);
 	p->gname = strdup("wheel");
+	if (p->gname == NULL)
+		pkg_emit_errno("strdup", __func__);
 
 	utstring_new(p->pre_install_buf);
 	utstring_new(p->post_install_buf);

--- a/libpkg/pkg_repo.c
+++ b/libpkg/pkg_repo.c
@@ -251,18 +251,18 @@ pkg_repo_meta_extract_signature_pubkey(int fd, void *ud)
 			sig = malloc(siglen);
 			if (sig == NULL) {
 				pkg_emit_errno("pkg_repo_meta_extract_signature",
-						"malloc failed");
+					       __func__);
 				return (EPKG_FATAL);
 			}
 			if (archive_read_data(a, sig, siglen) == -1) {
 				pkg_emit_errno("pkg_repo_meta_extract_signature",
-						"archive_read_data failed");
+					       __func__);
 				free(sig);
 				return (EPKG_FATAL);
 			}
 			if (write(fd, sig, siglen) == -1) {
 				pkg_emit_errno("pkg_repo_meta_extract_signature",
-						"write failed");
+					       __func__);
 				free(sig);
 				return (EPKG_FATAL);
 			}
@@ -271,7 +271,8 @@ pkg_repo_meta_extract_signature_pubkey(int fd, void *ud)
 		}
 		else if (strcmp(archive_entry_pathname(ae), cb->fname) == 0) {
 			if (archive_read_data_into_fd(a, cb->tfd) != 0) {
-				pkg_emit_errno("archive_read_extract", "extract error");
+				pkg_emit_errno("archive_read_extract",
+					       __func__);
 				rc = EPKG_FATAL;
 				break;
 			}
@@ -320,12 +321,12 @@ pkg_repo_meta_extract_signature_fingerprints(int fd, void *ud)
 			sig = malloc(siglen);
 			if (sig == NULL) {
 				pkg_emit_errno("pkg_repo_meta_extract_signature",
-						"malloc failed");
+					       __func__);
 				return (EPKG_FATAL);
 			}
 			if (archive_read_data(a, sig, siglen) == -1) {
 				pkg_emit_errno("pkg_repo_meta_extract_signature",
-						"archive_read_data failed");
+					       __func__);
 				free(sig);
 				return (EPKG_FATAL);
 			}
@@ -344,7 +345,7 @@ pkg_repo_meta_extract_signature_fingerprints(int fd, void *ud)
 			iov[4].iov_len = siglen;
 			if (writev(fd, iov, NELEM(iov)) == -1) {
 				pkg_emit_errno("pkg_repo_meta_extract_signature",
-						"writev failed");
+					       __func__);
 				free(sig);
 				return (EPKG_FATAL);
 			}
@@ -359,12 +360,12 @@ pkg_repo_meta_extract_signature_fingerprints(int fd, void *ud)
 			sig = malloc(siglen);
 			if (sig == NULL) {
 				pkg_emit_errno("pkg_repo_meta_extract_signature",
-						"malloc failed");
+					       __func__);
 				return (EPKG_FATAL);
 			}
 			if (archive_read_data(a, sig, siglen) == -1) {
 				pkg_emit_errno("pkg_repo_meta_extract_signature",
-						"archive_read_data failed");
+					       __func__);
 				free(sig);
 				return (EPKG_FATAL);
 			}
@@ -383,7 +384,7 @@ pkg_repo_meta_extract_signature_fingerprints(int fd, void *ud)
 			iov[4].iov_len = siglen;
 			if (writev(fd, iov, NELEM(iov)) == -1) {
 				pkg_emit_errno("pkg_repo_meta_extract_signature",
-						"writev failed");
+					       __func__);
 				free(sig);
 				return (EPKG_FATAL);
 			}
@@ -393,7 +394,8 @@ pkg_repo_meta_extract_signature_fingerprints(int fd, void *ud)
 		else {
 			if (strcmp(archive_entry_pathname(ae), cb->fname) == 0) {
 				if (archive_read_data_into_fd(a, cb->tfd) != 0) {
-					pkg_emit_errno("archive_read_extract", "extract error");
+					pkg_emit_errno("archive_read_extract",
+						       __func__);
 					rc = EPKG_FATAL;
 					break;
 				}
@@ -466,7 +468,8 @@ pkg_repo_parse_sigkeys(const char *in, int inlen, struct sig_cert **sc)
 			if (s == NULL) {
 				s = calloc(1, sizeof(struct sig_cert));
 				if (s == NULL) {
-					pkg_emit_errno("pkg_repo_parse_sigkeys", "calloc failed");
+					pkg_emit_errno("pkg_repo_parse_sigkeys",
+						       __func__);
 					return (EPKG_FATAL);
 				}
 				tlen = MIN(len, sizeof(s->name) - 1);
@@ -508,7 +511,8 @@ pkg_repo_parse_sigkeys(const char *in, int inlen, struct sig_cert **sc)
 			}
 			sig = malloc(len);
 			if (sig == NULL) {
-				pkg_emit_errno("pkg_repo_parse_sigkeys", "malloc failed");
+				pkg_emit_errno("pkg_repo_parse_sigkeys",
+					       __func__);
 				free(s);
 				return (EPKG_FATAL);
 			}
@@ -562,7 +566,7 @@ pkg_repo_archive_extract_archive(int fd, const char *file,
 		cbdata.tfd = open (dest, O_WRONLY | O_CREAT | O_TRUNC,
 				0644);
 		if (cbdata.tfd == -1) {
-			pkg_emit_errno("archive_read_extract", "open error");
+			pkg_emit_errno("archive_read_extract", __func__);
 			rc = EPKG_FATAL;
 			goto cleanup;
 		}
@@ -580,7 +584,7 @@ pkg_repo_archive_extract_archive(int fd, const char *file,
 			s = calloc(1, sizeof(struct sig_cert));
 			if (s == NULL) {
 				pkg_emit_errno("pkg_repo_archive_extract_archive",
-						"malloc failed");
+					       __func__);
 				rc = EPKG_FATAL;
 				goto cleanup;
 			}
@@ -775,7 +779,7 @@ pkg_repo_fetch_remote_extract_mmap(struct pkg_repo *repo, const char *filename,
 	map = mmap(NULL, st.st_size, PROT_READ, MAP_SHARED, fd, 0);
 	close(fd);
 	if (map == MAP_FAILED) {
-		pkg_emit_errno("pkg_repo_fetch_remote_mmap", "cannot mmap fetched");
+		pkg_emit_errno("pkg_repo_fetch_remote_mmap", __func__);
 		*rc = EPKG_FATAL;
 		return (MAP_FAILED);
 	}
@@ -798,7 +802,7 @@ pkg_repo_fetch_remote_extract_tmp(struct pkg_repo *repo, const char *filename,
 
 	res = fdopen(dest_fd, "r");
 	if (res == NULL) {
-		pkg_emit_errno("fdopen", "digest open failed");
+		pkg_emit_errno("fdopen", __func__);
 		*rc = EPKG_FATAL;
 		close(dest_fd);
 		return (NULL);
@@ -860,7 +864,7 @@ pkg_repo_meta_extract_pubkey(int fd, void *ud)
 					iov[0].iov_len = res_len;
 					if (writev(fd, iov, 1) == -1) {
 						pkg_emit_errno("pkg_repo_meta_extract_pubkey",
-								"writev error");
+							       __func__);
 						rc = EPKG_FATAL;
 						break;
 					}

--- a/libpkg/pkg_repo.c
+++ b/libpkg/pkg_repo.c
@@ -1056,6 +1056,8 @@ pkg_repo_parse_fingerprint(ucl_object_t *obj)
 	}
 
 	f = calloc(1, sizeof(struct fingerprint));
+	if (f == NULL)
+		pkg_emit_errno("calloc", __func__);
 	f->type = fct;
 	strlcpy(f->hash, fp, sizeof(f->hash));
 

--- a/libpkg/pkg_repo_create.c
+++ b/libpkg/pkg_repo_create.c
@@ -112,7 +112,7 @@ pkg_create_repo_fts_new(FTSENT *fts, const char *root_path)
 
 	item = malloc(sizeof(*item));
 	if (item == NULL) {
-		pkg_emit_errno("malloc", "struct pkg_fts_item");
+		pkg_emit_errno("malloc", __func__);
 		return (NULL);
 	}
 
@@ -209,7 +209,7 @@ pkg_create_repo_read_fts(struct pkg_fts_item **items, FTS *fts,
 	}
 
 	if (errno != 0) {
-		pkg_emit_errno("fts_read", "pkg_create_repo_read_fts");
+		pkg_emit_errno("fts_read", __func__);
 		return (EPKG_FATAL);
 	}
 
@@ -240,7 +240,7 @@ pkg_create_repo_worker(struct pkg_fts_item *start, size_t nelts,
 
 	mfd = open(mlfile, O_APPEND|O_CREAT|O_WRONLY, 00644);
 	if (mfd == -1) {
-		pkg_emit_errno("pkg_create_repo_worker", "open");
+		pkg_emit_errno("pkg_create_repo_worker", __func__);
 		utstring_free(b);
 		return (EPKG_FATAL);
 	}
@@ -250,7 +250,7 @@ pkg_create_repo_worker(struct pkg_fts_item *start, size_t nelts,
 		if (ffd == -1) {
 			close(mfd);
 			utstring_free(b);
-			pkg_emit_errno("pkg_create_repo_worker", "open");
+			pkg_emit_errno("pkg_create_repo_worker", __func__);
 			return (EPKG_FATAL);
 		}
 	}
@@ -258,7 +258,7 @@ pkg_create_repo_worker(struct pkg_fts_item *start, size_t nelts,
 	pid = fork();
 	switch(pid) {
 	case -1:
-		pkg_emit_errno("pkg_create_repo_worker", "fork");
+		pkg_emit_errno("pkg_create_repo_worker", __func__);
 		utstring_free(b);
 		close(mfd);
 		if (read_files)
@@ -287,7 +287,7 @@ pkg_create_repo_worker(struct pkg_fts_item *start, size_t nelts,
 		flags = PKG_OPEN_MANIFEST_ONLY | PKG_OPEN_MANIFEST_COMPACT;
 
 	if (read(pip, digestbuf, 1) == -1) {
-		pkg_emit_errno("pkg_create_repo_worker", "read");
+		pkg_emit_errno("pkg_create_repo_worker", __func__);
 		goto cleanup;
 	}
 
@@ -314,7 +314,7 @@ pkg_create_repo_worker(struct pkg_fts_item *start, size_t nelts,
 			else {
 				mdigest = malloc(pkg_checksum_type_size(meta->digest_format));
 				if (mdigest == NULL) {
-					pkg_emit_errno("malloc", "pkg_create_repo_worker");
+					pkg_emit_errno("malloc", __func__);
 					ret = EPKG_FATAL;
 					goto cleanup;
 				}
@@ -332,7 +332,8 @@ pkg_create_repo_worker(struct pkg_fts_item *start, size_t nelts,
 			mlen = utstring_len(b);
 
 			if (flock(mfd, LOCK_EX) == -1) {
-				pkg_emit_errno("pkg_create_repo_worker", "flock");
+				pkg_emit_errno("pkg_create_repo_worker",
+					       __func__);
 				ret = EPKG_FATAL;
 				goto cleanup;
 			}
@@ -345,7 +346,8 @@ pkg_create_repo_worker(struct pkg_fts_item *start, size_t nelts,
 			iov[1].iov_len = 1;
 
 			if (writev(mfd, iov, 2) == -1) {
-				pkg_emit_errno("pkg_create_repo_worker", "write");
+				pkg_emit_errno("pkg_create_repo_worker",
+					       __func__);
 				ret = EPKG_FATAL;
 				flock(mfd, LOCK_UN);
 				goto cleanup;
@@ -357,7 +359,8 @@ pkg_create_repo_worker(struct pkg_fts_item *start, size_t nelts,
 				FILE *fl;
 
 				if (flock(ffd, LOCK_EX) == -1) {
-					pkg_emit_errno("pkg_create_repo_worker", "flock");
+					pkg_emit_errno("pkg_create_repo_worker",
+						       __func__);
 					ret = EPKG_FATAL;
 					goto cleanup;
 				}
@@ -433,7 +436,7 @@ pkg_create_repo_read_pipe(int fd, struct digest_list_entry **dlist)
 			else if (errno == EAGAIN || errno == EWOULDBLOCK)
 				return (EPKG_OK);
 
-			pkg_emit_errno("pkg_create_repo_read_pipe", "read");
+			pkg_emit_errno("pkg_create_repo_read_pipe", __func__);
 			return (EPKG_FATAL);
 		}
 		else if (r == 0)
@@ -450,13 +453,13 @@ pkg_create_repo_read_pipe(int fd, struct digest_list_entry **dlist)
 					dig = calloc(1, sizeof(*dig));
 					if (dig == NULL) {
 						pkg_emit_errno("calloc",
-						    "pkg_create_repo_read_pipe");
+							       __func__);
 						return (EPKG_FATAL);
 					}
 					dig->origin = malloc(i - start + 1);
 					if (dig == NULL) {
 						pkg_emit_errno("malloc",
-						    "pkg_create_repo_read_pipe");
+							       __func__);
 						return (EPKG_FATAL);
 					}
 					strlcpy(dig->origin, &buf[start], i - start + 1);
@@ -466,7 +469,7 @@ pkg_create_repo_read_pipe(int fd, struct digest_list_entry **dlist)
 					dig->digest = malloc(i - start + 1);
 					if (dig == NULL) {
 						pkg_emit_errno("malloc",
-						    "pkg_create_repo_read_pipe");
+							       __func__);
 						return (EPKG_FATAL);
 					}
 					strlcpy(dig->digest, &buf[start], i - start + 1);
@@ -488,7 +491,7 @@ pkg_create_repo_read_pipe(int fd, struct digest_list_entry **dlist)
 					dig->checksum =  malloc(i - start + 1);
 					if (dig == NULL) {
 						pkg_emit_errno("malloc",
-						    "pkg_create_repo_read_pipe");
+							       __func__);
 						return (EPKG_FATAL);
 					}
 					strlcpy(dig->digest, &buf[start], i - start + 1);
@@ -505,7 +508,7 @@ pkg_create_repo_read_pipe(int fd, struct digest_list_entry **dlist)
 					dig->checksum =  malloc(i - start + 1);
 					if (dig == NULL) {
 						pkg_emit_errno("malloc",
-						    "pkg_create_repo_read_pipe");
+							       __func__);
 						return (EPKG_FATAL);
 					}
 					strlcpy(dig->checksum, &buf[start], i - start + 1);

--- a/libpkg/pkg_repo_create.c
+++ b/libpkg/pkg_repo_create.c
@@ -91,6 +91,8 @@ pkg_repo_new_conflict(const char *uniqueid, struct pkg_conflict_bulk *bulk)
 
 	pkg_conflict_new(&new);
 	new->uid = strdup(uniqueid);
+	if (new->uid == NULL)
+		pkg_emit_errno("strdup", __func__);
 
 	HASH_ADD_KEYPTR(hh, bulk->conflicts, new->uid, strlen(new->uid), new);
 }
@@ -117,7 +119,11 @@ pkg_create_repo_fts_new(FTSENT *fts, const char *root_path)
 	}
 
 	item->fts_accpath = strdup(fts->fts_accpath);
+	if (item->fts_accpath == NULL)
+		pkg_emit_errno("strdup", __func__);
 	item->fts_name = strdup(fts->fts_name);
+	if (item->fts_name == NULL)
+		pkg_emit_errno("strdup", __func__);
 	item->fts_size = fts->fts_statp->st_size;
 	item->fts_info = fts->fts_info;
 
@@ -127,6 +133,8 @@ pkg_create_repo_fts_new(FTSENT *fts, const char *root_path)
 		pkg_path++;
 
 	item->pkg_path = strdup(pkg_path);
+	if (item->pkg_path == NULL)
+		pkg_emit_errno("strdup", __func__);
 
 	return (item);
 }
@@ -304,6 +312,10 @@ pkg_create_repo_worker(struct pkg_fts_item *start, size_t nelts,
 			    PKG_HASH_TYPE_SHA256_HEX);
 			pkg->pkgsize = cur->fts_size;
 			pkg->repopath = strdup(cur->pkg_path);
+			if (pkg->repopath == NULL) {
+				pkg_emit_errno("strdup", __func__);
+				return (EPKG_FATAL);
+			}
 
 			/*
 			 * TODO: use pkg_checksum for new manifests
@@ -489,7 +501,7 @@ pkg_create_repo_read_pipe(int fd, struct digest_list_entry **dlist)
 					break;
 				case s_set_checksum:
 					dig->checksum =  malloc(i - start + 1);
-					if (dig == NULL) {
+					if (dig->checksum == NULL) {
 						pkg_emit_errno("malloc",
 							       __func__);
 						return (EPKG_FATAL);
@@ -506,7 +518,7 @@ pkg_create_repo_read_pipe(int fd, struct digest_list_entry **dlist)
 				}
 				else if (state == s_set_checksum) {
 					dig->checksum =  malloc(i - start + 1);
-					if (dig == NULL) {
+					if (dig->checksum == NULL) {
 						pkg_emit_errno("malloc",
 							       __func__);
 						return (EPKG_FATAL);

--- a/libpkg/pkg_repo_meta.c
+++ b/libpkg/pkg_repo_meta.c
@@ -151,7 +151,7 @@ pkg_repo_meta_parse_cert(const ucl_object_t *obj)
 
 	key = calloc(1, sizeof(*key));
 	if (key == NULL) {
-		pkg_emit_errno("pkg_repo_meta_parse", "malloc failed for pkg_repo_meta_key");
+		pkg_emit_errno("pkg_repo_meta_parse", __func__);
 		return (NULL);
 	}
 
@@ -183,7 +183,7 @@ pkg_repo_meta_parse(ucl_object_t *top, struct pkg_repo_meta **target, int versio
 
 	meta = calloc(1, sizeof(*meta));
 	if (meta == NULL) {
-		pkg_emit_errno("pkg_repo_meta_parse", "malloc failed for pkg_repo_meta");
+		pkg_emit_errno("pkg_repo_meta_parse", __func__);
 		return (EPKG_FATAL);
 	}
 
@@ -309,7 +309,7 @@ pkg_repo_meta_default(void)
 
 	meta = calloc(1, sizeof(*meta));
 	if (meta == NULL) {
-		pkg_emit_errno("pkg_repo_meta_default", "malloc failed for pkg_repo_meta");
+		pkg_emit_errno("pkg_repo_meta_default", __func__);
 		return (NULL);
 	}
 

--- a/libpkg/pkg_repo_meta.c
+++ b/libpkg/pkg_repo_meta.c
@@ -42,11 +42,23 @@ pkg_repo_meta_set_default(struct pkg_repo_meta *meta)
 	meta->conflicts = NULL;
 	meta->conflicts_archive = NULL;
 	meta->manifests = strdup("packagesite.yaml");
+	if (meta->manifests == NULL)
+		pkg_emit_errno("strdup", __func__);
 	meta->manifests_archive = strdup("packagesite");
+	if (meta->manifests_archive == NULL)
+		pkg_emit_errno("strdup", __func__);
 	meta->digests = strdup("digests");
+	if (meta->digests == NULL)
+		pkg_emit_errno("strdup", __func__);
 	meta->digests_archive = strdup("digests");
+	if (meta->digests_archive == NULL)
+		pkg_emit_errno("strdup", __func__);
 	meta->filesite = strdup("filesite.yaml");
+	if (meta->filesite == NULL)
+		pkg_emit_errno("strdup", __func__);
 	meta->filesite_archive = strdup("filesite");
+	if (meta->filesite_archive == NULL)
+		pkg_emit_errno("strdup", __func__);
 	/* Not using fulldb */
 	meta->fulldb = NULL;
 	meta->fulldb_archive = NULL;
@@ -159,8 +171,14 @@ pkg_repo_meta_parse_cert(const ucl_object_t *obj)
 	 * It is already validated so just use it as is
 	 */
 	key->name = strdup(ucl_object_tostring(ucl_object_find_key(obj, "name")));
+	if (key->name == NULL)
+		pkg_emit_errno("strdup", __func__);
 	key->pubkey = strdup(ucl_object_tostring(ucl_object_find_key(obj, "data")));
+	if (key->pubkey == NULL)
+		pkg_emit_errno("strdup", __func__);
 	key->pubkey_type = strdup(ucl_object_tostring(ucl_object_find_key(obj, "type")));
+	if (key->pubkey_type == NULL)
+		pkg_emit_errno("strdup", __func__);
 
 	return (key);
 }

--- a/libpkg/pkg_solve.c
+++ b/libpkg/pkg_solve.c
@@ -131,7 +131,7 @@ pkg_solve_item_new(struct pkg_solve_variable *var)
 	result = calloc(1, sizeof(struct pkg_solve_item));
 
 	if(result == NULL) {
-		pkg_emit_errno("calloc", "pkg_solve_item");
+		pkg_emit_errno("calloc", __func__);
 		return (NULL);
 	}
 
@@ -149,7 +149,7 @@ pkg_solve_rule_new(enum pkg_solve_rule_type reason)
 	result = calloc(1, sizeof(struct pkg_solve_rule));
 
 	if(result == NULL) {
-		pkg_emit_errno("calloc", "pkg_solve_rule");
+		pkg_emit_errno("calloc", __func__);
 		return (NULL);
 	}
 
@@ -1379,7 +1379,7 @@ pkg_solve_insert_res_job (struct pkg_solve_variable *var,
 		if (seen_add > 0) {
 			res = calloc(1, sizeof(struct pkg_solved));
 			if (res == NULL) {
-				pkg_emit_errno("calloc", "pkg_solved");
+				pkg_emit_errno("calloc", __func__);
 				return;
 			}
 			/* Pure install */
@@ -1416,7 +1416,7 @@ pkg_solve_insert_res_job (struct pkg_solve_variable *var,
 
 				res = calloc(1, sizeof(struct pkg_solved));
 				if (res == NULL) {
-					pkg_emit_errno("calloc", "pkg_solved");
+					pkg_emit_errno("calloc", __func__);
 					return;
 				}
 				res->items[0] = cur_var->unit;

--- a/libpkg/pkgdb.c
+++ b/libpkg/pkgdb.c
@@ -129,7 +129,7 @@ pkgdb_regex(sqlite3_context *ctx, int argc, sqlite3_value **argv)
 
 		re = malloc(sizeof *re);
 		if (re == NULL) {
-			pkg_emit_errno("malloc", "pkgdb_regex");
+			pkg_emit_errno("malloc", __func__);
 			return;
 		}
 		if (regcomp(re, regex, cflags) != 0) {
@@ -953,7 +953,7 @@ pkgdb_open_repos(struct pkgdb *db, const char *reponame)
 			if (r->ops->open(r, R_OK) == EPKG_OK) {
 				item = malloc(sizeof(*item));
 				if (item == NULL) {
-					pkg_emit_errno("malloc", "_pkg_repo_list_item");
+					pkg_emit_errno("malloc", __func__);
 					return (EPKG_FATAL);
 				}
 
@@ -1065,7 +1065,7 @@ pkgdb_open_all(struct pkgdb **db_p, pkgdb_t type, const char *reponame)
 	}
 
 	if (!reopen && (db = calloc(1, sizeof(struct pkgdb))) == NULL) {
-		pkg_emit_errno("malloc", "pkgdb");
+		pkg_emit_errno("malloc", __func__);
 		return (EPKG_FATAL);
 	}
 

--- a/libpkg/pkgdb.c
+++ b/libpkg/pkgdb.c
@@ -127,7 +127,11 @@ pkgdb_regex(sqlite3_context *ctx, int argc, sqlite3_value **argv)
 		else
 			cflags = REG_EXTENDED | REG_NOSUB | REG_ICASE;
 
-		re = malloc(sizeof(regex_t));
+		re = malloc(sizeof *re);
+		if (re == NULL) {
+			pkg_emit_errno("malloc", "pkgdb_regex");
+			return;
+		}
 		if (regcomp(re, regex, cflags) != 0) {
 			sqlite3_result_error(ctx, "Invalid regex\n", -1);
 			free(re);

--- a/libpkg/pkgdb.c
+++ b/libpkg/pkgdb.c
@@ -2659,6 +2659,8 @@ pkgdb_file_set_cksum(struct pkgdb *db, struct pkg_file *file,
 	}
 	sqlite3_finalize(stmt);
 	file->sum = strdup(sum);
+	if (file->sum == NULL)
+		pkg_emit_errno("strdup", __func__);
 
 	return (EPKG_OK);
 }
@@ -2706,6 +2708,8 @@ pkgshell_open(const char **reponame)
 
 	snprintf(localpath, sizeof(localpath), "%s/local.sqlite", dbdir);
 	*reponame = strdup(localpath);
+	if (*reponame == NULL)
+		pkg_emit_errno("strdup", __func__);
 }
 
 static int

--- a/libpkg/pkgdb_iterator.c
+++ b/libpkg/pkgdb_iterator.c
@@ -827,7 +827,7 @@ populate_pkg(sqlite3_stmt *stmt, struct pkg *pkg) {
 						pkg->message = calloc(1, sizeof(*pkg->message));
 						if (pkg->message == NULL) {
 							pkg_emit_errno("calloc",
-							    "populate_pkg");
+								       __func__);
 							return;
 						}
 						pkg->message->str = strdup(msg);
@@ -1170,7 +1170,7 @@ pkgdb_it_new_sqlite(struct pkgdb *db, sqlite3_stmt *s, int type, short flags)
 	assert(!(flags & (PKGDB_IT_FLAG_AUTO & (PKGDB_IT_FLAG_CYCLED | PKGDB_IT_FLAG_ONCE))));
 
 	if ((it = malloc(sizeof(struct pkgdb_it))) == NULL) {
-		pkg_emit_errno("malloc", "pkgdb_it");
+		pkg_emit_errno("malloc", __func__);
 		sqlite3_finalize(s);
 		return (NULL);
 	}
@@ -1194,7 +1194,7 @@ pkgdb_it_new_repo(struct pkgdb *db)
 	struct pkgdb_it	*it;
 
 	if ((it = malloc(sizeof(struct pkgdb_it))) == NULL) {
-		pkg_emit_errno("malloc", "pkgdb_it");
+		pkg_emit_errno("malloc", __func__);
 		return (NULL);
 	}
 
@@ -1213,7 +1213,7 @@ pkgdb_it_repo_attach(struct pkgdb_it *it, struct pkg_repo_it *rit)
 	struct _pkg_repo_it_set *item;
 
 	if ((item = malloc(sizeof(struct _pkg_repo_it_set))) == NULL) {
-		pkg_emit_errno("malloc", "_pkg_repo_it_set");
+		pkg_emit_errno("malloc", __func__);
 	}
 	else {
 		item->it = rit;

--- a/libpkg/pkgdb_iterator.c
+++ b/libpkg/pkgdb_iterator.c
@@ -797,24 +797,52 @@ populate_pkg(sqlite3_stmt *stmt, struct pkg *pkg) {
 			switch (column->type) {
 			case PKG_ABI:
 				pkg->abi = strdup(sqlite3_column_text(stmt, icol));
+				if (pkg->abi == NULL) {
+					pkg_emit_errno("strdup", __func__);
+					return;
+				}
 				break;
 			case PKG_CKSUM:
 				pkg->sum = strdup(sqlite3_column_text(stmt, icol));
+				if (pkg->sum == NULL) {
+					pkg_emit_errno("strdup", __func__);
+					return;
+				}
 				break;
 			case PKG_COMMENT:
 				pkg->comment = strdup(sqlite3_column_text(stmt, icol));
+				if (pkg->comment == NULL) {
+					pkg_emit_errno("strdup", __func__);
+					return;
+				}
 				break;
 			case PKG_REPONAME:
 				pkg->reponame = strdup(sqlite3_column_text(stmt, icol));
+				if (pkg->reponame == NULL) {
+					pkg_emit_errno("strdup", __func__);
+					return;
+				}
 				break;
 			case PKG_DESC:
 				pkg->desc = strdup(sqlite3_column_text(stmt, icol));
+				if (pkg->desc == NULL) {
+					pkg_emit_errno("strdup", __func__);
+					return;
+				}
 				break;
 			case PKG_MAINTAINER:
 				pkg->maintainer = strdup(sqlite3_column_text(stmt, icol));
+				if (pkg->maintainer == NULL) {
+					pkg_emit_errno("strdup", __func__);
+					return;
+				}
 				break;
 			case PKG_DIGEST:
 				pkg->digest = strdup(sqlite3_column_text(stmt, icol));
+				if (pkg->digest == NULL) {
+					pkg_emit_errno("strdup", __func__);
+					return;
+				}
 				break;
 			case PKG_MESSAGE:
 				msg = sqlite3_column_text(stmt, icol);
@@ -831,6 +859,11 @@ populate_pkg(sqlite3_stmt *stmt, struct pkg *pkg) {
 							return;
 						}
 						pkg->message->str = strdup(msg);
+						if (pkg->message->str == NULL) {
+							pkg_emit_errno("strdup",
+								       __func__);
+							return;
+						}
 					}
 				}
 				else {
@@ -839,33 +872,73 @@ populate_pkg(sqlite3_stmt *stmt, struct pkg *pkg) {
 				break;
 			case PKG_NAME:
 				pkg->name = strdup(sqlite3_column_text(stmt, icol));
+				if (pkg->name == NULL) {
+					pkg_emit_errno("strdup", __func__);
+					return;
+				}
 				break;
 			case PKG_OLD_VERSION:
 				pkg->old_version = strdup(sqlite3_column_text(stmt, icol));
+				if (pkg->old_version == NULL) {
+					pkg_emit_errno("strdup", __func__);
+					return;
+				}
 				break;
 			case PKG_ORIGIN:
 				pkg->origin = strdup(sqlite3_column_text(stmt, icol));
+				if (pkg->origin == NULL) {
+					pkg_emit_errno("strdup", __func__);
+					return;
+				}
 				break;
 			case PKG_PREFIX:
 				pkg->prefix = strdup(sqlite3_column_text(stmt, icol));
+				if (pkg->prefix == NULL) {
+					pkg_emit_errno("strdup", __func__);
+					return;
+				}
 				break;
 			case PKG_REPOPATH:
 				pkg->repopath = strdup(sqlite3_column_text(stmt, icol));
+				if (pkg->repopath == NULL) {
+					pkg_emit_errno("strdup", __func__);
+					return;
+				}
 				break;
 			case PKG_REPOURL:
 				pkg->repourl = strdup(sqlite3_column_text(stmt, icol));
+				if (pkg->repourl == NULL) {
+					pkg_emit_errno("strdup", __func__);
+					return;
+				}
 				break;
 			case PKG_UNIQUEID:
 				pkg->uid = strdup(sqlite3_column_text(stmt, icol));
+				if (pkg->uid == NULL) {
+					pkg_emit_errno("strdup", __func__);
+					return;
+				}
 				break;
 			case PKG_VERSION:
 				pkg->version = strdup(sqlite3_column_text(stmt, icol));
+				if (pkg->version == NULL) {
+					pkg_emit_errno("strdup", __func__);
+					return;
+				}
 				break;
 			case PKG_WWW:
 				pkg->www = strdup(sqlite3_column_text(stmt, icol));
+				if (pkg->www == NULL) {
+					pkg_emit_errno("strdup", __func__);
+					return;
+				}
 				break;
 			case PKG_DEP_FORMULA:
 				pkg->dep_formula = strdup(sqlite3_column_text(stmt, icol));
+				if (pkg->dep_formula == NULL) {
+					pkg_emit_errno("strdup", __func__);
+					return;
+				}
 				break;
 			default:
 				pkg_emit_error("Unexpected text value for %s", colname);
@@ -926,6 +999,8 @@ populate_pkg(sqlite3_stmt *stmt, struct pkg *pkg) {
 
 	pkg_arch_to_legacy(pkg->abi, legacyarch, BUFSIZ);
 	pkg->arch = strdup(legacyarch);
+	if (pkg->arch == NULL)
+		pkg_emit_errno("strdup", __func__);
 }
 
 static struct load_on_flag {

--- a/libpkg/pkgdb_iterator.c
+++ b/libpkg/pkgdb_iterator.c
@@ -825,6 +825,11 @@ populate_pkg(sqlite3_stmt *stmt, struct pkg *pkg) {
 					}
 					else {
 						pkg->message = calloc(1, sizeof(*pkg->message));
+						if (pkg->message == NULL) {
+							pkg_emit_errno("calloc",
+							    "populate_pkg");
+							return;
+						}
 						pkg->message->str = strdup(msg);
 					}
 				}

--- a/libpkg/plugins.c
+++ b/libpkg/plugins.c
@@ -297,7 +297,7 @@ pkg_plugins_init(void)
 		    pkg_object_string(cur));
 		p = calloc(1, sizeof(struct pkg_plugin));
 		if (p == NULL) {
-			pkg_emit_errno("calloc", "pkg_plugins_init");
+			pkg_emit_errno("calloc", __func__);
 			return (EPKG_FATAL);
 		}
 		if ((p->lh = dlopen(pluginfile, RTLD_LAZY)) == NULL) {

--- a/libpkg/plugins.c
+++ b/libpkg/plugins.c
@@ -296,6 +296,10 @@ pkg_plugins_init(void)
 		snprintf(pluginfile, sizeof(pluginfile), "%s/%s.so", plugdir,
 		    pkg_object_string(cur));
 		p = calloc(1, sizeof(struct pkg_plugin));
+		if (p == NULL) {
+			pkg_emit_errno("calloc", "pkg_plugins_init");
+			return (EPKG_FATAL);
+		}
 		if ((p->lh = dlopen(pluginfile, RTLD_LAZY)) == NULL) {
 			pkg_emit_error("Loading of plugin '%s' failed: %s",
 			    pkg_object_string(cur), dlerror());

--- a/libpkg/rcscripts.c
+++ b/libpkg/rcscripts.c
@@ -98,7 +98,7 @@ rc_stop(const char *rc_file)
 	    (error = posix_spawn(&pid, "/usr/sbin/service", &actions, NULL,
 	    __DECONST(char **, argv), environ)) != 0) {
 		errno = error;
-		pkg_emit_errno("Cannot query service", rc_file);
+		pkg_emit_errno("Cannot query service", __func__);
 		return (-1);
 	}
 
@@ -117,7 +117,7 @@ rc_stop(const char *rc_file)
 	if ((error = posix_spawn(&pid, "/usr/sbin/service", NULL, NULL,
 	    __DECONST(char **, argv), environ)) != 0) {
 		errno = error;
-		pkg_emit_errno("Cannot stop service", rc_file);
+		pkg_emit_errno("Cannot stop service", __func__);
 		return (-1);
 	}
 
@@ -147,7 +147,7 @@ rc_start(const char *rc_file)
 	if ((error = posix_spawn(&pid, "/usr/sbin/service", NULL, NULL,
 	    __DECONST(char **, argv), environ)) != 0) {
 		errno = error;
-		pkg_emit_errno("Cannot start service", rc_file);
+		pkg_emit_errno("Cannot start service", __func__);
 		return (-1);
 	}
 

--- a/libpkg/repo/binary/fetch.c
+++ b/libpkg/repo/binary/fetch.c
@@ -110,12 +110,12 @@ pkg_repo_binary_create_symlink(struct pkg *pkg, const char *fname,
 	if ((dest_fname = strrchr(fname, '/')) != NULL)
 		++dest_fname;
 	if (symlink(dest_fname, link_dest_tmp) == -1) {
-		pkg_emit_errno("symlink", link_dest);
+		pkg_emit_errno("symlink", __func__);
 		return (EPKG_FATAL);
 	}
 
 	if (rename(link_dest_tmp, link_dest) == -1) {
-		pkg_emit_errno("rename", link_dest);
+		pkg_emit_errno("rename", __func__);
 		unlink(link_dest_tmp);
 		return (EPKG_FATAL);
 	}
@@ -168,7 +168,7 @@ pkg_repo_binary_try_fetch(struct pkg_repo *repo, struct pkg *pkg,
 	/* Create the dirs in cachedir */
 	dir = strdup(dest);
 	if (dir == NULL || (path = dirname(dir)) == NULL) {
-		pkg_emit_errno("dirname", dest);
+		pkg_emit_errno("dirname", __func__);
 		retcode = EPKG_FATAL;
 		goto cleanup;
 	}

--- a/libpkg/repo/binary/query.c
+++ b/libpkg/repo/binary/query.c
@@ -61,7 +61,7 @@ pkg_repo_binary_it_new(struct pkg_repo *repo, sqlite3_stmt *s, short flags)
 
 	it = malloc(sizeof(*it));
 	if (it == NULL) {
-		pkg_emit_errno("malloc", "pkg_repo_it");
+		pkg_emit_errno("malloc", __func__);
 		sqlite3_finalize(s);
 		return (NULL);
 	}

--- a/libpkg/repo/binary/update.c
+++ b/libpkg/repo/binary/update.c
@@ -432,6 +432,11 @@ pkg_repo_binary_parse_conflicts(FILE *f, sqlite3 *sqlite)
 			pdep ++;
 		}
 		deps = malloc(sizeof(char *) * ndep);
+		if (deps == NULL) {
+			pkg_emit_errno("malloc",
+			    "pkg_repo_binary_parse_conflicts");
+			return;
+		}
 		for (i = 0; i < ndep; i ++) {
 			deps[i] = strsep(&p, ",\n");
 		}

--- a/libpkg/repo/binary/update.c
+++ b/libpkg/repo/binary/update.c
@@ -397,6 +397,8 @@ pkg_repo_binary_add_from_manifest(char *buf, sqlite3 *sqlite, size_t len,
 
 	free(pkg->reponame);
 	pkg->reponame = strdup(repo->name);
+	if (pkg->reponame == NULL)
+		pkg_emit_errno("strdup", __func__);
 
 	rc = pkg_repo_binary_add_pkg(pkg, NULL, sqlite, true);
 

--- a/libpkg/repo/binary/update.c
+++ b/libpkg/repo/binary/update.c
@@ -433,8 +433,7 @@ pkg_repo_binary_parse_conflicts(FILE *f, sqlite3 *sqlite)
 		}
 		deps = malloc(sizeof(char *) * ndep);
 		if (deps == NULL) {
-			pkg_emit_errno("malloc",
-			    "pkg_repo_binary_parse_conflicts");
+			pkg_emit_errno("malloc", __func__);
 			return;
 		}
 		for (i = 0; i < ndep; i ++) {

--- a/libpkg/rsa.c
+++ b/libpkg/rsa.c
@@ -142,7 +142,7 @@ rsa_verify_cert(const char *path, unsigned char *key, int keylen,
 
 	if (fd == -1) {
 		if ((fd = open(path, O_RDONLY)) == -1) {
-			pkg_emit_errno("fopen", path);
+			pkg_emit_errno("fopen", __func__);
 			return (EPKG_FATAL);
 		}
 		need_close = true;
@@ -211,13 +211,13 @@ rsa_verify(const char *path, const char *key, unsigned char *sig,
 	off_t key_len;
 
 	if (file_to_buffer(key, (char**)&key_buf, &key_len) != EPKG_OK) {
-		pkg_emit_errno("rsa_verify", "cannot read key");
+		pkg_emit_errno("rsa_verify", __func__);
 		return (EPKG_FATAL);
 	}
 
 	if (fd == -1) {
 		if ((fd = open(path, O_RDONLY)) == -1) {
-			pkg_emit_errno("fopen", path);
+			pkg_emit_errno("fopen", __func__);
 			free(key_buf);
 			return (EPKG_FATAL);
 		}
@@ -251,7 +251,7 @@ rsa_sign(char *path, struct rsa_key *rsa, unsigned char **sigret, unsigned int *
 	char *sha256;
 
 	if (access(rsa->path, R_OK) == -1) {
-		pkg_emit_errno("access", rsa->path);
+		pkg_emit_errno("access", __func__);
 		return (EPKG_FATAL);
 	}
 
@@ -263,7 +263,7 @@ rsa_sign(char *path, struct rsa_key *rsa, unsigned char **sigret, unsigned int *
 	max_len = RSA_size(rsa->key);
 	*sigret = calloc(1, max_len + 1);
 	if (*sigret == NULL) {
-		pkg_emit_errno("calloc", "rsa_sign");
+		pkg_emit_errno("calloc", __func__);
 		return (EPKG_FATAL);
 	}
 
@@ -292,7 +292,7 @@ rsa_new(struct rsa_key **rsa, pkg_password_cb *cb, char *path)
 
 	*rsa = calloc(1, sizeof(struct rsa_key));
 	if (*rsa == NULL) {
-		pkg_emit_errno("calloc", "rsa_new");
+		pkg_emit_errno("calloc", __func__);
 		return (EPKG_FATAL);
 	}
 	(*rsa)->path = path;

--- a/libpkg/rsa.c
+++ b/libpkg/rsa.c
@@ -262,6 +262,10 @@ rsa_sign(char *path, struct rsa_key *rsa, unsigned char **sigret, unsigned int *
 
 	max_len = RSA_size(rsa->key);
 	*sigret = calloc(1, max_len + 1);
+	if (*sigret == NULL) {
+		pkg_emit_errno("calloc", "rsa_sign");
+		return (EPKG_FATAL);
+	}
 
 	sha256 = pkg_checksum_file(path, PKG_HASH_TYPE_SHA256_HEX);
 	if (sha256 == NULL)
@@ -287,6 +291,10 @@ rsa_new(struct rsa_key **rsa, pkg_password_cb *cb, char *path)
 	assert(*rsa == NULL);
 
 	*rsa = calloc(1, sizeof(struct rsa_key));
+	if (*rsa == NULL) {
+		pkg_emit_errno("calloc", "rsa_new");
+		return (EPKG_FATAL);
+	}
 	(*rsa)->path = path;
 	(*rsa)->pw_cb = cb;
 

--- a/libpkg/utils.c
+++ b/libpkg/utils.c
@@ -69,7 +69,7 @@ mkdirs(const char *_path)
 
 		if (mkdir(path, S_IRWXU | S_IRWXG | S_IRWXO) < 0)
 			if (errno != EEXIST && errno != EISDIR) {
-				pkg_emit_errno("mkdir", path);
+				pkg_emit_errno("mkdir", __func__);
 				return (EPKG_FATAL);
 			}
 
@@ -95,25 +95,25 @@ file_to_bufferat(int dfd, const char *path, char **buffer, off_t *sz)
 	assert(sz != NULL);
 
 	if ((fd = openat(dfd, path, O_RDONLY)) == -1) {
-		pkg_emit_errno("openat", path);
+		pkg_emit_errno("openat", __func__);
 		retcode = EPKG_FATAL;
 		goto cleanup;
 	}
 
 	if (fstatat(dfd, path, &st, 0) == -1) {
-		pkg_emit_errno("fstatat", path);
+		pkg_emit_errno("fstatat", __func__);
 		retcode = EPKG_FATAL;
 		goto cleanup;
 	}
 
 	if ((*buffer = malloc(st.st_size + 1)) == NULL) {
-		pkg_emit_errno("malloc", "");
+		pkg_emit_errno("malloc", __func__);
 		retcode = EPKG_FATAL;
 		goto cleanup;
 	}
 
 	if (read(fd, *buffer, st.st_size) == -1) {
-		pkg_emit_errno("read", path);
+		pkg_emit_errno("read", __func__);
 		retcode = EPKG_FATAL;
 		goto cleanup;
 	}
@@ -144,25 +144,25 @@ file_to_buffer(const char *path, char **buffer, off_t *sz)
 	assert(sz != NULL);
 
 	if ((fd = open(path, O_RDONLY)) == -1) {
-		pkg_emit_errno("open", path);
+		pkg_emit_errno("open", __func__);
 		retcode = EPKG_FATAL;
 		goto cleanup;
 	}
 
 	if (fstat(fd, &st) == -1) {
-		pkg_emit_errno("fstat", path);
+		pkg_emit_errno("fstat", __func__);
 		retcode = EPKG_FATAL;
 		goto cleanup;
 	}
 
 	if ((*buffer = malloc(st.st_size + 1)) == NULL) {
-		pkg_emit_errno("malloc", "");
+		pkg_emit_errno("malloc", __func__);
 		retcode = EPKG_FATAL;
 		goto cleanup;
 	}
 
 	if (read(fd, *buffer, st.st_size) == -1) {
-		pkg_emit_errno("read", path);
+		pkg_emit_errno("read", __func__);
 		retcode = EPKG_FATAL;
 		goto cleanup;
 	}

--- a/libpkg/utils.c
+++ b/libpkg/utils.c
@@ -285,6 +285,8 @@ format_exec_cmd(char **dest, const char *in, const char *prefix,
 	}
 
 	*dest = strdup(utstring_body(buf));
+	if (*dest == NULL)
+		pkg_emit_errno("strdup", __func__);
 	utstring_free(buf);
 	
 	return (EPKG_OK);
@@ -737,6 +739,8 @@ mkdirat_p(int fd, const char *path)
 	char *walk, pathdone[MAXPATHLEN];
 
 	walk = strdup(path);
+	if (walk == NULL)
+		pkg_emit_errno("strdup", __func__);
 	pathdone[0] = '\0';
 
 	while ((next = strsep(&walk, "/")) != NULL) {

--- a/tests/cocci/pkg/unchecked_malloc.cocci
+++ b/tests/cocci/pkg/unchecked_malloc.cocci
@@ -8,45 +8,53 @@
 // URL: https://github.com/freebsd/pkg/tree/master/tests/cocci/pkg/unchecked_malloc.cocci
 
 @@
-local idexpression n;
-expression E;
+expression T;
 @@
 
-n = malloc(E);
-+ if (n == NULL)
-+ 	pkg_emit_errno("malloc", TEXT(E));
-... when != (n == NULL)
-    when != (n != NULL)
+T = malloc(...);
++ if (T == NULL) {
++ 	pkg_emit_errno("malloc", __func__);
++	return (EPKG_FATAL);
++ }
+... when != (T == NULL)
+    when != (T != NULL)
+? T = malloc(...);
 
 @@
-local idexpression n;
-expression E, E1;
+expression T;
 @@
 
-n = calloc(E, E1);
-+ if (n == NULL)
-+ 	pkg_emit_errno("calloc", TEXT2(E, E1));
-... when != (n == NULL)
-    when != (n != NULL)
+T = calloc(...);
++ if (T == NULL) {
++ 	pkg_emit_errno("calloc", __func__);
++	return (EPKG_FATAL);
++ }
+... when != (T == NULL)
+    when != (T != NULL)
+? T = calloc(...);
 
 @@
-local idexpression n;
-expression E, E1;
+expression T;
 @@
 
-n = realloc(E, E1);
-+ if (n == NULL)
-+ 	pkg_emit_errno("realloc", TEXT2(E, E1));
-... when != (n == NULL)
-    when != (n != NULL)
+T = realloc(...);
++ if (T == NULL) {
++ 	pkg_emit_errno("realloc", __func__);
++	return (EPKG_FATAL);
++ }
+... when != (T == NULL)
+    when != (T != NULL)
+? T = realloc(...);
 
 @@
-local idexpression n;
-expression E;
+expression T;
 @@
 
- n = strdup(E);
-+ if (n == NULL)
-+ 	pkg_emit_errno("strdup", TEXT(E));
-... when != (n == NULL)
-    when != (n != NULL)
+T = strdup(...);
++ if (T == NULL) {
++ 	pkg_emit_errno("strdup", __func__);
++	return (EPKG_FATAL);
++ }
+... when != (T == NULL)
+    when != (T != NULL)
+? T = strdup(...);


### PR DESCRIPTION
Hi,

This patch series does a few things incrementally:

1.  Using the existing `libpkg/tests/cocci/pkg/unchecked_malloc.cocci` file, adds a few missing checks.
2.  I've gone through that and added additional calls to plug a few memory leaks.
3.  I've replaced hard-coded strings to function names where `pkg_emit_errno()` was being called, to replace those with `__func__`.  This will make error reporting a little easier, since the code won't need to change if the function name changes.
4.  I've tweaked `libpkg/tests/cocci/pkg/unchecked_malloc.cocci` to completely revamp how it looks for missing NULL checks.
5.  I've ran that back over `libpkg/*.c` and committed the result.

Overall, we're a little more resilient now to memory problems, and might even be using less!