### PR TITLE
libpkg: Missing NULL checks and pkg_emit_errno -> pkg_errno/pkg_fatal_errno

### DIFF
--- a/libpkg/clean_cache.c
+++ b/libpkg/clean_cache.c
@@ -30,6 +30,7 @@
 #include <dirent.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <errno.h>
 #include "pkg.h"
 #include "private/pkg.h"
 #include "private/event.h"
@@ -48,7 +49,7 @@ rm_rf(int basefd, const char *path)
 
 		dirfd = openat(basefd, path, O_DIRECTORY|O_CLOEXEC);
 		if (dirfd == -1) {
-			pkg_emit_errno("openat", path);
+			pkg_errno("%s: %s", __func__, "openat: %s", path);
 			return;
 		}
 	} else {
@@ -64,7 +65,7 @@ rm_rf(int basefd, const char *path)
 		if (strcmp(e->d_name, ".") == 0 || strcmp(e->d_name, "..") == 0)
 			continue;
 		if (fstatat(dirfd, e->d_name, &st, AT_SYMLINK_NOFOLLOW) != 0) {
-			pkg_emit_errno("fstatat", path);
+			pkg_errno("%s: %s", __func__, "fstatat: %s", path);
 			continue;
 		}
 		if (S_ISDIR(st.st_mode))

--- a/libpkg/diff.c
+++ b/libpkg/diff.c
@@ -23,8 +23,10 @@
 #include <string.h>
 #include <stdlib.h>
 #include <utstring.h>
+#include <errno.h>
 
 #include "private/utils.h"
+#include "private/event.h"
 
 /*
 ** Maximum length of a line in a text file, in bytes.  (2**13 = 8192 bytes)
@@ -124,6 +126,10 @@ static DLine *break_into_lines(char *z, int *pnLine){
     return 0;
   }
   a = calloc(nLine, sizeof(a[0]) );
+  if (a == NULL) {
+    pkg_errno("%s: %s", __func__, "calloc");
+    return (0);
+  }
   if( n==0 ){
     *pnLine = 0;
     return a;
@@ -319,6 +325,10 @@ static void longestCommonSequence(
 */
 static void expandEdit(DContext *p, int nEdit){
   p->aEdit = realloc(p->aEdit, nEdit*sizeof(int));
+  if (p->aEdit == NULL) {
+    pkg_errno("%s: %s", __func__, "realloc");
+    return;
+  }
   p->nEditAlloc = nEdit;
 }
 

--- a/libpkg/dns_utils.c
+++ b/libpkg/dns_utils.c
@@ -29,6 +29,7 @@
 
 #include <sys/stat.h> /* for private.utils.h */
 
+#include <errno.h>
 #include <string.h>
 #include <netinet/in.h>
 #ifdef HAVE_LDNS
@@ -75,6 +76,7 @@
 
 #include <bsd_compat.h>
 #include "private/utils.h"
+#include "private/event.h"
 #include "pkg.h"
 
 #ifndef HAVE_LDNS
@@ -134,6 +136,10 @@ compute_weight(struct dns_srvinfo **d, int first, int last)
 		return;
 
 	chosen = malloc(sizeof(int) * (last - first + 1));
+	if (chosen == NULL) {
+		pkg_errno("%s: %s", __func__, "malloc");
+		return;
+	}
 
 	for (i = 0; i <= last; i++) {
 		for (;;) {
@@ -335,6 +341,10 @@ compute_weight(struct dns_srvinfo *d, int first, int last)
 		return;
 
 	chosen = malloc(sizeof(int) * (last - first + 1));
+	if (chosen == NULL) {
+		pkg_errno("%s: %s", __func__, "malloc");
+		return;
+	}
 
 	for (i = 0; i <= last; i++) {
 		for (;;) {

--- a/libpkg/fetch.c
+++ b/libpkg/fetch.c
@@ -74,6 +74,10 @@ gethttpmirrors(struct pkg_repo *repo, const char *url) {
 
 			if ((u = fetchParseURL(line)) != NULL) {
 				m = malloc(sizeof(struct http_mirror));
+				if (m == NULL) {
+					pkg_errno("%s: %s", __func__, "malloc");
+					return;
+				}
 				m->url = u;
 				LL_APPEND(repo->http, m);
 			}

--- a/libpkg/packing.c
+++ b/libpkg/packing.c
@@ -29,6 +29,7 @@
 #include <archive.h>
 #include <archive_entry.h>
 #include <assert.h>
+#include <errno.h>
 #include <fcntl.h>
 #include <fts.h>
 #include <string.h>
@@ -57,8 +58,7 @@ packing_init(struct packing **pack, const char *path, pkg_formats format)
 	assert(pack != NULL);
 
 	if ((*pack = calloc(1, sizeof(struct packing))) == NULL) {
-		pkg_emit_errno("calloc", "packing");
-		return (EPKG_FATAL);
+		pkg_fatal_errno("%s: %s", __func__, "calloc: packing");
 	}
 
 	(*pack)->aread = archive_read_disk_new();
@@ -82,8 +82,8 @@ packing_init(struct packing **pack, const char *path, pkg_formats format)
 	pkg_debug(1, "Packing to file '%s'", archive_path);
 	if (archive_write_open_filename(
 	    (*pack)->awrite, archive_path) != ARCHIVE_OK) {
-		pkg_emit_errno("archive_write_open_filename",
-		    archive_path);
+		pkg_errno("%s: %s", __func__,
+			  "archive_write_open_filename: %s", archive_path);
 		archive_read_close((*pack)->aread);
 		archive_read_free((*pack)->aread);
 		archive_write_close((*pack)->awrite);
@@ -115,13 +115,13 @@ packing_append_buffer(struct packing *pack, const char *buffer,
 	archive_entry_set_pathname(entry, path);
 	archive_entry_set_size(entry, size);
 	if (archive_write_header(pack->awrite, entry) == -1) {
-		pkg_emit_errno("archive_write_header", path);
+		pkg_errno("%s: %s", __func__, "archive_write_header: %s", path);
 		ret = EPKG_FATAL;
 		goto cleanup;
 	}
 
 	if (archive_write_data(pack->awrite, buffer, size) == -1) {
-		pkg_emit_errno("archive_write_data", path);
+		pkg_errno("%s: %s", __func__, "archive_write_data: %s", path);
 		ret = EPKG_FATAL;
 	}
 
@@ -152,7 +152,7 @@ packing_append_file_attr(struct packing *pack, const char *filepath,
 	pkg_debug(2, "Packing file '%s'", filepath);
 
 	if (lstat(filepath, &st) != 0) {
-		pkg_emit_errno("lstat", filepath);
+		pkg_errno("%s: %s", __func__, "lstat: %s", filepath);
 		retcode = EPKG_FATAL;
 		goto cleanup;
 	}
@@ -219,7 +219,7 @@ packing_append_file_attr(struct packing *pack, const char *filepath,
 
 	if (archive_entry_size(entry) > 0) {
 		if ((fd = open(filepath, O_RDONLY)) < 0) {
-			pkg_emit_errno("open", filepath);
+			pkg_errno("%s: %s", __func__, "open: %s", filepath);
 			retcode = EPKG_FATAL;
 			goto cleanup;
 		}
@@ -229,13 +229,15 @@ packing_append_file_attr(struct packing *pack, const char *filepath,
 
 			while ((len = read(fd, buf, sizeof(buf))) > 0)
 				if (archive_write_data(pack->awrite, buf, len) == -1) {
-					pkg_emit_errno("archive_write_data", "archive write error");
+					pkg_errno("%s: %s", __func__,
+						  "archive_write_data: archive write error");
 					retcode = EPKG_FATAL;
 					break;
 				}
 
 			if (len == -1) {
-				pkg_emit_errno("read", "file read error");
+				pkg_errno("%s: %s", __func__,
+					  "read: file read error");
 				retcode = EPKG_FATAL;
 			}
 			close(fd);
@@ -245,14 +247,16 @@ packing_append_file_attr(struct packing *pack, const char *filepath,
 					MAP_SHARED, fd, 0)) != MAP_FAILED) {
 				close(fd);
 				if (archive_write_data(pack->awrite, map, st.st_size) == -1) {
-					pkg_emit_errno("archive_write_data", "archive write error");
+					pkg_errno("%s: %s", __func__,
+						  "archive_write_data: archive write error");
 					retcode = EPKG_FATAL;
 				}
 				munmap(map, st.st_size);
 			}
 			else {
 				close(fd);
-				pkg_emit_errno("open", filepath);
+				pkg_errno("%s: %s", __func__,
+					  "open: %s", filepath);
 				retcode = EPKG_FATAL;
 				goto cleanup;
 			}

--- a/libpkg/pkg.c
+++ b/libpkg/pkg.c
@@ -322,24 +322,42 @@ pkg_vset(struct pkg *pkg, va_list ap)
 		case PKG_NAME:
 			free(pkg->name);
 			pkg->name = strdup(va_arg(ap, const char *));
+			if (pkg->name == NULL) {
+				pkg_fatal_errno("%s: %s", __func__, "strdup");
+			}
 			free(pkg->uid);
 			pkg->uid = strdup(pkg->name);
+			if (pkg->uid == NULL) {
+				pkg_fatal_errno("%s: %s", __func__, "strdup");
+			}
 			break;
 		case PKG_ORIGIN:
 			free(pkg->origin);
 			pkg->origin = strdup(va_arg(ap, const char *));
+			if (pkg->origin == NULL) {
+				pkg_fatal_errno("%s: %s", __func__, "strdup");
+			}
 			break;
 		case PKG_VERSION:
 			free(pkg->version);
 			pkg->version = strdup(va_arg(ap, const char *));
+			if (pkg->version == NULL) {
+				pkg_fatal_errno("%s: %s", __func__, "strdup");
+			}
 			break;
 		case PKG_COMMENT:
 			free(pkg->comment);
 			pkg->comment = strdup(va_arg(ap, const char *));
+			if (pkg->comment == NULL) {
+				pkg_fatal_errno("%s: %s", __func__, "strdup");
+			}
 			break;
 		case PKG_DESC:
 			free(pkg->desc);
 			pkg->desc = strdup(va_arg(ap, const char *));
+			if (pkg->desc == NULL) {
+				pkg_fatal_errno("%s: %s", __func__, "strdup");
+			}
 			break;
 		case PKG_MTREE:
 			(void)va_arg(ap, const char *);
@@ -361,50 +379,86 @@ pkg_vset(struct pkg *pkg, va_list ap)
 		case PKG_ARCH:
 			free(pkg->arch);
 			pkg->arch = strdup(va_arg(ap, const char *));
+			if (pkg->arch == NULL) {
+				pkg_fatal_errno("%s: %s", __func__, "strdup");
+			}
 			break;
 		case PKG_ABI:
 			free(pkg->abi);
 			pkg->abi = strdup(va_arg(ap, const char *));
+			if (pkg->abi == NULL) {
+				pkg_fatal_errno("%s: %s", __func__, "strdup");
+			}
 			break;
 		case PKG_MAINTAINER:
 			free(pkg->maintainer);
 			pkg->maintainer = strdup(va_arg(ap, const char *));
+			if (pkg->maintainer == NULL) {
+				pkg_fatal_errno("%s: %s", __func__, "strdup");
+			}
 			break;
 		case PKG_WWW:
 			free(pkg->www);
 			pkg->www = strdup(va_arg(ap, const char *));
+			if (pkg->www == NULL) {
+				pkg_fatal_errno("%s: %s", __func__, "strdup");
+			}
 			break;
 		case PKG_PREFIX:
 			free(pkg->prefix);
 			pkg->prefix = strdup(va_arg(ap, const char *));
+			if (pkg->prefix == NULL) {
+				pkg_fatal_errno("%s: %s", __func__, "strdup");
+			}
 			break;
 		case PKG_REPOPATH:
 			free(pkg->repopath);
 			pkg->repopath = strdup(va_arg(ap, const char *));
+			if (pkg->repopath == NULL) {
+				pkg_fatal_errno("%s: %s", __func__, "strdup");
+			}
 			break;
 		case PKG_CKSUM:
 			free(pkg->sum);
 			pkg->sum = strdup(va_arg(ap, const char *));
+			if (pkg->sum == NULL) {
+				pkg_fatal_errno("%s: %s", __func__, "strdup");
+			}
 			break;
 		case PKG_OLD_VERSION:
 			free(pkg->old_version);
 			pkg->old_version = strdup(va_arg(ap, const char *));
+			if (pkg->old_version == NULL) {
+				pkg_fatal_errno("%s: %s", __func__, "strdup");
+			}
 			break;
 		case PKG_REPONAME:
 			free(pkg->reponame);
 			pkg->reponame = strdup(va_arg(ap, const char *));
+			if (pkg->reponame == NULL) {
+				pkg_fatal_errno("%s: %s", __func__, "strdup");
+			}
 			break;
 		case PKG_REPOURL:
 			free(pkg->repourl);
 			pkg->repourl = strdup(va_arg(ap, const char *));
+			if (pkg->repourl == NULL) {
+				pkg_fatal_errno("%s: %s", __func__, "strdup");
+			}
 			break;
 		case PKG_DIGEST:
 			free(pkg->digest);
 			pkg->digest = strdup(va_arg(ap, const char *));
+			if (pkg->digest == NULL) {
+				pkg_fatal_errno("%s: %s", __func__, "strdup");
+			}
 			break;
 		case PKG_REASON:
 			free(pkg->reason);
 			pkg->reason = strdup(va_arg(ap, const char *));
+			if (pkg->reason == NULL) {
+				pkg_fatal_errno("%s: %s", __func__, "strdup");
+			}
 			break;
 		case PKG_FLATSIZE:
 			pkg->flatsize = va_arg(ap, int64_t);
@@ -433,6 +487,9 @@ pkg_vset(struct pkg *pkg, va_list ap)
 		case PKG_DEP_FORMULA:
 			free(pkg->dep_formula);
 			pkg->dep_formula = strdup(va_arg(ap, const char *));
+			if (pkg->dep_formula == NULL) {
+				pkg_fatal_errno("%s: %s", __func__, "strdup");
+			}
 			break;
 		case PKG_VITAL:
 			pkg->vital = (bool)va_arg(ap, int);
@@ -594,6 +651,9 @@ pkg_adduser(struct pkg *pkg, const char *name)
 	}
 
 	storename = strdup(name);
+	if (storename == NULL) {
+		pkg_fatal_errno("%s: %s", __func__, "strdup");
+	}
 	kh_add(strings, pkg->users, storename, storename, free);
 
 	return (EPKG_OK);
@@ -618,6 +678,9 @@ pkg_addgroup(struct pkg *pkg, const char *name)
 	}
 
 	storename = strdup(name);
+	if (storename == NULL) {
+		pkg_fatal_errno("%s: %s", __func__, "strdup");
+	}
 	kh_add(strings, pkg->groups, storename, storename, free);
 
 	return (EPKG_OK);
@@ -648,10 +711,23 @@ pkg_adddep(struct pkg *pkg, const char *name, const char *origin, const char *ve
 	pkg_dep_new(&d);
 
 	d->origin = strdup(origin);
+	if (d->origin == NULL) {
+		pkg_fatal_errno("%s: %s", __func__, "strdup");
+	}
 	d->name = strdup(name);
-	if (version != NULL && version[0] != '\0')
+	if (d->name == NULL) {
+		pkg_fatal_errno("%s: %s", __func__, "strdup");
+	}
+	if (version != NULL && version[0] != '\0') {
 		d->version = strdup(version);
+		if (d->version == NULL) {
+			pkg_fatal_errno("%s: %s", __func__, "strdup");
+		}
+	}
 	d->uid = strdup(name);
+	if (d->uid == NULL) {
+		pkg_fatal_errno("%s: %s", __func__, "strdup");
+	}
 	d->locked = locked;
 
 	kh_add(pkg_deps, pkg->depshash, d, d->name, pkg_dep_free);
@@ -673,10 +749,23 @@ pkg_addrdep(struct pkg *pkg, const char *name, const char *origin, const char *v
 	pkg_dep_new(&d);
 
 	d->origin = strdup(origin);
+	if (d->origin == NULL) {
+		pkg_fatal_errno("%s: %s", __func__, "strdup");
+	}
 	d->name = strdup(name);
-	if (version != NULL && version[0] != '\0')
+	if (d->name == NULL) {
+		pkg_fatal_errno("%s: %s", __func__, "strdup");
+	}
+	if (version != NULL && version[0] != '\0') {
 		d->version = strdup(version);
+		if (d->version == NULL) {
+			pkg_fatal_errno("%s: %s", __func__, "strdup");
+		}
+	}
 	d->uid = strdup(name);
+	if (d->uid == NULL) {
+		pkg_fatal_errno("%s: %s", __func__, "strdup");
+	}
 	d->locked = locked;
 
 	kh_add(pkg_deps, pkg->rdepshash, d, d->name, pkg_dep_free);
@@ -718,8 +807,12 @@ pkg_addfile_attr(struct pkg *pkg, const char *path, const char *sum,
 	pkg_file_new(&f);
 	strlcpy(f->path, path, sizeof(f->path));
 
-	if (sum != NULL)
+	if (sum != NULL) {
 		f->sum = strdup(sum);
+		if (f->sum == NULL) {
+			pkg_fatal_errno("%s: %s", __func__, "strdup");
+		}
+	}
 
 	if (uname != NULL)
 		strlcpy(f->uname, uname, sizeof(f->uname));
@@ -759,8 +852,12 @@ pkg_addconfig_file(struct pkg *pkg, const char *path, const char *content)
 	pkg_config_file_new(&f);
 	strlcpy(f->path, path, sizeof(f->path));
 
-	if (content != NULL)
+	if (content != NULL) {
 		f->content = strdup(content);
+		if (f->content == NULL) {
+			pkg_fatal_errno("%s: %s", __func__, "strdup");
+		}
+	}
 
 	kh_add(pkg_config_files, pkg->config_files, f, f->path, pkg_config_file_free);
 
@@ -788,6 +885,9 @@ pkg_addstring(kh_strings_t **list, const char *val, const char *title)
 	}
 
 	store = strdup(val);
+	if (store == NULL) {
+		pkg_fatal_errno("%s: %s", __func__, "strdup");
+	}
 	kh_add(strings, *list, store, store, free);
 
 	return (EPKG_OK);
@@ -1007,6 +1107,9 @@ pkg_addoption(struct pkg *pkg, const char *key, const char *value)
 	if (o == NULL) {
 		pkg_option_new(&o);
 		o->key = strdup(key);
+		if (o->key == NULL) {
+			pkg_fatal_errno("%s: %s", __func__, "strdup");
+		}
 	} else if ( o->value != NULL) {
 		if (developer_mode) {
 			pkg_emit_error("duplicate options listing: %s, fatal (developer mode)", key);
@@ -1018,6 +1121,9 @@ pkg_addoption(struct pkg *pkg, const char *key, const char *value)
 	}
 
 	o->value = strdup(value);
+	if (o->value == NULL) {
+		pkg_fatal_errno("%s: %s", __func__, "strdup");
+	}
 	HASH_ADD_KEYPTR(hh, pkg->options, o->key, strlen(o->key), o);
 
 	return (EPKG_OK);
@@ -1043,6 +1149,9 @@ pkg_addoption_default(struct pkg *pkg, const char *key,
 	if (o == NULL) {
 		pkg_option_new(&o);
 		o->key = strdup(key);
+		if (o->key == NULL) {
+			pkg_fatal_errno("%s: %s", __func__, "strdup");
+		}
 	} else if ( o->default_value != NULL) {
 		if (developer_mode) {
 			pkg_emit_error("duplicate default value for option: %s, fatal (developer mode)", key);
@@ -1054,6 +1163,9 @@ pkg_addoption_default(struct pkg *pkg, const char *key,
 	}
 
 	o->default_value = strdup(default_value);
+	if (o->default_value == NULL) {
+		pkg_fatal_errno("%s: %s", __func__, "strdup");
+	}
 	HASH_ADD_KEYPTR(hh, pkg->options, o->default_value,
 	    strlen(o->default_value), o);
 
@@ -1079,6 +1191,9 @@ pkg_addoption_description(struct pkg *pkg, const char *key,
 	if (o == NULL) {
 		pkg_option_new(&o);
 		o->key = strdup(key);
+		if (o->key == NULL) {
+			pkg_fatal_errno("%s: %s", __func__, "strdup");
+		}
 	} else if ( o->description != NULL) {
 		if (developer_mode) {
 			pkg_emit_error("duplicate description for option: %s, fatal (developer mode)", key);
@@ -1090,6 +1205,9 @@ pkg_addoption_description(struct pkg *pkg, const char *key,
 	}
 
 	o->description = strdup(description);
+	if (o->description == NULL) {
+		pkg_fatal_errno("%s: %s", __func__, "strdup");
+	}
 	HASH_ADD_KEYPTR(hh, pkg->options, o->description,
 	    strlen(o->description), o);
 
@@ -1109,6 +1227,9 @@ pkg_addshlib_required(struct pkg *pkg, const char *name)
 		return (EPKG_OK);
 
 	storename = strdup(name);
+	if (storename == NULL) {
+		pkg_fatal_errno("%s: %s", __func__, "strdup");
+	}
 	kh_add(strings, pkg->shlibs_required, storename, storename, free);
 
 	pkg_debug(3, "added shlib deps for %s on %s", pkg->name, name);
@@ -1133,6 +1254,9 @@ pkg_addshlib_provided(struct pkg *pkg, const char *name)
 		return (EPKG_OK);
 
 	storename = strdup(name);
+	if (storename == NULL) {
+		pkg_fatal_errno("%s: %s", __func__, "strdup");
+	}
 	kh_add(strings, pkg->shlibs_provided, storename, storename, free);
 
 	pkg_debug(3, "added shlib provide %s for %s", name, pkg->name);
@@ -1155,6 +1279,9 @@ pkg_addconflict(struct pkg *pkg, const char *uniqueid)
 
 	pkg_conflict_new(&c);
 	c->uid = strdup(uniqueid);
+	if (c->uid == NULL) {
+		pkg_fatal_errno("%s: %s", __func__, "strdup");
+	}
 	pkg_debug(3, "Pkg: add a new conflict origin: %s, with %s", pkg->uid, uniqueid);
 
 	HASH_ADD_KEYPTR(hh, pkg->conflicts, c->uid, strlen(c->uid), c);
@@ -1175,6 +1302,9 @@ pkg_addrequire(struct pkg *pkg, const char *name)
 		return (EPKG_OK);
 
 	storename = strdup(name);
+	if (storename == NULL) {
+		pkg_fatal_errno("%s: %s", __func__, "strdup");
+	}
 
 	kh_add(strings, pkg->requires, storename, storename, free);
 
@@ -1194,6 +1324,9 @@ pkg_addprovide(struct pkg *pkg, const char *name)
 		return (EPKG_OK);
 
 	storename = strdup(name);
+	if (storename == NULL) {
+		pkg_fatal_errno("%s: %s", __func__, "strdup");
+	}
 
 	kh_add(strings, pkg->provides, storename, storename, free);
 
@@ -1449,6 +1582,11 @@ pkg_open2(struct pkg **pkg_p, struct archive **a, struct archive_entry **ae,
 
 			size_t len = archive_entry_size(*ae);
 			buffer = malloc(len);
+			if (buffer == NULL) {
+				pkg_errno("%s: %s", __func__, "malloc");
+				retcode = EPKG_FATAL;
+				goto cleanup;
+			}
 			archive_read_data(*a, buffer, archive_entry_size(*ae));
 			ret = pkg_parse_manifest(pkg, buffer, len, keys);
 			free(buffer);
@@ -1465,6 +1603,11 @@ pkg_open2(struct pkg **pkg_p, struct archive **a, struct archive_entry **ae,
 
 			size_t len = archive_entry_size(*ae);
 			buffer = malloc(len);
+			if (buffer == NULL) {
+				pkg_errno("%s: %s", __func__, "malloc");
+				retcode = EPKG_FATAL;
+				goto cleanup;
+			}
 			archive_read_data(*a, buffer, archive_entry_size(*ae));
 			ret = pkg_parse_manifest(pkg, buffer, len, keys);
 			free(buffer);
@@ -1530,6 +1673,9 @@ pkg_validate(struct pkg *pkg, struct pkgdb *db)
 			return (EPKG_FATAL);
 
 		pkg->uid = strdup(pkg->name);
+		if (pkg->uid == NULL) {
+			pkg_fatal_errno("%s: %s", __func__, "strdup");
+		}
 	}
 
 	if (pkg->digest == NULL || !pkg_checksum_is_valid(pkg->digest,
@@ -1774,10 +1920,13 @@ pkg_message_from_ucl(struct pkg *pkg, const ucl_object_t *obj)
 		msg = calloc(1, sizeof(*msg));
 
 		if (msg == NULL) {
-			pkg_emit_errno("malloc", "struct pkg_message");
-			return (EPKG_FATAL);
+			pkg_fatal_errno("%s: %s", __func__,
+			    "malloc: struct pkg_message");
 		}
 		msg->str = strdup(ucl_object_tostring(obj));
+		if (msg->str == NULL) {
+			pkg_fatal_errno("%s: %s", __func__, "strdup");
+		}
 		msg->type = PKG_MESSAGE_ALWAYS;
 		LL_APPEND(pkg->message, msg);
 		return (EPKG_OK);
@@ -1806,6 +1955,9 @@ pkg_message_from_ucl(struct pkg *pkg, const ucl_object_t *obj)
 		}
 
 		msg->str = strdup(ucl_object_tostring(elt));
+		if (msg->str == NULL) {
+			pkg_fatal_errno("%s: %s", __func__, "strdup");
+		}
 		msg->type = PKG_MESSAGE_ALWAYS;
 		elt = ucl_object_find_key(cur, "type");
 		if (elt != NULL && ucl_object_type(elt) == UCL_STRING) {
@@ -1827,11 +1979,17 @@ pkg_message_from_ucl(struct pkg *pkg, const ucl_object_t *obj)
 		elt = ucl_object_find_key(cur, "minimum_version");
 		if (elt != NULL && ucl_object_type(elt) == UCL_STRING) {
 			msg->minimum_version = strdup(ucl_object_tostring(elt));
+			if (msg->minimum_version == NULL) {
+				pkg_fatal_errno("%s: %s", __func__, "strdup");
+			}
 		}
 
 		elt = ucl_object_find_key(cur, "maximum_version");
 		if (elt != NULL && ucl_object_type(elt) == UCL_STRING) {
 			msg->maximum_version = strdup(ucl_object_tostring(elt));
+			if (msg->maximum_version == NULL) {
+				pkg_fatal_errno("%s: %s", __func__, "strdup");
+			}
 		}
 
 		LL_APPEND(pkg->message, msg);

--- a/libpkg/pkg.c
+++ b/libpkg/pkg.c
@@ -44,8 +44,7 @@ int
 pkg_new(struct pkg **pkg, pkg_t type)
 {
 	if ((*pkg = calloc(1, sizeof(struct pkg))) == NULL) {
-		pkg_emit_errno("calloc", "pkg");
-		return EPKG_FATAL;
+		pkg_fatal_errno("%s: %s", __func__, "calloc: pkg");
 	}
 
 	(*pkg)->type = type;
@@ -1892,8 +1891,7 @@ pkg_open_root_fd(struct pkg *pkg)
 #else
 		if ((pkg->rootfd = dup(rootfd)) == -1 || fcntl(pkg->rootfd, F_SETFD, FD_CLOEXEC) == -1) {
 #endif
-			pkg_emit_errno("dup2", "rootfd");
-			return (EPKG_FATAL);
+			pkg_fatal_errno("%s: %s", __func__, "dup2: rootfd");
 		}
 		return (EPKG_OK);
 	}
@@ -1904,9 +1902,7 @@ pkg_open_root_fd(struct pkg *pkg)
 		return (EPKG_OK);
 
 	pkg->rootpath[0] = '\0';
-	pkg_emit_errno("open", path);
-
-	return (EPKG_FATAL);
+	pkg_fatal_errno("%s: %s", __func__, "open: %s", path);
 }
 
 int
@@ -1950,8 +1946,8 @@ pkg_message_from_ucl(struct pkg *pkg, const ucl_object_t *obj)
 		msg = calloc(1, sizeof(*msg));
 
 		if (msg == NULL) {
-			pkg_emit_errno("malloc", "struct pkg_message");
-			return (EPKG_FATAL);
+			pkg_fatal_errno("%s: %s", __func__,
+					"malloc: struct pkg_message");
 		}
 
 		msg->str = strdup(ucl_object_tostring(elt));

--- a/libpkg/pkg_attributes.c
+++ b/libpkg/pkg_attributes.c
@@ -27,6 +27,7 @@
  */
 
 #include <assert.h>
+#include <errno.h>
 
 #include "pkg.h"
 #include "private/event.h"
@@ -229,7 +230,13 @@ pkg_kv_new(struct pkg_kv **c, const char *key, const char *val)
 		return (EPKG_FATAL);
 
 	(*c)->key = strdup(key);
+	if ((*c)->key == NULL) {
+		pkg_fatal_errno("%s: %s", __func__, "strdup");
+	}
 	(*c)->value = strdup(val);
+	if ((*c)->value == NULL) {
+		pkg_fatal_errno("%s: %s", __func__, "strdup");
+	}
 
 	return (EPKG_OK);
 }

--- a/libpkg/pkg_attributes.c
+++ b/libpkg/pkg_attributes.c
@@ -153,8 +153,7 @@ int
 pkg_option_new(struct pkg_option **option)
 {
 	if ((*option = calloc(1, sizeof(struct pkg_option))) == NULL) {
-		pkg_emit_errno("calloc", "pkg_option");
-		return (EPKG_FATAL);
+		pkg_fatal_errno("%s: %s", __func__, "calloc: pkg_option");
 	}
 	return (EPKG_OK);
 }

--- a/libpkg/pkg_audit.c
+++ b/libpkg/pkg_audit.c
@@ -300,7 +300,8 @@ pkg_audit_fetch(const char *src, const char *dest)
 		    S_IRUSR|S_IRGRP|S_IROTH);
 	}
 	if (outfd == -1) {
-		pkg_emit_errno("pkg_audit_fetch", "open out fd");
+		pkg_errno("%s: %s", __func__,
+			  "pkg_audit_fetch: open out fd");
 		goto cleanup;
 	}
 

--- a/libpkg/pkg_audit.c
+++ b/libpkg/pkg_audit.c
@@ -30,6 +30,7 @@
 
 #include <archive.h>
 #include <err.h>
+#include <errno.h>
 #include <fcntl.h>
 #include <fnmatch.h>
 #include <stdio.h>
@@ -394,6 +395,11 @@ vulnxml_start_element(void *data, const char *element, const char **attributes)
 		for (i = 0; attributes[i]; i += 2) {
 			if (strcasecmp(attributes[i], "vid") == 0) {
 				ud->cur_entry->id = strdup(attributes[i + 1]);
+				if (ud->cur_entry->id == NULL) {
+					pkg_errno("%s: %s", __func__,
+							"strdup");
+					return;
+				}
 				break;
 			}
 		}
@@ -531,6 +537,10 @@ vulnxml_handle_data(void *data, const char *content, int length)
 	case VULNXML_PARSE_CVE:
 		entry = ud->cur_entry;
 		cve = malloc(sizeof(struct pkg_audit_cve));
+		if (cve == NULL) {
+			pkg_errno("%s: %s", __func__, "malloc");
+			return;
+		}
 		cve->cvename = strndup(content, length);
 		LL_PREPEND(entry->cve, cve);
 		break;
@@ -856,6 +866,10 @@ pkg_audit_new(void)
 	struct pkg_audit *audit;
 
 	audit = calloc(1, sizeof(struct pkg_audit));
+	if (audit == NULL) {
+		pkg_errno("%s: %s", __func__, "calloc");
+		return (NULL);
+	}
 
 	return (audit);
 }

--- a/libpkg/pkg_checksum.c
+++ b/libpkg/pkg_checksum.c
@@ -181,6 +181,10 @@ pkg_checksum_add_entry(const char *key,
 
 	e->field = key;
 	e->value = strdup(value);
+	if (e->value == NULL) {
+		pkg_errno("%s: %s", __func__, "strdup");
+		return;
+	}
 	DL_APPEND(*entries, e);
 }
 
@@ -397,6 +401,10 @@ pkg_checksum_hash_sha256_bulk(const unsigned char *in, size_t inlen,
 	SHA256_CTX sign_ctx;
 
 	*out = malloc(SHA256_BLOCK_SIZE);
+	if (*out == NULL) {
+		pkg_errno("%s: %s", __func__, "malloc");
+		return;
+	}
 	sha256_init(&sign_ctx);
 	sha256_update(&sign_ctx, in, inlen);
 	sha256_final(&sign_ctx, *out);
@@ -411,6 +419,10 @@ pkg_checksum_hash_sha256_file(int fd, unsigned char **out, size_t *outlen)
 
 	SHA256_CTX sign_ctx;
 	*out = malloc(SHA256_BLOCK_SIZE);
+	if (*out == NULL) {
+		pkg_errno("%s: %s", __func__, "malloc");
+		return;
+	}
 	sha256_init(&sign_ctx);
 	while ((r = read(fd, buffer, sizeof(buffer))) > 0)
 		sha256_update(&sign_ctx, buffer, r);
@@ -447,6 +459,10 @@ pkg_checksum_hash_blake2_bulk(const unsigned char *in, size_t inlen,
 				unsigned char **out, size_t *outlen)
 {
 	*out = malloc(BLAKE2B_OUTBYTES);
+	if (*out == NULL) {
+		pkg_errno("%s: %s", __func__, "malloc");
+		return;
+	}
 	blake2b(*out, BLAKE2B_OUTBYTES,  in, inlen, NULL, 0);
 	*outlen = BLAKE2B_OUTBYTES;
 }
@@ -464,6 +480,10 @@ pkg_checksum_hash_blake2_file(int fd, unsigned char **out, size_t *outlen)
 		blake2b_update(&st, buffer, r);
 
 	*out = malloc(BLAKE2B_OUTBYTES);
+	if (*out == NULL) {
+		pkg_errno("%s: %s", __func__, "malloc");
+		return;
+	}
 	blake2b_final(&st, *out, BLAKE2B_OUTBYTES);
 	*outlen = BLAKE2B_OUTBYTES;
 }
@@ -497,6 +517,10 @@ pkg_checksum_hash_blake2s_bulk(const unsigned char *in, size_t inlen,
 				unsigned char **out, size_t *outlen)
 {
 	*out = malloc(BLAKE2S_OUTBYTES);
+	if (*out == NULL) {
+		pkg_errno("%s: %s", __func__, "malloc");
+		return;
+	}
 	blake2s(*out, BLAKE2S_OUTBYTES,  in, inlen, NULL, 0);
 	*outlen = BLAKE2S_OUTBYTES;
 }
@@ -514,6 +538,10 @@ pkg_checksum_hash_blake2s_file(int fd, unsigned char **out, size_t *outlen)
 		blake2s_update(&st, buffer, r);
 
 	*out = malloc(BLAKE2S_OUTBYTES);
+	if (*out == NULL) {
+		pkg_errno("%s: %s", __func__, "malloc");
+		return;
+	}
 	blake2s_final(&st, *out, BLAKE2S_OUTBYTES);
 	*outlen = BLAKE2S_OUTBYTES;
 }
@@ -688,6 +716,10 @@ pkg_checksum_data(const unsigned char *in, size_t inlen,
 	if (out != NULL) {
 		if (cksum->encfunc != NULL) {
 			res = malloc(cksum->hlen);
+			if (res == NULL) {
+				pkg_errno("%s: %s", __func__, "malloc");
+				return (NULL);
+			}
 			cksum->encfunc(out, outlen, res, cksum->hlen);
 			free(out);
 		}
@@ -750,6 +782,10 @@ pkg_checksum_fd(int fd, pkg_checksum_type_t type)
 	if (out != NULL) {
 		if (cksum->encfunc != NULL) {
 			res = malloc(cksum->hlen);
+			if (res == NULL) {
+				pkg_errno("%s: %s", __func__, "malloc");
+				return (NULL);
+			}
 			cksum->encfunc(out, outlen, res, cksum->hlen);
 			free(out);
 		} else {

--- a/libpkg/pkg_checksum.c
+++ b/libpkg/pkg_checksum.c
@@ -175,7 +175,7 @@ pkg_checksum_add_entry(const char *key,
 
 	e = malloc(sizeof(*e));
 	if (e == NULL) {
-		pkg_emit_errno("malloc", "pkg_checksum_entry");
+		pkg_errno("%s: %s", __func__, "malloc");
 		return;
 	}
 
@@ -389,7 +389,7 @@ pkg_checksum_hash_sha256(struct pkg_checksum_entry *entries,
 		*outlen = SHA256_BLOCK_SIZE;
 	}
 	else {
-		pkg_emit_errno("malloc", "pkg_checksum_hash_sha256");
+		pkg_errno("%s: %s", __func__, "malloc");
 		*outlen = 0;
 	}
 }
@@ -449,7 +449,7 @@ pkg_checksum_hash_blake2(struct pkg_checksum_entry *entries,
 		*outlen = BLAKE2B_OUTBYTES;
 	}
 	else {
-		pkg_emit_errno("malloc", "pkg_checksum_hash_blake2");
+		pkg_errno("%s: %s", __func__, "malloc");
 		*outlen = 0;
 	}
 }
@@ -507,7 +507,7 @@ pkg_checksum_hash_blake2s(struct pkg_checksum_entry *entries,
 		*outlen = BLAKE2S_OUTBYTES;
 	}
 	else {
-		pkg_emit_errno("malloc", "pkg_checksum_hash_blake2s");
+		pkg_errno("%s: %s", __func__, "malloc");
 		*outlen = 0;
 	}
 }
@@ -674,8 +674,8 @@ pkg_checksum_calculate(struct pkg *pkg, struct pkgdb *db)
 
 	new_digest = malloc(pkg_checksum_type_size(type));
 	if (new_digest == NULL) {
-		pkg_emit_errno("malloc", "pkg_checksum_type_t");
-		return (EPKG_FATAL);
+		pkg_fatal_errno("%s: %s", __func__,
+				"malloc: pkg_checksum_type_t");
 	}
 
 	if (pkg_checksum_generate(pkg, new_digest, pkg_checksum_type_size(type), type)
@@ -738,7 +738,7 @@ pkg_checksum_fileat(int rootfd, const char *path, pkg_checksum_type_t type)
 	unsigned char *ret;
 
 	if ((fd = openat(rootfd, path, O_RDONLY)) == -1) {
-		pkg_emit_errno("open", path);
+		pkg_errno("%s: %s", __func__, "open: %s", path);
 		return (NULL);
 	}
 
@@ -756,7 +756,7 @@ pkg_checksum_file(const char *path, pkg_checksum_type_t type)
 	unsigned char *ret;
 
 	if ((fd = open(path, O_RDONLY)) == -1) {
-		pkg_emit_errno("open", path);
+		pkg_errno("%s: %s", __func__, "open: %s", path);
 		return (NULL);
 	}
 
@@ -818,7 +818,7 @@ pkg_checksum_symlink(const char *path, pkg_checksum_type_t type)
 	int linklen;
 
 	if ((linklen = readlink(path, linkbuf, sizeof(linkbuf) - 1)) == -1) {
-		pkg_emit_errno("pkg_checksum_symlink", "readlink failed");
+		pkg_errno("%s: %s", __func__, "readlink failed");
 		return (NULL);
 	}
 	linkbuf[linklen] = '\0';
@@ -833,7 +833,7 @@ pkg_checksum_symlinkat(int fd, const char *path, pkg_checksum_type_t type)
 	int linklen;
 
 	if ((linklen = readlinkat(fd, path, linkbuf, sizeof(linkbuf) - 1)) == -1) {
-		pkg_emit_errno("pkg_checksum_symlinkat", "readlink failed");
+		pkg_errno("%s: %s", __func__, "readlink failed");
 		return (NULL);
 	}
 	linkbuf[linklen] = '\0';
@@ -887,7 +887,7 @@ pkg_checksum_generate_file(const char *path, pkg_checksum_type_t type)
 	char *cksum;
 
 	if (lstat(path, &st) == -1) {
-		pkg_emit_errno("pkg_checksum_generate_file", "lstat");
+		pkg_errno("%s: %s", __func__, "lstat");
 		return (NULL);
 	}
 
@@ -952,7 +952,7 @@ pkg_checksum_generate_fileat(int rootfd, const char *path,
 	char *cksum;
 
 	if (fstatat(rootfd, path, &st, AT_SYMLINK_NOFOLLOW) == -1) {
-		pkg_emit_errno("pkg_checksum_generate_file", "lstat");
+		pkg_errno("%s: %s", __func__, "lstat");
 		return (NULL);
 	}
 

--- a/libpkg/pkg_config.c
+++ b/libpkg/pkg_config.c
@@ -636,11 +636,19 @@ add_repo(const ucl_object_t *obj, struct pkg_repo *r, const char *rname, pkg_ini
 	if (fingerprints != NULL) {
 		free(r->fingerprints);
 		r->fingerprints = strdup(fingerprints);
+		if (r->fingerprints == NULL) {
+			pkg_errno("%s: %s", __func__, "strdup");
+			return;
+		}
 	}
 
 	if (pubkey != NULL) {
 		free(r->pubkey);
 		r->pubkey = strdup(pubkey);
+		if (r->pubkey == NULL) {
+			pkg_errno("%s: %s", __func__, "strdup");
+			return;
+		}
 	}
 
 	r->enable = enable;
@@ -1235,13 +1243,25 @@ pkg_repo_new(const char *name, const char *url, const char *type)
 	struct pkg_repo *r;
 
 	r = calloc(1, sizeof(struct pkg_repo));
+	if (r == NULL) {
+		pkg_errno("%s: %s", __func__, "calloc");
+		return (NULL);
+	}
 	r->ops = pkg_repo_find_type(type);
 	r->url = strdup(url);
+	if (r->url == NULL) {
+		pkg_errno("%s: %s", __func__, "strdup");
+		return (NULL);
+	}
 	r->signature_type = SIG_NONE;
 	r->mirror_type = NOMIRROR;
 	r->enable = true;
 	r->meta = pkg_repo_meta_default();
 	r->name = strdup(name);
+	if (r->name == NULL) {
+		pkg_errno("%s: %s", __func__, "strdup");
+		return (NULL);
+	}
 	HASH_ADD_KEYPTR(hh, repos, r->name, strlen(r->name), r);
 
 	return (r);
@@ -1254,9 +1274,17 @@ pkg_repo_overwrite(struct pkg_repo *r, const char *name, const char *url,
 
 	free(r->name);
 	r->name = strdup(name);
+	if (r->name == NULL) {
+		pkg_errno("%s: %s", __func__, "strdup");
+		return;
+	}
 	if (url != NULL) {
 		free(r->url);
 		r->url = strdup(url);
+		if (r->url == NULL) {
+			pkg_errno("%s: %s", __func__, "strdup");
+			return;
+		}
 	}
 	r->ops = pkg_repo_find_type(type);
 	HASH_DEL(repos, r);

--- a/libpkg/pkg_config.c
+++ b/libpkg/pkg_config.c
@@ -441,13 +441,15 @@ connect_evpipe(const char *evpipe) {
 	if (S_ISFIFO(st.st_mode)) {
 		flag |= O_NONBLOCK;
 		if ((eventpipe = open(evpipe, flag)) == -1)
-			pkg_emit_errno("open event pipe", evpipe);
+			pkg_errno("%s: %s", __func__,
+				  "open event pipe: %s", evpipe);
 		return;
 	}
 
 	if (S_ISSOCK(st.st_mode)) {
 		if ((eventpipe = socket(AF_UNIX, SOCK_STREAM, 0)) == -1) {
-			pkg_emit_errno("Open event pipe", evpipe);
+			pkg_errno("%s: %s", __func__,
+				  "Open event pipe: %s", evpipe);
 			return;
 		}
 		memset(&sock, 0, sizeof(struct sockaddr_un));
@@ -461,7 +463,8 @@ connect_evpipe(const char *evpipe) {
 		}
 
 		if (connect(eventpipe, (struct sockaddr *)&sock, SUN_LEN(&sock)) == -1) {
-			pkg_emit_errno("Connect event pipe", evpipe);
+			pkg_errno("%s: %s", __func__,
+				  "Connect event pipe: %s", evpipe);
 			close(eventpipe);
 			eventpipe = -1;
 			return;
@@ -959,7 +962,7 @@ pkg_ini(const char *path, const char *reposdir, pkg_init_flags flags)
 	}
 
 	if (path == NULL)
-		conffd = openat(rootfd, PREFIX"/etc/pkg.conf" + 1, 0);
+		conffd = openat(rootfd, PREFIX"/etc/pkg.conf: %s", 1, 0);
 	else
 		conffd = open(path, O_RDONLY);
 	if (conffd == -1 && errno != ENOENT) {

--- a/libpkg/pkg_create.c
+++ b/libpkg/pkg_create.c
@@ -182,7 +182,7 @@ pkg_create_archive(const char *outdir, struct pkg *pkg, pkg_formats format,
 		return NULL;
 
 	if (pkg_asprintf(&pkg_path, "%S/%n-%v", outdir, pkg, pkg) == -1) {
-		pkg_emit_errno("pkg_asprintf", "");
+		pkg_errno("%s: %s", __func__, "pkg_asprintf");
 		return (NULL);
 	}
 
@@ -316,7 +316,7 @@ pkg_load_metadata(struct pkg *pkg, const char *mfile, const char *md_dir,
 
 	if (md_dir != NULL &&
 	    (mfd = open(md_dir, O_DIRECTORY|O_CLOEXEC)) == -1) {
-		pkg_emit_errno("open", md_dir);
+		pkg_errno("%s: %s", __func__, "open: %s", md_dir);
 		goto cleanup;
 	}
 

--- a/libpkg/pkg_create.c
+++ b/libpkg/pkg_create.c
@@ -348,6 +348,9 @@ pkg_load_metadata(struct pkg *pkg, const char *mfile, const char *md_dir,
 	if (pkg->abi == NULL) {
 		pkg_get_myarch(arch, BUFSIZ);
 		pkg->abi = strdup(arch);
+		if (pkg->abi == NULL) {
+			pkg_fatal_errno("%s: %s", __func__, "strdup");
+		}
 		defaultarch = true;
 	}
 
@@ -375,6 +378,9 @@ pkg_load_metadata(struct pkg *pkg, const char *mfile, const char *md_dir,
 			pkg->www = strndup(&pkg->desc[pmatch[1].rm_so], size);
 		} else {
 			pkg->www = strdup("UNKNOWN");
+			if (pkg->www == NULL) {
+				pkg_fatal_errno("%s: %s", __func__, "strdup");
+			}
 		}
 		regfree(&preg);
 	}

--- a/libpkg/pkg_cudf.c
+++ b/libpkg/pkg_cudf.c
@@ -26,6 +26,7 @@
 
 #include <stdio.h>
 #include <ctype.h>
+#include <errno.h>
 
 #include "pkg.h"
 #include "private/event.h"
@@ -336,7 +337,7 @@ pkg_jobs_cudf_insert_res_job (struct pkg_solved **target,
 
 	res = calloc(1, sizeof(struct pkg_solved));
 	if (res == NULL) {
-		pkg_emit_errno("calloc", "pkg_solved");
+		pkg_errno("%s: %s", __func__, "calloc: pkg_solved");
 		return;
 	}
 

--- a/libpkg/pkg_delete.c
+++ b/libpkg/pkg_delete.c
@@ -169,6 +169,10 @@ pkg_add_dir_to_del(struct pkg *pkg, const char *file, const char *dir)
 			    pkg->dir_to_del[i], path);
 			free(pkg->dir_to_del[i]);
 			pkg->dir_to_del[i] = strdup(path);
+			if (pkg->dir_to_del[i] == NULL) {
+				pkg_errno("%s: %s", __func__, "strdup");
+				return;
+			}
 			return;
 		}
 	}
@@ -179,9 +183,17 @@ pkg_add_dir_to_del(struct pkg *pkg, const char *file, const char *dir)
 		pkg->dir_to_del_cap += 64;
 		pkg->dir_to_del = realloc(pkg->dir_to_del,
 		    pkg->dir_to_del_cap * sizeof(char *));
+		if (pkg->dir_to_del == NULL) {
+			pkg_errno("%s: %s", __func__, "realloc");
+			return;
+		}
 	}
 
 	pkg->dir_to_del[pkg->dir_to_del_len++] = strdup(path);
+	if (pkg->dir_to_del[pkg->dir_to_del_len] == NULL) {
+		pkg_errno("%s: %s", __func__, "strdup");
+		return;
+	}
 }
 
 static void
@@ -408,8 +420,16 @@ pkg_delete_dir(struct pkg *pkg, struct pkg_dir *dir)
 			pkg->dir_to_del_cap += 64;
 			pkg->dir_to_del = realloc(pkg->dir_to_del,
 			    pkg->dir_to_del_cap * sizeof(char *));
+			if (pkg->dir_to_del == NULL) {
+				pkg_errno("%s: %s", __func__, "realloc");
+				return;
+			}
 		}
 		pkg->dir_to_del[pkg->dir_to_del_len++] = strdup(path);
+		if (pkg->dir_to_del[pkg->dir_to_del_len] == NULL) {
+			pkg_errno("%s: %s", __func__, "strdup");
+			return;
+		}
 	}
 }
 

--- a/libpkg/pkg_delete.c
+++ b/libpkg/pkg_delete.c
@@ -251,7 +251,7 @@ rmdir_p(struct pkgdb *db, struct pkg *pkg, char *dir, const char *prefix_r)
 
 	if (unlinkat(pkg->rootfd, dir, AT_REMOVEDIR) == -1) {
 		if (errno != ENOTEMPTY && errno != EBUSY)
-			pkg_emit_errno("unlinkat", dir);
+			pkg_errno("%s: %s", __func__, "unlinkat: %s", dir);
 		/* If the directory was already removed by a bogus script, continue removing parents */
 		if (errno != ENOENT)
 			return;
@@ -354,7 +354,8 @@ pkg_delete_file(struct pkg *pkg, struct pkg_file *file, unsigned force)
 			if (errno == ENOENT)
 				pkg_emit_file_missing(pkg, file);
 			else
-				pkg_emit_errno("unlinkat", path);
+				pkg_errno("%s: %s", __func__,
+				          "unlinkat: %s", path);
 		}
 		return;
 	}

--- a/libpkg/pkg_deps.c
+++ b/libpkg/pkg_deps.c
@@ -30,6 +30,7 @@
 
 #include <stddef.h>
 #include <ctype.h>
+#include <errno.h>
 #include <assert.h>
 #include <string.h>
 #include <stdlib.h>
@@ -84,14 +85,16 @@ pkg_deps_parse_formula(const char *in)
 					cur_item = calloc(1, sizeof(*cur_item));
 
 					if (cur_item == NULL) {
-						pkg_emit_errno("malloc", "struct pkg_dep_formula_item");
+						pkg_errno("%s: %s", __func__,
+							  "malloc: struct pkg_dep_formula_item");
 
 						return (NULL);
 					}
 					cur_item->name = malloc(p - c + 1);
 
 					if (cur_item->name == NULL) {
-						pkg_emit_errno("malloc", "cur->name");
+						pkg_errno("%s: %s", __func__,
+							  "malloc: cur->name");
 
 						return (NULL);
 					}
@@ -108,14 +111,16 @@ pkg_deps_parse_formula(const char *in)
 					cur_item = calloc(1, sizeof(*cur_item));
 
 					if (cur_item == NULL) {
-						pkg_emit_errno("malloc", "struct pkg_dep_formula_item");
+						pkg_errno("%s: %s", __func__,
+							  "malloc: struct pkg_dep_formula_item");
 
 						return (NULL);
 					}
 					cur_item->name = malloc(p - c + 1);
 
 					if (cur_item->name == NULL) {
-						pkg_emit_errno("malloc", "cur->name");
+						pkg_errno("%s: %s", __func__,
+							  "malloc: cur->name");
 
 						return (NULL);
 					}
@@ -238,14 +243,16 @@ pkg_deps_parse_formula(const char *in)
 					cur_ver = calloc(1, sizeof(*cur_ver));
 
 					if (cur_ver == NULL) {
-						pkg_emit_errno("malloc", "struct pkg_dep_version");
+						pkg_errno("%s: %s", __func__,
+							  "malloc: struct pkg_dep_version");
 
 						return (NULL);
 					}
 					cur_ver->ver = malloc(p - c + 1);
 
 					if (cur_ver->ver == NULL) {
-						pkg_emit_errno("malloc", "cur_ver->ver");
+						pkg_errno("%s: %s", __func__,
+							  "malloc: cur_ver->ver");
 
 						return (NULL);
 					}
@@ -266,7 +273,8 @@ pkg_deps_parse_formula(const char *in)
 		case st_parse_option_start:
 			cur_opt = calloc(1, sizeof(*cur_opt));
 			if (cur_opt == NULL) {
-				pkg_emit_errno("malloc", "struct pkg_dep_option");
+				pkg_errno("%s: %s", __func__,
+					  "malloc: struct pkg_dep_option");
 
 				return (NULL);
 			}
@@ -292,7 +300,8 @@ pkg_deps_parse_formula(const char *in)
 					cur_opt->opt = malloc(p - c + 1);
 
 					if (cur_opt->opt == NULL) {
-						pkg_emit_errno("malloc", "cur_opt->opt");
+						pkg_errno("%s: %s", __func__,
+							  "malloc: cur_opt->opt");
 
 						return (NULL);
 					}
@@ -316,7 +325,8 @@ pkg_deps_parse_formula(const char *in)
 				cur = calloc(1, sizeof(*cur));
 
 				if (cur == NULL) {
-					pkg_emit_errno("malloc", "struct pkg_dep_formula");
+					pkg_errno("%s: %s", __func__,
+						  "malloc: struct pkg_dep_formula");
 
 					return (NULL);
 				}
@@ -338,7 +348,8 @@ pkg_deps_parse_formula(const char *in)
 				cur = calloc(1, sizeof(*cur));
 
 				if (cur == NULL) {
-					pkg_emit_errno("malloc", "struct pkg_dep_formula");
+					pkg_errno("%s: %s", __func__,
+						  "malloc: struct pkg_dep_formula");
 
 					return (NULL);
 				}
@@ -489,7 +500,7 @@ pkg_deps_formula_tostring(struct pkg_dep_formula *f)
 	res = malloc(rlen + 1);
 
 	if (res == NULL) {
-		pkg_emit_errno("malloc", "string");
+		pkg_errno("%s: %s", __func__, "malloc: string");
 
 		return (NULL);
 	}
@@ -556,7 +567,7 @@ pkg_deps_formula_tosql(struct pkg_dep_formula_item *f)
 	res = malloc(rlen + 1);
 
 	if (res == NULL) {
-		pkg_emit_errno("malloc", "string");
+		pkg_errno("%s: %s", __func__, "malloc: string");
 
 		return (NULL);
 	}

--- a/libpkg/pkg_elf.c
+++ b/libpkg/pkg_elf.c
@@ -45,6 +45,7 @@
 #include <assert.h>
 #include <ctype.h>
 #include <dlfcn.h>
+#include <errno.h>
 #include <fcntl.h>
 #include <gelf.h>
 #include <libgen.h>
@@ -263,7 +264,7 @@ analyse_elf(struct pkg *pkg, const char *fpath)
 
 	pkg_debug(1, "analysing elf %s", fpath);
 	if (lstat(fpath, &sb) != 0)
-		pkg_emit_errno("fstat() failed for", fpath);
+		pkg_errno("%s: %s", __func__, "fstat() failed for: %s", fpath);
 	/* ignore empty files and non regular files */
 	if (sb.st_size == 0 || !S_ISREG(sb.st_mode))
 		return (EPKG_END); /* Empty file or sym-link: no results */
@@ -724,7 +725,7 @@ pkg_get_myarch_elfparse(char *dest, size_t sz)
 	}
 
 	if ((fd = open(path, O_RDONLY)) < 0) {
-		pkg_emit_errno("open", _PATH_BSHELL);
+		pkg_errno("%s: %s", __func__, "open: %s", _PATH_BSHELL);
 		snprintf(dest, sz, "%s", "unknown");
 		return (EPKG_FATAL);
 	}

--- a/libpkg/pkg_jobs.c
+++ b/libpkg/pkg_jobs.c
@@ -78,8 +78,7 @@ pkg_jobs_new(struct pkg_jobs **j, pkg_jobs_t t, struct pkgdb *db)
 	assert(db != NULL);
 
 	if ((*j = calloc(1, sizeof(struct pkg_jobs))) == NULL) {
-		pkg_emit_errno("calloc", "pkg_jobs");
-		return (EPKG_FATAL);
+		pkg_fatal_errno("%s: %s", __func__, "calloc: pkg_jobs");
 	}
 
 	(*j)->universe = pkg_jobs_universe_new(*j);
@@ -317,7 +316,8 @@ pkg_jobs_add_req_from_universe(struct pkg_job_request **head,
 	if (req == NULL) {
 		req = calloc(1, sizeof(*req));
 		if (req == NULL) {
-			pkg_emit_errno("malloc", "struct pkg_job_request");
+			pkg_errno("%s: %s", __func__,
+				  "malloc: struct pkg_job_request");
 			return (NULL);
 		}
 		new_req = true;
@@ -336,7 +336,8 @@ pkg_jobs_add_req_from_universe(struct pkg_job_request **head,
 				(uit->pkg->type != PKG_INSTALLED && !local)) {
 			nit = calloc(1, sizeof(*nit));
 			if (nit == NULL) {
-				pkg_emit_errno("malloc", "struct pkg_job_request_item");
+				pkg_errno("%s: %s", __func__,
+					  "malloc: struct pkg_job_request_item");
 				free(req);
 				return (NULL);
 			}
@@ -420,7 +421,8 @@ pkg_jobs_add_req(struct pkg_jobs *j, struct pkg *pkg)
 
 	nit = calloc(1, sizeof(*nit));
 	if (nit == NULL) {
-		pkg_emit_errno("malloc", "struct pkg_job_request_item");
+		pkg_errno("%s: %s", __func__,
+			  "malloc: struct pkg_job_request_item");
 		return (NULL);
 	}
 	nit->pkg = pkg;
@@ -430,7 +432,8 @@ pkg_jobs_add_req(struct pkg_jobs *j, struct pkg *pkg)
 		/* Allocate new unique request item */
 		req = calloc(1, sizeof(*req));
 		if (req == NULL) {
-			pkg_emit_errno("malloc", "struct pkg_job_request");
+			pkg_errno("%s: %s", __func__,
+				  "malloc: struct pkg_job_request");
 			free(nit);
 			return (NULL);
 		}
@@ -603,8 +606,8 @@ pkg_jobs_set_execute_priority(struct pkg_jobs *j, struct pkg_solved *solved)
 			 */
 			ts = calloc(1, sizeof(struct pkg_solved));
 			if (ts == NULL) {
-				pkg_emit_errno("calloc", "pkg_solved");
-				return (EPKG_FATAL);
+				pkg_fatal_errno("%s: %s", __func__,
+						"calloc: pkg_solved");
 			}
 
 			ts->type = PKG_SOLVED_UPGRADE_REMOVE;
@@ -1539,7 +1542,8 @@ pkg_jobs_new_candidate(struct pkg *pkg)
 
 	n = malloc(sizeof(*n));
 	if (n == NULL) {
-		pkg_emit_errno("malloc", "pkg_jobs_install_candidate");
+		pkg_errno("%s: %s", __func__,
+			  "malloc: pkg_jobs_install_candidate");
 		return (NULL);
 	}
 	n->id = pkg->id;
@@ -1885,7 +1889,9 @@ again:
 						dot = fopen(dotfile, "w");
 
 						if (dot == NULL) {
-							pkg_emit_errno("fopen", dotfile);
+							pkg_errno("%s: %s",
+								  __func__,
+								  "fopen: %s", dotfile);
 						}
 					}
 
@@ -2287,8 +2293,8 @@ pkg_jobs_fetch(struct pkg_jobs *j)
 			if (mkdirs(cachedir) != EPKG_OK)
 				return (EPKG_FATAL);
 		} else {
-			pkg_emit_errno("statfs", cachedir);
-			return (EPKG_FATAL);
+			pkg_fatal_errno("%s: %s", __func__, "statfs: %s",
+					cachedir);
 		}
 	}
 	fs_avail = fs.f_bsize * (int64_t)fs.f_bavail;
@@ -2299,8 +2305,8 @@ pkg_jobs_fetch(struct pkg_jobs *j)
 			if (mkdirs(cachedir) != EPKG_OK)
 				return (EPKG_FATAL);
 		} else {
-			pkg_emit_errno("statvfs", cachedir);
-			return (EPKG_FATAL);
+			pkg_fatal_errno("%s: %s", __func__, "statvfs: %s",
+					cachedir);
 		}
 	}
 	fs_avail = fs.f_bsize * (int64_t)fs.f_bavail;

--- a/libpkg/pkg_jobs.c
+++ b/libpkg/pkg_jobs.c
@@ -207,6 +207,10 @@ pkg_jobs_maybe_match_file(struct job_pattern *jp, const char *pattern)
 				jp->flags |= PKG_PATTERN_FLAG_FILE;
 				jp->path = pkg_path;
 				jp->pattern = malloc(len);
+				if (jp->pattern == NULL) {
+					pkg_fatal_errno("%s: %s", __func__,
+							"malloc");
+				}
 				strlcpy(jp->pattern, pattern, len);
 
 				return (true);
@@ -219,7 +223,13 @@ pkg_jobs_maybe_match_file(struct job_pattern *jp, const char *pattern)
 		 */
 		jp->flags = PKG_PATTERN_FLAG_FILE;
 		jp->path = strdup(pattern);
+		if (jp->path == NULL) {
+			pkg_fatal_errno("%s: %s", __func__, "strdup");
+		}
 		jp->pattern = strdup(pattern);
+		if (jp->pattern == NULL) {
+			pkg_fatal_errno("%s: %s", __func__, "strdup");
+		}
 	}
 
 	return (false);
@@ -239,9 +249,15 @@ pkg_jobs_add(struct pkg_jobs *j, match_t match, char **argv, int argc)
 
 	for (i = 0; i < argc; i++) {
 		jp = calloc(1, sizeof(struct job_pattern));
+		if (jp == NULL) {
+			pkg_fatal_errno("%s: %s", __func__, "calloc");
+		}
 		if (j->type == PKG_JOBS_DEINSTALL ||
 		    !pkg_jobs_maybe_match_file(jp, argv[i])) {
 			jp->pattern = strdup(argv[i]);
+			if (jp->pattern == NULL) {
+				pkg_fatal_errno("%s: %s", __func__, "strdup");
+			}
 			jp->match = match;
 		}
 		HASH_ADD_KEYPTR(hh, j->patterns, jp->pattern, strlen(jp->pattern), jp);
@@ -249,6 +265,9 @@ pkg_jobs_add(struct pkg_jobs *j, match_t match, char **argv, int argc)
 
 	if (argc == 0 && match == MATCH_ALL) {
 		jp = calloc(1, sizeof(struct job_pattern));
+		if (jp == NULL) {
+			pkg_fatal_errno("%s: %s", __func__, "calloc");
+		}
 		jp->pattern = NULL;
 		jp->match = match;
 		HASH_ADD_KEYPTR(hh, j->patterns, "all", 3, jp);
@@ -908,6 +927,9 @@ pkg_jobs_guess_upgrade_candidate(struct pkg_jobs *j, const char *pattern)
 	if (olen != len) {
 		/* Try exact pattern without numbers */
 		cpy = malloc(len + 1);
+		if (cpy == NULL) {
+			pkg_fatal_errno("%s: %s", __func__, "malloc");
+		}
 		strlcpy(cpy, pos, len + 1);
 		if (pkg_jobs_try_remote_candidate(j, cpy, opattern, MATCH_EXACT) != EPKG_OK) {
 			free(cpy);
@@ -1184,12 +1206,19 @@ pkg_jobs_need_upgrade(struct pkg *rp, struct pkg *lp)
 		if (ret1 != ret2) {
 			free(rp->reason);
 			rp->reason = strdup("direct conflict changed");
+			if (rp->reason == NULL) {
+				pkg_fatal_errno("%s: %s", __func__, "strdup");
+			}
 			return (true);
 		}
 		if (ret1 == EPKG_OK) {
 			if (strcmp(rc->uid, lc->uid) != 0) {
 				free(rp->reason);
 				rp->reason = strdup("direct conflict changed");
+				if (rp->reason == NULL) {
+					pkg_fatal_errno("%s: %s", __func__,
+							"strdup");
+				}
 				return (true);
 			}
 		}
@@ -1205,12 +1234,19 @@ pkg_jobs_need_upgrade(struct pkg *rp, struct pkg *lp)
 		if (ret1 != ret2) {
 			free(rp->reason);
 			rp->reason = strdup("provides changed");
+			if (rp->reason == NULL) {
+				pkg_fatal_errno("%s: %s", __func__, "strdup");
+			}
 			return (true);
 		}
 		if (ret1 == EPKG_OK) {
 			if (strcmp(rb, lb) != 0) {
 				free(rp->reason);
 				rp->reason = strdup("provides changed");
+				if (rp->reason == NULL) {
+					pkg_fatal_errno("%s: %s", __func__,
+							"strdup");
+				}
 				return (true);
 			}
 		}
@@ -1225,12 +1261,19 @@ pkg_jobs_need_upgrade(struct pkg *rp, struct pkg *lp)
 		if (ret1 != ret2) {
 			free(rp->reason);
 			rp->reason = strdup("requires changed");
+			if (rp->reason == NULL) {
+				pkg_fatal_errno("%s: %s", __func__, "strdup");
+			}
 			return (true);
 		}
 		if (ret1 == EPKG_OK) {
 			if (strcmp(rb, lb) != 0) {
 				free(rp->reason);
 				rp->reason = strdup("requires changed");
+				if (rp->reason == NULL) {
+					pkg_fatal_errno("%s: %s", __func__,
+							"strdup");
+				}
 				return (true);
 			}
 		}
@@ -1246,12 +1289,19 @@ pkg_jobs_need_upgrade(struct pkg *rp, struct pkg *lp)
 		if (ret1 != ret2) {
 			free(rp->reason);
 			rp->reason = strdup("provided shared library changed");
+			if (rp->reason == NULL) {
+				pkg_fatal_errno("%s: %s", __func__, "strdup");
+			}
 			return (true);
 		}
 		if (ret1 == EPKG_OK) {
 			if (strcmp(rb, lb) != 0) {
 				free(rp->reason);
 				rp->reason = strdup("provided shared library changed");
+				if (rp->reason == NULL) {
+					pkg_fatal_errno("%s: %s", __func__,
+							"strdup");
+				}
 				pkg_debug(1, "provided shlib changed %s -> %s",
 				    lb, rb);
 				return (true);
@@ -1268,12 +1318,19 @@ pkg_jobs_need_upgrade(struct pkg *rp, struct pkg *lp)
 		if (ret1 != ret2) {
 			free(rp->reason);
 			rp->reason = strdup("needed shared library changed");
+			if (rp->reason == NULL) {
+				pkg_fatal_errno("%s: %s", __func__, "strdup");
+			}
 			return (true);
 		}
 		if (ret1 == EPKG_OK) {
 			if (strcmp(rb, lb) != 0) {
 				free(rp->reason);
 				rp->reason = strdup("needed shared library changed");
+				if (rp->reason == NULL) {
+					pkg_fatal_errno("%s: %s", __func__,
+							"strdup");
+				}
 				pkg_debug(1, "Required shlib changed %s -> %s",
 				    lb, rb);
 				return (true);
@@ -1963,6 +2020,9 @@ pkg_jobs_handle_install(struct pkg_solved *ps, struct pkg_jobs *j,
 		target = req->item->jp->path;
 		free(new->reponame);
 		new->reponame = strdup("local file");
+		if (new->reponame == NULL) {
+			pkg_fatal_errno("%s: %s", __func__, "strdup");
+		}
 	}
 	else {
 		pkg_snprintf(path, sizeof(path), "%R", new);
@@ -1971,8 +2031,12 @@ pkg_jobs_handle_install(struct pkg_solved *ps, struct pkg_jobs *j,
 		target = path;
 	}
 
-	if (old != NULL)
+	if (old != NULL) {
 		new->old_version = strdup(old->version);
+		if (new->old_version == NULL) {
+			pkg_fatal_errno("%s: %s", __func__, "strdup");
+		}
+	}
 
 	if ((j->flags & PKG_FLAG_FORCE) == PKG_FLAG_FORCE)
 		flags |= PKG_ADD_FORCE;

--- a/libpkg/pkg_jobs_conflicts.c
+++ b/libpkg/pkg_jobs_conflicts.c
@@ -124,7 +124,7 @@ pkg_conflicts_request_add_chain(struct pkg_conflict_chain **chain, struct pkg_jo
 
 	elt = calloc(1, sizeof(struct pkg_conflict_chain));
 	if (elt == NULL) {
-		pkg_emit_errno("resolve_request_conflicts", "calloc: struct pkg_conflict_chain");
+		pkg_errno("%s: %s", __func__, "calloc: struct pkg_conflict_chain");
 		return;
 	}
 	elt->req = req;
@@ -455,7 +455,7 @@ pkg_conflicts_check_all_paths(struct pkg_jobs *j, const char *path,
 		/* New entry */
 		cit = calloc(1, sizeof(*cit));
 		if (cit == NULL) {
-			pkg_emit_errno("malloc failed", "pkg_conflicts_check_all_paths");
+			pkg_errno("%s: %s", __func__, "malloc failed");
 		}
 		else {
 			cit->hash = hv;

--- a/libpkg/pkg_jobs_universe.c
+++ b/libpkg/pkg_jobs_universe.c
@@ -887,6 +887,11 @@ pkg_jobs_universe_change_uid(struct pkg_jobs_universe *universe,
 					if (strcmp(d->uid, unit->pkg->uid) == 0) {
 						free(d->uid);
 						d->uid = strdup(new_uid);
+						if (d->uid == NULL) {
+							pkg_errno("%s: %s",
+							    __func__, "strdup");
+							return;
+						}
 					}
 				}
 			}
@@ -896,13 +901,25 @@ pkg_jobs_universe_change_uid(struct pkg_jobs_universe *universe,
 	replacement = calloc(1, sizeof(*replacement));
 	if (replacement != NULL) {
 		replacement->old_uid = strdup(unit->pkg->uid);
+		if (replacement->old_uid == NULL) {
+			pkg_errno("%s: %s", __func__, "strdup");
+			return;
+		}
 		replacement->new_uid = strdup(new_uid);
+		if (replacement->new_uid == NULL) {
+			pkg_errno("%s: %s", __func__, "strdup");
+			return;
+		}
 		LL_PREPEND(universe->uid_replaces, replacement);
 	}
 
 	HASH_DELETE(hh, universe->items, unit);
 	free(unit->pkg->uid);
 	unit->pkg->uid = strdup(new_uid);
+	if (unit->pkg->uid == NULL) {
+		pkg_errno("%s: %s", __func__, "strdup");
+		return;
+	}
 
 	HASH_FIND(hh, universe->items, new_uid, uidlen, found);
 	if (found != NULL)

--- a/libpkg/pkg_jobs_universe.c
+++ b/libpkg/pkg_jobs_universe.c
@@ -208,8 +208,8 @@ pkg_jobs_universe_add_pkg(struct pkg_jobs_universe *universe, struct pkg *pkg,
 
 	item = calloc(1, sizeof (struct pkg_job_universe_item));
 	if (item == NULL) {
-		pkg_emit_errno("pkg_jobs_pkg_insert_universe", "calloc: struct pkg_job_universe_item");
-		return (EPKG_FATAL);
+		pkg_fatal_errno("%s: %s", __func__,
+				"calloc: struct pkg_job_universe_item");
 	}
 
 	item->pkg = pkg;
@@ -444,9 +444,9 @@ pkg_jobs_universe_handle_provide(struct pkg_jobs_universe *universe,
 
 		pr = calloc (1, sizeof (*pr));
 		if (pr == NULL) {
-			pkg_emit_errno("pkg_jobs_add_universe", "calloc: "
-					"struct pkg_job_provide");
-			return (EPKG_FATAL);
+			pkg_fatal_errno("%s: %s", __func__,
+				  "pkg_jobs_add_universe: calloc: %s",
+				  "struct pkg_job_provide");
 		}
 
 		pr->un = unit;
@@ -841,7 +841,8 @@ pkg_jobs_universe_new(struct pkg_jobs *j)
 
 	universe = calloc(1, sizeof(struct pkg_jobs_universe));
 	if (universe == NULL) {
-		pkg_emit_errno("pkg_jobs_universe_new", "calloc");
+		pkg_errno("%s: %s", __func__,
+			  "pkg_jobs_universe_new: calloc");
 		return (NULL);
 	}
 

--- a/libpkg/pkg_macho.c
+++ b/libpkg/pkg_macho.c
@@ -178,6 +178,9 @@ parse_major_release(const char *src, long long *release)
 	char *eos;
 
 	parsed = strdup(src);
+	if (parsed == NULL) {
+		pkg_fatal_errno("%s: %s", __func__, "strdup");
+	}
 	eos = strchr(parsed, '.');
 	if (eos == NULL) {
 		pkg_emit_error("failed to parse major release version from %s", src);

--- a/libpkg/pkg_macho.c
+++ b/libpkg/pkg_macho.c
@@ -69,7 +69,7 @@ analyse_macho(struct pkg *pkg, const char *fpath,
 	cpu_type = cpu_type & ~CPU_ARCH_MASK;
 
 	if (lstat(fpath, &sb) != 0)
-		pkg_emit_errno("fstat() failed for", fpath);
+		pkg_errno("%s: %s", __func__, "fstat() failed for: %s", fpath);
 
 	/* ignore empty files and non regular files */
 	if (sb.st_size == 0 || !S_ISREG(sb.st_mode))
@@ -215,8 +215,8 @@ host_cpu_type(cpu_type_t *result)
 	/* Fetch CPU type */
 	len = sizeof(resint);
 	if (sysctlbyname("hw.cputype", &resint, &len, NULL, 0) != 0) {
-		pkg_emit_errno("sysctlbyname", "hw.cputype");
-		return EPKG_FATAL;
+		pkg_fatal_errno("%s: %s", __func__,
+				"sysctlbyname: hw.cputype");
 	}
 
 	*result = resint;
@@ -237,8 +237,7 @@ host_os_info(char *osname, size_t sz, long long *major_version)
 
 	/* Fetch OS info from uname() */
 	if (uname(&ut) != 0) {
-		pkg_emit_errno("uname", "&ut");
-		return EPKG_FATAL;
+		pkg_fatal_errno("%s: %s", __func__, "uname: &ut");
 	}
 
 	/* Provide the OS name to the caller. */

--- a/libpkg/pkg_old.c
+++ b/libpkg/pkg_old.c
@@ -28,7 +28,10 @@
 #include <regex.h>
 
 #include <pkg.h>
+#include <errno.h>
+
 #include <private/pkg.h>
+#include <private/event.h>
 
 static const char * const scripts[] = {
 	"+INSTALL",
@@ -94,13 +97,22 @@ pkg_old_load_from_path(struct pkg *pkg, const char *path)
 
 	pkg_get_myarch(myarch, BUFSIZ);
 	pkg->arch = strdup(myarch);
+	if (pkg->arch == NULL) {
+		pkg_fatal_errno("%s: %s", __func__, "strdup");
+	}
 	pkg->maintainer = strdup("unknown");
+	if (pkg->maintainer == NULL) {
+		pkg_fatal_errno("%s: %s", __func__, "strdup");
+	}
 	regcomp(&preg, "^WWW:[[:space:]]*(.*)$", REG_EXTENDED|REG_ICASE|REG_NEWLINE);
 	if (regexec(&preg, pkg->desc, 2, pmatch, 0) == 0) {
 		size = pmatch[1].rm_eo - pmatch[1].rm_so;
 		pkg->www = strndup(&pkg->desc[pmatch[1].rm_so], size);
 	} else {
 		pkg->www = strdup("UNKNOWN");
+		if (pkg->www == NULL) {
+			pkg_fatal_errno("%s: %s", __func__, "strdup");
+		}
 	}
 	regfree(&preg);
 

--- a/libpkg/pkg_ports.c
+++ b/libpkg/pkg_ports.c
@@ -176,8 +176,12 @@ setprefix(struct plist *p, char *line, struct file_attr *a)
 	else
 		strlcpy(p->prefix, line, sizeof(p->prefix));
 
-	if (p->pkg->prefix == NULL)
+	if (p->pkg->prefix == NULL) {
 		p->pkg->prefix = strdup(line);
+		if (p->pkg->prefix == NULL) {
+			pkg_fatal_errno("%s: %s", __func__, "strdup");
+		}
+	}
 
 	p->slash = p->prefix[strlen(p->prefix) -1] == '/' ? "" : "/";
 
@@ -200,7 +204,13 @@ name_key(struct plist *p, char *line, struct file_attr *a)
 	tmp[0] = '\0';
 	tmp++;
 	p->pkg->name = strdup(line);
+	if (p->pkg->name == NULL) {
+		pkg_fatal_errno("%s: %s", __func__, "strdup");
+	}
 	p->pkg->version = strdup(tmp);
+	if (p->pkg->version == NULL) {
+		pkg_fatal_errno("%s: %s", __func__, "strdup");
+	}
 
 	return (EPKG_OK);
 }
@@ -211,6 +221,9 @@ pkgdep(struct plist *p, char *line, struct file_attr *a)
 	if (*line != '\0') {
 		free(p->pkgdep);
 		p->pkgdep = strdup(line);
+		if (p->pkgdep == NULL) {
+			pkg_fatal_errno("%s: %s", __func__, "strdup");
+		}
 	}
 	return (EPKG_OK);
 }
@@ -430,10 +443,18 @@ static int
 setowner(struct plist *p, char *line, struct file_attr *a)
 {
 	free(p->uname);
-	if (line[0] == '\0')
+	if (line[0] == '\0') {
 		p->uname = strdup("root");
-	else
+		if (p->uname == NULL) {
+			pkg_fatal_errno("%s: %s", __func__, "strdup");
+		}
+	}
+	else {
 		p->uname = strdup(line);
+		if (p->uname == NULL) {
+			pkg_fatal_errno("%s: %s", __func__, "strdup");
+		}
+	}
 	return (EPKG_OK);
 }
 
@@ -441,10 +462,18 @@ static int
 setgroup(struct plist *p, char *line, struct file_attr *a)
 {
 	free(p->gname);
-	if (line[0] == '\0')
+	if (line[0] == '\0') {
 		p->gname = strdup("wheel");
-	else
+		if (p->gname == NULL) {
+			pkg_fatal_errno("%s: %s", __func__, "strdup");
+		}
+	}
+	else {
 		p->gname = strdup(line);
+		if (p->gname == NULL) {
+			pkg_fatal_errno("%s: %s", __func__, "strdup");
+		}
+	}
 	return (EPKG_OK);
 }
 
@@ -468,6 +497,9 @@ comment_key(struct plist *p, char *line, struct file_attr *a)
 		line += 7;
 		free(p->pkg->origin);
 		p->pkg->origin = strdup(line);
+		if (p->pkg->origin == NULL) {
+			pkg_fatal_errno("%s: %s", __func__, "strdup");
+		}
 	} else if (strncmp(line, "OPTIONS:", 8) == 0) {
 		line += 8;
 		/* OPTIONS:+OPTION -OPTION */
@@ -507,12 +539,20 @@ parse_post(struct plist *p)
 		return;
 
 	p->post_patterns.buf = strdup(env);
+	if (p->post_patterns.buf == NULL) {
+		pkg_errno("%s: %s", __func__, "strdup");
+		return;
+	}
 	while ((token = strsep(&p->post_patterns.buf, " \t")) != NULL) {
 		if (token[0] == '\0')
 			continue;
 		if (p->post_patterns.len >= p->post_patterns.cap) {
 			p->post_patterns.cap += 10;
 			p->post_patterns.patterns = realloc(p->post_patterns.patterns, p->post_patterns.cap * sizeof (char *));
+			if (p->post_patterns.patterns == NULL) {
+				pkg_errno("%s: %s", __func__, "realloc");
+				return;
+			}
 		}
 		p->post_patterns.patterns[p->post_patterns.len++] = token;
 	}
@@ -737,7 +777,15 @@ populate_keywords(struct plist *p)
 
 	for (i = 0; keyacts[i].key != NULL; i++) {
 		k = calloc(1, sizeof(struct keyword));
+		if (k == NULL) {
+			pkg_errno("%s: %s", __func__, "calloc");
+			return;
+		}
 		a = malloc(sizeof(struct action));
+		if (a == NULL) {
+			pkg_errno("%s: %s", __func__, "malloc");
+			return;
+		}
 		strlcpy(k->keyword, keyacts[i].key, sizeof(k->keyword));
 		a->perform = keyacts[i].action;
 		LL_APPEND(k->actions, a);
@@ -803,8 +851,13 @@ parse_attributes(const ucl_object_t *o, struct file_attr **a)
 	ucl_object_iter_t it = NULL;
 	const char *key;
 
-	if (*a == NULL)
+	if (*a == NULL) {
 		*a = calloc(1, sizeof(struct file_attr));
+		if (*a == NULL) {
+			pkg_errno("%s: %s", __func__, "calloc");
+			return;
+		}
+	}
 
 	while ((cur = ucl_iterate_object(o, &it, true))) {
 		key = ucl_object_key(cur);
@@ -813,11 +866,19 @@ parse_attributes(const ucl_object_t *o, struct file_attr **a)
 		if (!strcasecmp(key, "owner") && cur->type == UCL_STRING) {
 			free((*a)->owner);
 			(*a)->owner = strdup(ucl_object_tostring(cur));
+			if ((*a)->owner == NULL) {
+				pkg_errno("%s: %s", __func__, "strdup");
+				return;
+			}
 			continue;
 		}
 		if (!strcasecmp(key, "group") && cur->type == UCL_STRING) {
 			free((*a)->group);
 			(*a)->group = strdup(ucl_object_tostring(cur));
+			if ((*a)->group == NULL) {
+				pkg_errno("%s: %s", __func__, "strdup");
+				return;
+			}
 			continue;
 		}
 		if (!strcasecmp(key, "mode")) {
@@ -923,6 +984,9 @@ apply_keyword_file(ucl_object_t *obj, struct plist *p, char *line, struct file_a
 			}
 
 			msg->str = strdup(ucl_object_tostring(elt));
+			if (msg->str == NULL) {
+				pkg_fatal_errno("%s: %s", __func__, "strdup");
+			}
 			msg->type = PKG_MESSAGE_ALWAYS;
 			elt = ucl_object_find_key(cur, "type");
 			if (elt != NULL) {
@@ -1050,10 +1114,24 @@ parse_keyword_args(char *args, char *keyword)
 	}
 
 	attr = calloc(1, sizeof(struct file_attr));
-	if (owner != NULL && *owner != '\0')
+	if (attr == NULL) {
+		pkg_errno("%s: %s", __func__, "calloc");
+		return (NULL);
+	}
+	if (owner != NULL && *owner != '\0') {
 		attr->owner = strdup(owner);
-	if (group != NULL && *group != '\0')
+		if (attr->owner == NULL) {
+			pkg_errno("%s: %s", __func__, "strdup");
+			return (NULL);
+		}
+	}
+	if (group != NULL && *group != '\0') {
 		attr->group = strdup(group);
+		if (attr->group == NULL) {
+			pkg_errno("%s: %s", __func__, "strdup");
+			return (NULL);
+		}
+	}
 	if (set != NULL) {
 		attr->mode = getmode(set, 0);
 		free(set);
@@ -1186,7 +1264,15 @@ plist_new(struct pkg *pkg, const char *stage)
 	p->slash = p->prefix[strlen(p->prefix) - 1] == '/' ? "" : "/";
 	p->stage = stage;
 	p->uname = strdup("root");
+	if (p->uname == NULL) {
+		pkg_errno("%s: %s", __func__, "strdup");
+		return (NULL);
+	}
 	p->gname = strdup("wheel");
+	if (p->gname == NULL) {
+		pkg_errno("%s: %s", __func__, "strdup");
+		return (NULL);
+	}
 
 	utstring_new(p->pre_install_buf);
 	utstring_new(p->post_install_buf);

--- a/libpkg/pkg_ports.c
+++ b/libpkg/pkg_ports.c
@@ -257,7 +257,7 @@ dir(struct plist *p, char *line, struct file_attr *a)
 	}
 
 	if (lstat(testpath, &st) == -1) {
-		pkg_emit_errno("lstat", testpath);
+		pkg_errno("%s: %s", __func__, "lstat: %s", testpath);
 		if (p->stage != NULL)
 			ret = EPKG_FATAL;
 		if (developer_mode) {
@@ -979,7 +979,8 @@ apply_keyword_file(ucl_object_t *obj, struct plist *p, char *line, struct file_a
 			msg = calloc(1, sizeof(*msg));
 
 			if (msg == NULL) {
-				pkg_emit_errno("malloc", "struct pkg_message");
+				pkg_errno("%s: %s", __func__,
+					  "malloc: struct pkg_message");
 				goto keywords_cleanup;
 			}
 

--- a/libpkg/pkg_repo.c
+++ b/libpkg/pkg_repo.c
@@ -1052,6 +1052,10 @@ pkg_repo_parse_fingerprint(ucl_object_t *obj)
 	}
 
 	f = calloc(1, sizeof(struct fingerprint));
+	if (f == NULL) {
+		pkg_errno("%s: %s", __func__, "calloc");
+		return (NULL);
+	}
 	f->type = fct;
 	strlcpy(f->hash, fp, sizeof(f->hash));
 

--- a/libpkg/pkg_repo.c
+++ b/libpkg/pkg_repo.c
@@ -250,19 +250,17 @@ pkg_repo_meta_extract_signature_pubkey(int fd, void *ud)
 			siglen = archive_entry_size(ae);
 			sig = malloc(siglen);
 			if (sig == NULL) {
-				pkg_emit_errno("pkg_repo_meta_extract_signature",
-						"malloc failed");
-				return (EPKG_FATAL);
+				pkg_fatal_errno("%s: %s", __func__, "malloc failed");
 			}
 			if (archive_read_data(a, sig, siglen) == -1) {
-				pkg_emit_errno("pkg_repo_meta_extract_signature",
-						"archive_read_data failed");
+				pkg_errno("%s: %s", __func__,
+					  "archive_read_data failed");
 				free(sig);
 				return (EPKG_FATAL);
 			}
 			if (write(fd, sig, siglen) == -1) {
-				pkg_emit_errno("pkg_repo_meta_extract_signature",
-						"write failed");
+				pkg_errno("%s: %s", __func__,
+					  "write failed");
 				free(sig);
 				return (EPKG_FATAL);
 			}
@@ -271,7 +269,8 @@ pkg_repo_meta_extract_signature_pubkey(int fd, void *ud)
 		}
 		else if (strcmp(archive_entry_pathname(ae), cb->fname) == 0) {
 			if (archive_read_data_into_fd(a, cb->tfd) != 0) {
-				pkg_emit_errno("archive_read_extract", "extract error");
+				pkg_errno("%s: %s", __func__,
+					  "archive_read_extract: extract error");
 				rc = EPKG_FATAL;
 				break;
 			}
@@ -319,13 +318,12 @@ pkg_repo_meta_extract_signature_fingerprints(int fd, void *ud)
 			siglen = archive_entry_size(ae);
 			sig = malloc(siglen);
 			if (sig == NULL) {
-				pkg_emit_errno("pkg_repo_meta_extract_signature",
-						"malloc failed");
-				return (EPKG_FATAL);
+				pkg_fatal_errno("%s: %s", __func__,
+						"pkg_repo_meta_extract_signature: malloc failed");
 			}
 			if (archive_read_data(a, sig, siglen) == -1) {
-				pkg_emit_errno("pkg_repo_meta_extract_signature",
-						"archive_read_data failed");
+				pkg_errno("%s: %s", __func__,
+					  "pkg_repo_meta_extract_signature: archive_read_data failed");
 				free(sig);
 				return (EPKG_FATAL);
 			}
@@ -343,8 +341,8 @@ pkg_repo_meta_extract_signature_fingerprints(int fd, void *ud)
 			iov[4].iov_base = sig;
 			iov[4].iov_len = siglen;
 			if (writev(fd, iov, NELEM(iov)) == -1) {
-				pkg_emit_errno("pkg_repo_meta_extract_signature",
-						"writev failed");
+				pkg_errno("%s: %s", __func__,
+					  "pkg_repo_meta_extract_signature: writev failed");
 				free(sig);
 				return (EPKG_FATAL);
 			}
@@ -358,13 +356,12 @@ pkg_repo_meta_extract_signature_fingerprints(int fd, void *ud)
 			siglen = archive_entry_size(ae);
 			sig = malloc(siglen);
 			if (sig == NULL) {
-				pkg_emit_errno("pkg_repo_meta_extract_signature",
-						"malloc failed");
-				return (EPKG_FATAL);
+				pkg_fatal_errno("%s: %s", __func__,
+						"pkg_repo_meta_extract_signature: malloc failed");
 			}
 			if (archive_read_data(a, sig, siglen) == -1) {
-				pkg_emit_errno("pkg_repo_meta_extract_signature",
-						"archive_read_data failed");
+				pkg_errno("%s: %s", __func__,
+					  "pkg_repo_meta_extract_signature: archive_read_data failed");
 				free(sig);
 				return (EPKG_FATAL);
 			}
@@ -382,8 +379,8 @@ pkg_repo_meta_extract_signature_fingerprints(int fd, void *ud)
 			iov[4].iov_base = sig;
 			iov[4].iov_len = siglen;
 			if (writev(fd, iov, NELEM(iov)) == -1) {
-				pkg_emit_errno("pkg_repo_meta_extract_signature",
-						"writev failed");
+				pkg_errno("%s: %s", __func__,
+					  "pkg_repo_meta_extract_signature: writev failed");
 				free(sig);
 				return (EPKG_FATAL);
 			}
@@ -393,7 +390,8 @@ pkg_repo_meta_extract_signature_fingerprints(int fd, void *ud)
 		else {
 			if (strcmp(archive_entry_pathname(ae), cb->fname) == 0) {
 				if (archive_read_data_into_fd(a, cb->tfd) != 0) {
-					pkg_emit_errno("archive_read_extract", "extract error");
+					pkg_errno("%s: %s", __func__,
+						  "archive_read_extract: extract error");
 					rc = EPKG_FATAL;
 					break;
 				}
@@ -466,8 +464,8 @@ pkg_repo_parse_sigkeys(const char *in, int inlen, struct sig_cert **sc)
 			if (s == NULL) {
 				s = calloc(1, sizeof(struct sig_cert));
 				if (s == NULL) {
-					pkg_emit_errno("pkg_repo_parse_sigkeys", "calloc failed");
-					return (EPKG_FATAL);
+					pkg_fatal_errno("%s: %s", __func__,
+							"pkg_repo_parse_sigkeys: calloc failed");
 				}
 				tlen = MIN(len, sizeof(s->name) - 1);
 				memcpy(s->name, p, tlen);
@@ -508,7 +506,8 @@ pkg_repo_parse_sigkeys(const char *in, int inlen, struct sig_cert **sc)
 			}
 			sig = malloc(len);
 			if (sig == NULL) {
-				pkg_emit_errno("pkg_repo_parse_sigkeys", "malloc failed");
+				pkg_errno("%s: %s", __func__,
+					  "pkg_repo_parse_sigkeys: malloc failed");
 				free(s);
 				return (EPKG_FATAL);
 			}
@@ -562,7 +561,8 @@ pkg_repo_archive_extract_archive(int fd, const char *file,
 		cbdata.tfd = open (dest, O_WRONLY | O_CREAT | O_TRUNC,
 				0644);
 		if (cbdata.tfd == -1) {
-			pkg_emit_errno("archive_read_extract", "open error");
+			pkg_errno("%s: %s", __func__,
+				  "archive_read_extract: open error");
 			rc = EPKG_FATAL;
 			goto cleanup;
 		}
@@ -579,8 +579,8 @@ pkg_repo_archive_extract_archive(int fd, const char *file,
 				&cbdata, (char **)&sig, &siglen) == EPKG_OK && sig != NULL) {
 			s = calloc(1, sizeof(struct sig_cert));
 			if (s == NULL) {
-				pkg_emit_errno("pkg_repo_archive_extract_archive",
-						"malloc failed");
+				pkg_errno("%s: %s", __func__,
+					  "pkg_repo_archive_extract_archive: malloc failed");
 				rc = EPKG_FATAL;
 				goto cleanup;
 			}
@@ -775,7 +775,8 @@ pkg_repo_fetch_remote_extract_mmap(struct pkg_repo *repo, const char *filename,
 	map = mmap(NULL, st.st_size, PROT_READ, MAP_SHARED, fd, 0);
 	close(fd);
 	if (map == MAP_FAILED) {
-		pkg_emit_errno("pkg_repo_fetch_remote_mmap", "cannot mmap fetched");
+		pkg_errno("%s: %s", __func__,
+			  "pkg_repo_fetch_remote_mmap: cannot mmap fetched");
 		*rc = EPKG_FATAL;
 		return (MAP_FAILED);
 	}
@@ -798,7 +799,7 @@ pkg_repo_fetch_remote_extract_tmp(struct pkg_repo *repo, const char *filename,
 
 	res = fdopen(dest_fd, "r");
 	if (res == NULL) {
-		pkg_emit_errno("fdopen", "digest open failed");
+		pkg_errno("%s: %s", __func__, "fdopen: digest open failed");
 		*rc = EPKG_FATAL;
 		close(dest_fd);
 		return (NULL);
@@ -859,8 +860,8 @@ pkg_repo_meta_extract_pubkey(int fd, void *ud)
 					iov[0].iov_base = (void *)ucl_object_tostring(elt);
 					iov[0].iov_len = res_len;
 					if (writev(fd, iov, 1) == -1) {
-						pkg_emit_errno("pkg_repo_meta_extract_pubkey",
-								"writev error");
+						pkg_errno("%s: %s", __func__,
+							  "pkg_repo_meta_extract_pubkey: writev error");
 						rc = EPKG_FATAL;
 						break;
 					}
@@ -930,13 +931,13 @@ pkg_repo_fetch_meta(struct pkg_repo *repo, time_t *t)
 
 	/* Map meta file for extracting pubkeys from it */
 	if ((fd = open(filepath, O_RDONLY)) == -1) {
-		pkg_emit_errno("pkg_repo_fetch_meta", "cannot open meta fetched");
+		pkg_errno("%s: %s", __func__, "cannot open meta fetched");
 		rc = EPKG_FATAL;
 		goto cleanup;
 	}
 
 	if (fstat(fd, &st) == -1) {
-		pkg_emit_errno("pkg_repo_fetch_meta", "cannot stat meta fetched");
+		pkg_errno("%s: %s", __func__, "cannot stat meta fetched");
 		rc = EPKG_FATAL;
 		goto cleanup;
 	}
@@ -944,7 +945,7 @@ pkg_repo_fetch_meta(struct pkg_repo *repo, time_t *t)
 	map = mmap(NULL, st.st_size, PROT_READ, MAP_SHARED, fd, 0);
 	close(fd);
 	if (map == MAP_FAILED) {
-		pkg_emit_errno("pkg_repo_fetch_meta", "cannot mmap meta fetched");
+		pkg_errno("%s: %s", __func__, "cannot mmap meta fetched");
 		rc = EPKG_FATAL;
 		goto cleanup;
 	}

--- a/libpkg/pkg_repo_meta.c
+++ b/libpkg/pkg_repo_meta.c
@@ -25,6 +25,7 @@
  */
 
 #include <ucl.h>
+#include <errno.h>
 
 #include "pkg.h"
 #include "private/event.h"
@@ -42,11 +43,35 @@ pkg_repo_meta_set_default(struct pkg_repo_meta *meta)
 	meta->conflicts = NULL;
 	meta->conflicts_archive = NULL;
 	meta->manifests = strdup("packagesite.yaml");
+	if (meta->manifests == NULL) {
+		pkg_errno("%s: %s", __func__, "strdup");
+		return;
+	}
 	meta->manifests_archive = strdup("packagesite");
+	if (meta->manifests_archive == NULL) {
+		pkg_errno("%s: %s", __func__, "strdup");
+		return;
+	}
 	meta->digests = strdup("digests");
+	if (meta->digests == NULL) {
+		pkg_errno("%s: %s", __func__, "strdup");
+		return;
+	}
 	meta->digests_archive = strdup("digests");
+	if (meta->digests_archive == NULL) {
+		pkg_errno("%s: %s", __func__, "strdup");
+		return;
+	}
 	meta->filesite = strdup("filesite.yaml");
+	if (meta->filesite == NULL) {
+		pkg_errno("%s: %s", __func__, "strdup");
+		return;
+	}
 	meta->filesite_archive = strdup("filesite");
+	if (meta->filesite_archive == NULL) {
+		pkg_errno("%s: %s", __func__, "strdup");
+		return;
+	}
 	/* Not using fulldb */
 	meta->fulldb = NULL;
 	meta->fulldb_archive = NULL;
@@ -159,8 +184,20 @@ pkg_repo_meta_parse_cert(const ucl_object_t *obj)
 	 * It is already validated so just use it as is
 	 */
 	key->name = strdup(ucl_object_tostring(ucl_object_find_key(obj, "name")));
+	if (key->name == NULL) {
+		pkg_errno("%s: %s", __func__, "strdup");
+		return (NULL);
+	}
 	key->pubkey = strdup(ucl_object_tostring(ucl_object_find_key(obj, "data")));
+	if (key->pubkey == NULL) {
+		pkg_errno("%s: %s", __func__, "strdup");
+		return (NULL);
+	}
 	key->pubkey_type = strdup(ucl_object_tostring(ucl_object_find_key(obj, "type")));
+	if (key->pubkey_type == NULL) {
+		pkg_errno("%s: %s", __func__, "strdup");
+		return (NULL);
+	}
 
 	return (key);
 }

--- a/libpkg/pkg_repo_meta.c
+++ b/libpkg/pkg_repo_meta.c
@@ -176,7 +176,8 @@ pkg_repo_meta_parse_cert(const ucl_object_t *obj)
 
 	key = calloc(1, sizeof(*key));
 	if (key == NULL) {
-		pkg_emit_errno("pkg_repo_meta_parse", "malloc failed for pkg_repo_meta_key");
+		pkg_errno("%s: %s", __func__,
+			  "pkg_repo_meta_parse: malloc failed for pkg_repo_meta_key");
 		return (NULL);
 	}
 
@@ -220,8 +221,8 @@ pkg_repo_meta_parse(ucl_object_t *top, struct pkg_repo_meta **target, int versio
 
 	meta = calloc(1, sizeof(*meta));
 	if (meta == NULL) {
-		pkg_emit_errno("pkg_repo_meta_parse", "malloc failed for pkg_repo_meta");
-		return (EPKG_FATAL);
+		pkg_fatal_errno("%s: %s", __func__,
+				"pkg_repo_meta_parse: malloc failed for pkg_repo_meta");
 	}
 
 	pkg_repo_meta_set_default(meta);
@@ -346,7 +347,8 @@ pkg_repo_meta_default(void)
 
 	meta = calloc(1, sizeof(*meta));
 	if (meta == NULL) {
-		pkg_emit_errno("pkg_repo_meta_default", "malloc failed for pkg_repo_meta");
+		pkg_errno("%s: %s", __func__,
+			  "pkg_repo_meta_default: malloc failed for pkg_repo_meta");
 		return (NULL);
 	}
 

--- a/libpkg/pkg_solve.c
+++ b/libpkg/pkg_solve.c
@@ -131,7 +131,7 @@ pkg_solve_item_new(struct pkg_solve_variable *var)
 	result = calloc(1, sizeof(struct pkg_solve_item));
 
 	if(result == NULL) {
-		pkg_emit_errno("calloc", "pkg_solve_item");
+		pkg_errno("%s: %s", __func__, "calloc: pkg_solve_item");
 		return (NULL);
 	}
 
@@ -149,7 +149,7 @@ pkg_solve_rule_new(enum pkg_solve_rule_type reason)
 	result = calloc(1, sizeof(struct pkg_solve_rule));
 
 	if(result == NULL) {
-		pkg_emit_errno("calloc", "pkg_solve_rule");
+		pkg_errno("%s: %s", __func__, "calloc: pkg_solve_rule");
 		return (NULL);
 	}
 
@@ -845,7 +845,7 @@ pkg_solve_jobs_to_sat(struct pkg_jobs *j)
 	problem = calloc(1, sizeof(struct pkg_solve_problem));
 
 	if (problem == NULL) {
-		pkg_emit_errno("calloc", "pkg_solve_problem");
+		pkg_errno("%s: %s", __func__, "calloc: pkg_solve_problem");
 		return (NULL);
 	}
 
@@ -856,12 +856,13 @@ pkg_solve_jobs_to_sat(struct pkg_jobs *j)
 	kv_init(problem->rules);
 
 	if (problem->sat == NULL) {
-		pkg_emit_errno("picosat_init", "pkg_solve_sat_problem");
+		pkg_errno("%s: %s", __func__,
+		    "picosat_init: pkg_solve_sat_problem");
 		return (NULL);
 	}
 
 	if (problem->variables == NULL) {
-		pkg_emit_errno("calloc", "variables");
+		pkg_errno("%s: %s", __func__, "calloc: variables");
 		return (NULL);
 	}
 
@@ -1379,7 +1380,8 @@ pkg_solve_insert_res_job (struct pkg_solve_variable *var,
 		if (seen_add > 0) {
 			res = calloc(1, sizeof(struct pkg_solved));
 			if (res == NULL) {
-				pkg_emit_errno("calloc", "pkg_solved");
+				pkg_errno("%s: %s", __func__,
+					  "calloc: pkg_solved");
 				return;
 			}
 			/* Pure install */
@@ -1416,7 +1418,8 @@ pkg_solve_insert_res_job (struct pkg_solve_variable *var,
 
 				res = calloc(1, sizeof(struct pkg_solved));
 				if (res == NULL) {
-					pkg_emit_errno("calloc", "pkg_solved");
+					pkg_errno("%s: %s", __func__,
+						  "calloc: pkg_solved");
 					return;
 				}
 				res->items[0] = cur_var->unit;

--- a/libpkg/pkgdb.c
+++ b/libpkg/pkgdb.c
@@ -953,8 +953,8 @@ pkgdb_open_repos(struct pkgdb *db, const char *reponame)
 			if (r->ops->open(r, R_OK) == EPKG_OK) {
 				item = malloc(sizeof(*item));
 				if (item == NULL) {
-					pkg_emit_errno("malloc", "_pkg_repo_list_item");
-					return (EPKG_FATAL);
+					pkg_fatal_errno("%s: %s", __func__,
+							"malloc: _pkg_repo_list_item");
 				}
 
 				r->ops->init(r);
@@ -1065,8 +1065,7 @@ pkgdb_open_all(struct pkgdb **db_p, pkgdb_t type, const char *reponame)
 	}
 
 	if (!reopen && (db = calloc(1, sizeof(struct pkgdb))) == NULL) {
-		pkg_emit_errno("malloc", "pkgdb");
-		return (EPKG_FATAL);
+		pkg_fatal_errno("%s: %s", __func__, "malloc: pkgdb");
 	}
 
 	db->prstmt_initialized = false;

--- a/libpkg/pkgdb.c
+++ b/libpkg/pkgdb.c
@@ -128,6 +128,10 @@ pkgdb_regex(sqlite3_context *ctx, int argc, sqlite3_value **argv)
 			cflags = REG_EXTENDED | REG_NOSUB | REG_ICASE;
 
 		re = malloc(sizeof(regex_t));
+		if (re == NULL) {
+			pkg_errno("%s: %s", __func__, "malloc");
+			return;
+		}
 		if (regcomp(re, regex, cflags) != 0) {
 			sqlite3_result_error(ctx, "Invalid regex\n", -1);
 			free(re);
@@ -2655,6 +2659,9 @@ pkgdb_file_set_cksum(struct pkgdb *db, struct pkg_file *file,
 	}
 	sqlite3_finalize(stmt);
 	file->sum = strdup(sum);
+	if (file->sum == NULL) {
+		pkg_fatal_errno("%s: %s", __func__, "strdup");
+	}
 
 	return (EPKG_OK);
 }
@@ -2702,6 +2709,10 @@ pkgshell_open(const char **reponame)
 
 	snprintf(localpath, sizeof(localpath), "%s/local.sqlite", dbdir);
 	*reponame = strdup(localpath);
+	if (*reponame == NULL) {
+		pkg_errno("%s: %s", __func__, "strdup");
+		return;
+	}
 }
 
 static int

--- a/libpkg/pkgdb_iterator.c
+++ b/libpkg/pkgdb_iterator.c
@@ -1275,7 +1275,7 @@ pkgdb_it_new_repo(struct pkgdb *db)
 	struct pkgdb_it	*it;
 
 	if ((it = malloc(sizeof(struct pkgdb_it))) == NULL) {
-		pkg_emit_errno("malloc", "pkgdb_it");
+		pkg_errno("%s: %s", __func__, "malloc: pkgdb_it");
 		return (NULL);
 	}
 
@@ -1294,7 +1294,7 @@ pkgdb_it_repo_attach(struct pkgdb_it *it, struct pkg_repo_it *rit)
 	struct _pkg_repo_it_set *item;
 
 	if ((item = malloc(sizeof(struct _pkg_repo_it_set))) == NULL) {
-		pkg_emit_errno("malloc", "_pkg_repo_it_set");
+		pkg_errno("%s: %s", __func__, "malloc: _pkg_repo_it_set");
 	}
 	else {
 		item->it = rit;

--- a/libpkg/pkgdb_iterator.c
+++ b/libpkg/pkgdb_iterator.c
@@ -775,7 +775,8 @@ pkgdb_load_requires(sqlite3 *sqlite, struct pkg *pkg)
 }
 
 static void
-populate_pkg(sqlite3_stmt *stmt, struct pkg *pkg) {
+populate_pkg(sqlite3_stmt *stmt, struct pkg *pkg)
+{
 	int		 icol = 0;
 	const char	*colname, *msg;
 	char		 legacyarch[BUFSIZ];
@@ -797,24 +798,53 @@ populate_pkg(sqlite3_stmt *stmt, struct pkg *pkg) {
 			switch (column->type) {
 			case PKG_ABI:
 				pkg->abi = strdup(sqlite3_column_text(stmt, icol));
+				if (pkg->abi == NULL) {
+					pkg_errno("%s: %s", __func__, "strdup");
+					return;
+				}
 				break;
 			case PKG_CKSUM:
 				pkg->sum = strdup(sqlite3_column_text(stmt, icol));
+				if (pkg->sum == NULL) {
+					pkg_errno("%s: %s", __func__, "strdup");
+					return;
+				}
 				break;
 			case PKG_COMMENT:
 				pkg->comment = strdup(sqlite3_column_text(stmt, icol));
+				if (pkg->comment == NULL) {
+					pkg_errno("%s: %s", __func__, "strdup");
+					return;
+				}
 				break;
 			case PKG_REPONAME:
 				pkg->reponame = strdup(sqlite3_column_text(stmt, icol));
+				if (pkg->reponame == NULL) {
+					pkg_errno("%s: %s", __func__,
+							"strdup");
+					return;
+				}
 				break;
 			case PKG_DESC:
 				pkg->desc = strdup(sqlite3_column_text(stmt, icol));
+				if (pkg->desc == NULL) {
+					pkg_errno("%s: %s", __func__, "strdup");
+					return;
+				}
 				break;
 			case PKG_MAINTAINER:
 				pkg->maintainer = strdup(sqlite3_column_text(stmt, icol));
+				if (pkg->maintainer == NULL) {
+					pkg_errno("%s: %s", __func__, "strdup");
+					return;
+				}
 				break;
 			case PKG_DIGEST:
 				pkg->digest = strdup(sqlite3_column_text(stmt, icol));
+				if (pkg->digest == NULL) {
+					pkg_errno("%s: %s", __func__, "strdup");
+					return;
+				}
 				break;
 			case PKG_MESSAGE:
 				msg = sqlite3_column_text(stmt, icol);
@@ -825,7 +855,17 @@ populate_pkg(sqlite3_stmt *stmt, struct pkg *pkg) {
 					}
 					else {
 						pkg->message = calloc(1, sizeof(*pkg->message));
+						if (pkg->message == NULL) {
+							pkg_errno("%s: %s",
+							    __func__, "calloc");
+							return;
+						}
 						pkg->message->str = strdup(msg);
+						if (pkg->message->str == NULL) {
+							pkg_errno("%s: %s",
+							    __func__, "strdup");
+							return;
+						}
 					}
 				}
 				else {
@@ -834,33 +874,74 @@ populate_pkg(sqlite3_stmt *stmt, struct pkg *pkg) {
 				break;
 			case PKG_NAME:
 				pkg->name = strdup(sqlite3_column_text(stmt, icol));
+				if (pkg->name == NULL) {
+					pkg_errno("%s: %s", __func__, "strdup");
+					return;
+				}
 				break;
 			case PKG_OLD_VERSION:
 				pkg->old_version = strdup(sqlite3_column_text(stmt, icol));
+				if (pkg->old_version == NULL) {
+					pkg_errno("%s: %s", __func__,
+							"strdup");
+					return;
+				}
 				break;
 			case PKG_ORIGIN:
 				pkg->origin = strdup(sqlite3_column_text(stmt, icol));
+				if (pkg->origin == NULL) {
+					pkg_errno("%s: %s", __func__, "strdup");
+					return;
+				}
 				break;
 			case PKG_PREFIX:
 				pkg->prefix = strdup(sqlite3_column_text(stmt, icol));
+				if (pkg->prefix == NULL) {
+					pkg_errno("%s: %s", __func__, "strdup");
+					return;
+				}
 				break;
 			case PKG_REPOPATH:
 				pkg->repopath = strdup(sqlite3_column_text(stmt, icol));
+				if (pkg->repopath == NULL) {
+					pkg_errno("%s: %s", __func__, "strdup");
+					return;
+				}
 				break;
 			case PKG_REPOURL:
 				pkg->repourl = strdup(sqlite3_column_text(stmt, icol));
+				if (pkg->repourl == NULL) {
+					pkg_errno("%s: %s", __func__, "strdup");
+					return;
+				}
 				break;
 			case PKG_UNIQUEID:
 				pkg->uid = strdup(sqlite3_column_text(stmt, icol));
+				if (pkg->uid == NULL) {
+					pkg_errno("%s: %s", __func__, "strdup");
+					return;
+				}
 				break;
 			case PKG_VERSION:
 				pkg->version = strdup(sqlite3_column_text(stmt, icol));
+				if (pkg->version == NULL) {
+					pkg_errno("%s: %s", __func__, "strdup");
+					return;
+				}
 				break;
 			case PKG_WWW:
 				pkg->www = strdup(sqlite3_column_text(stmt, icol));
+				if (pkg->www == NULL) {
+					pkg_errno("%s: %s", __func__, "strdup");
+					return;
+				}
 				break;
 			case PKG_DEP_FORMULA:
 				pkg->dep_formula = strdup(sqlite3_column_text(stmt, icol));
+				if (pkg->dep_formula == NULL) {
+					pkg_errno("%s: %s", __func__, "strdup");
+					return;
+				}
 				break;
 			default:
 				pkg_emit_error("Unexpected text value for %s", colname);
@@ -921,6 +1002,10 @@ populate_pkg(sqlite3_stmt *stmt, struct pkg *pkg) {
 
 	pkg_arch_to_legacy(pkg->abi, legacyarch, BUFSIZ);
 	pkg->arch = strdup(legacyarch);
+	if (pkg->arch == NULL) {
+		pkg_errno("%s: %s", __func__, "strdup");
+		return;
+	}
 }
 
 static struct load_on_flag {
@@ -1010,7 +1095,8 @@ pkgdb_sqlite_it_next(struct pkgdb_sqlite_it *it,
 						return (ret);
 				}
 				else {
-					pkg_emit_error("invalid iterator passed to pkgdb_it_next");
+					pkg_emit_error("%s: %s", __func__,
+					    "invalid iterator");
 					return (EPKG_FATAL);
 				}
 			}
@@ -1165,7 +1251,7 @@ pkgdb_it_new_sqlite(struct pkgdb *db, sqlite3_stmt *s, int type, short flags)
 	assert(!(flags & (PKGDB_IT_FLAG_AUTO & (PKGDB_IT_FLAG_CYCLED | PKGDB_IT_FLAG_ONCE))));
 
 	if ((it = malloc(sizeof(struct pkgdb_it))) == NULL) {
-		pkg_emit_errno("malloc", "pkgdb_it");
+		pkg_errno("%s: %s", __func__, "malloc: pkgdb_it");
 		sqlite3_finalize(s);
 		return (NULL);
 	}

--- a/libpkg/plugins.c
+++ b/libpkg/plugins.c
@@ -296,6 +296,9 @@ pkg_plugins_init(void)
 		snprintf(pluginfile, sizeof(pluginfile), "%s/%s.so", plugdir,
 		    pkg_object_string(cur));
 		p = calloc(1, sizeof(struct pkg_plugin));
+		if (p == NULL) {
+			pkg_fatal_errno("%s: %s", __func__, "calloc");
+		}
 		if ((p->lh = dlopen(pluginfile, RTLD_LAZY)) == NULL) {
 			pkg_emit_error("Loading of plugin '%s' failed: %s",
 			    pkg_object_string(cur), dlerror());

--- a/libpkg/repo/binary/fetch.c
+++ b/libpkg/repo/binary/fetch.c
@@ -110,12 +110,11 @@ pkg_repo_binary_create_symlink(struct pkg *pkg, const char *fname,
 	if ((dest_fname = strrchr(fname, '/')) != NULL)
 		++dest_fname;
 	if (symlink(dest_fname, link_dest_tmp) == -1) {
-		pkg_emit_errno("symlink", link_dest);
-		return (EPKG_FATAL);
+		pkg_fatal_errno("%s: %s", __func__, "symlink: %s", link_dest);
 	}
 
 	if (rename(link_dest_tmp, link_dest) == -1) {
-		pkg_emit_errno("rename", link_dest);
+		pkg_errno("%s: %s", __func__, "rename: %s", link_dest);
 		unlink(link_dest_tmp);
 		return (EPKG_FATAL);
 	}
@@ -168,7 +167,7 @@ pkg_repo_binary_try_fetch(struct pkg_repo *repo, struct pkg *pkg,
 	/* Create the dirs in cachedir */
 	dir = strdup(dest);
 	if (dir == NULL || (path = dirname(dir)) == NULL) {
-		pkg_emit_errno("dirname", dest);
+		pkg_errno("%s: %s", __func__, "dirname: %s", dest);
 		retcode = EPKG_FATAL;
 		goto cleanup;
 	}

--- a/libpkg/repo/binary/query.c
+++ b/libpkg/repo/binary/query.c
@@ -61,7 +61,7 @@ pkg_repo_binary_it_new(struct pkg_repo *repo, sqlite3_stmt *s, short flags)
 
 	it = malloc(sizeof(*it));
 	if (it == NULL) {
-		pkg_emit_errno("malloc", "pkg_repo_it");
+		pkg_errno("%s: %s", __func__, "malloc: pkg_repo_it");
 		sqlite3_finalize(s);
 		return (NULL);
 	}

--- a/libpkg/repo/binary/update.c
+++ b/libpkg/repo/binary/update.c
@@ -397,6 +397,9 @@ pkg_repo_binary_add_from_manifest(char *buf, sqlite3 *sqlite, size_t len,
 
 	free(pkg->reponame);
 	pkg->reponame = strdup(repo->name);
+	if (pkg->reponame == NULL) {
+		pkg_fatal_errno("%s: %s", __func__, "strdup");
+	}
 
 	rc = pkg_repo_binary_add_pkg(pkg, NULL, sqlite, true);
 
@@ -432,6 +435,10 @@ pkg_repo_binary_parse_conflicts(FILE *f, sqlite3 *sqlite)
 			pdep ++;
 		}
 		deps = malloc(sizeof(char *) * ndep);
+		if (deps == NULL) {
+			pkg_errno("%s: %s", __func__, "malloc");
+			return;
+		}
 		for (i = 0; i < ndep; i ++) {
 			deps[i] = strsep(&p, ",\n");
 		}

--- a/libpkg/rsa.c
+++ b/libpkg/rsa.c
@@ -262,6 +262,9 @@ rsa_sign(char *path, struct rsa_key *rsa, unsigned char **sigret, unsigned int *
 
 	max_len = RSA_size(rsa->key);
 	*sigret = calloc(1, max_len + 1);
+	if (*sigret == NULL) {
+		pkg_fatal_errno("%s: %s", __func__, "calloc");
+	}
 
 	sha256 = pkg_checksum_file(path, PKG_HASH_TYPE_SHA256_HEX);
 	if (sha256 == NULL)
@@ -287,6 +290,9 @@ rsa_new(struct rsa_key **rsa, pkg_password_cb *cb, char *path)
 	assert(*rsa == NULL);
 
 	*rsa = calloc(1, sizeof(struct rsa_key));
+	if (*rsa == NULL) {
+		pkg_fatal_errno("%s: %s", __func__, "calloc");
+	}
 	(*rsa)->path = path;
 	(*rsa)->pw_cb = cb;
 

--- a/libpkg/rsa.c
+++ b/libpkg/rsa.c
@@ -142,8 +142,7 @@ rsa_verify_cert(const char *path, unsigned char *key, int keylen,
 
 	if (fd == -1) {
 		if ((fd = open(path, O_RDONLY)) == -1) {
-			pkg_emit_errno("fopen", path);
-			return (EPKG_FATAL);
+			pkg_fatal_errno("%s: %s", __func__, "fopen: %s", path);
 		}
 		need_close = true;
 	}
@@ -211,13 +210,13 @@ rsa_verify(const char *path, const char *key, unsigned char *sig,
 	off_t key_len;
 
 	if (file_to_buffer(key, (char**)&key_buf, &key_len) != EPKG_OK) {
-		pkg_emit_errno("rsa_verify", "cannot read key");
-		return (EPKG_FATAL);
+		pkg_fatal_errno("%s: %s", __func__,
+				"rsa_verify: cannot read key");
 	}
 
 	if (fd == -1) {
 		if ((fd = open(path, O_RDONLY)) == -1) {
-			pkg_emit_errno("fopen", path);
+			pkg_errno("%s: %s", __func__, "fopen: %s", path);
 			free(key_buf);
 			return (EPKG_FATAL);
 		}
@@ -251,8 +250,7 @@ rsa_sign(char *path, struct rsa_key *rsa, unsigned char **sigret, unsigned int *
 	char *sha256;
 
 	if (access(rsa->path, R_OK) == -1) {
-		pkg_emit_errno("access", rsa->path);
-		return (EPKG_FATAL);
+		pkg_fatal_errno("%s: %s", __func__, "access: %s", rsa->path);
 	}
 
 	if (rsa->key == NULL && _load_rsa_private_key(rsa) != EPKG_OK) {

--- a/libpkg/utils.c
+++ b/libpkg/utils.c
@@ -285,6 +285,9 @@ format_exec_cmd(char **dest, const char *in, const char *prefix,
 	}
 
 	*dest = strdup(utstring_body(buf));
+	if (*dest == NULL) {
+		pkg_fatal_errno("%s: %s", __func__, "strdup");
+	}
 	utstring_free(buf);
 	
 	return (EPKG_OK);
@@ -737,6 +740,9 @@ mkdirat_p(int fd, const char *path)
 	char *walk, pathdone[MAXPATHLEN];
 
 	walk = strdup(path);
+	if (walk == NULL) {
+		pkg_fatal_errno("%s: %s", __func__, "strdup");
+	}
 	pathdone[0] = '\0';
 
 	while ((next = strsep(&walk, "/")) != NULL) {

--- a/libpkg/utils.c
+++ b/libpkg/utils.c
@@ -69,8 +69,8 @@ mkdirs(const char *_path)
 
 		if (mkdir(path, S_IRWXU | S_IRWXG | S_IRWXO) < 0)
 			if (errno != EEXIST && errno != EISDIR) {
-				pkg_emit_errno("mkdir", path);
-				return (EPKG_FATAL);
+				pkg_fatal_errno("%s: %s", __func__,
+						"mkdir: %s", path);
 			}
 
 		/* that was the last element of the path */
@@ -95,25 +95,25 @@ file_to_bufferat(int dfd, const char *path, char **buffer, off_t *sz)
 	assert(sz != NULL);
 
 	if ((fd = openat(dfd, path, O_RDONLY)) == -1) {
-		pkg_emit_errno("openat", path);
+		pkg_errno("%s: %s", __func__, "openat: %s", path);
 		retcode = EPKG_FATAL;
 		goto cleanup;
 	}
 
 	if (fstatat(dfd, path, &st, 0) == -1) {
-		pkg_emit_errno("fstatat", path);
+		pkg_errno("%s: %s", __func__, "fstatat: %s", path);
 		retcode = EPKG_FATAL;
 		goto cleanup;
 	}
 
 	if ((*buffer = malloc(st.st_size + 1)) == NULL) {
-		pkg_emit_errno("malloc", "");
+		pkg_errno("%s: %s", __func__, "malloc");
 		retcode = EPKG_FATAL;
 		goto cleanup;
 	}
 
 	if (read(fd, *buffer, st.st_size) == -1) {
-		pkg_emit_errno("read", path);
+		pkg_errno("%s: %s", __func__, "read: %s", path);
 		retcode = EPKG_FATAL;
 		goto cleanup;
 	}
@@ -144,25 +144,25 @@ file_to_buffer(const char *path, char **buffer, off_t *sz)
 	assert(sz != NULL);
 
 	if ((fd = open(path, O_RDONLY)) == -1) {
-		pkg_emit_errno("open", path);
+		pkg_errno("%s: %s", __func__, "open: %s", path);
 		retcode = EPKG_FATAL;
 		goto cleanup;
 	}
 
 	if (fstat(fd, &st) == -1) {
-		pkg_emit_errno("fstat", path);
+		pkg_errno("%s: %s", __func__, "fstat: %s", path);
 		retcode = EPKG_FATAL;
 		goto cleanup;
 	}
 
 	if ((*buffer = malloc(st.st_size + 1)) == NULL) {
-		pkg_emit_errno("malloc", "");
+		pkg_errno("%s: %s", __func__, "malloc: ");
 		retcode = EPKG_FATAL;
 		goto cleanup;
 	}
 
 	if (read(fd, *buffer, st.st_size) == -1) {
-		pkg_emit_errno("read", path);
+		pkg_errno("%s: %s", __func__, "read: %s", path);
 		retcode = EPKG_FATAL;
 		goto cleanup;
 	}

--- a/tests/cocci/pkg/unchecked_malloc.cocci
+++ b/tests/cocci/pkg/unchecked_malloc.cocci
@@ -1,52 +1,58 @@
 // Unchecked malloc(3) family functions calls.
 //
-// XXX: there is still a lot of work to be done here as it does not yet catch
-// all.
+// XXX: The generated code is a guide for identifying missing checks.  Check
+// the caller to ensure if pkg_fatal_errno() is correct, or whether that needs
+// to use pkg_errno() instead with the appropriate return value for that
+// function.
 //
-// Confidence: Low
+// Confidence: Moderate
 // Copyright: (C) The pkgng project, see COPYING.
 // URL: https://github.com/freebsd/pkg/tree/master/tests/cocci/pkg/unchecked_malloc.cocci
 
 @@
-local idexpression n;
-expression E;
+expression T;
 @@
 
-n = malloc(E);
-+ if (n == NULL)
-+ 	pkg_emit_errno("malloc", TEXT(E));
-... when != (n == NULL)
-    when != (n != NULL)
+T = malloc(...);
++ if (T == NULL) {
++ 	pkg_fatal_errno("%s: %s", __func__, "malloc");
++ }
+... when != (T == NULL)
+    when != (T != NULL)
+? T = malloc(...);
 
 @@
-local idexpression n;
-expression E, E1;
+expression T;
 @@
 
-n = calloc(E, E1);
-+ if (n == NULL)
-+ 	pkg_emit_errno("calloc", TEXT2(E, E1));
-... when != (n == NULL)
-    when != (n != NULL)
+T = calloc(...);
++ if (T == NULL) {
++ 	pkg_fatal_errno("%s: %s", __func__, "calloc");
++ }
+... when != (T == NULL)
+    when != (T != NULL)
+? T = calloc(...);
 
 @@
-local idexpression n;
-expression E, E1;
+expression T;
 @@
 
-n = realloc(E, E1);
-+ if (n == NULL)
-+ 	pkg_emit_errno("realloc", TEXT2(E, E1));
-... when != (n == NULL)
-    when != (n != NULL)
+T = realloc(...);
++ if (T == NULL) {
++ 	pkg_fatal_errno("%s: %s", __func__, "realloc");
++ }
+... when != (T == NULL)
+    when != (T != NULL)
+? T = realloc(...);
 
 @@
-local idexpression n;
-expression E;
+expression T;
 @@
 
- n = strdup(E);
-+ if (n == NULL)
-+ 	pkg_emit_errno("strdup", TEXT(E));
-... when != (n == NULL)
-    when != (n != NULL)
+T = strdup(...);
++ if (T == NULL) {
++ 	pkg_fatal_errno("%s: %s", __func__, "strdup");
++ }
+... when != (T == NULL)
+    when != (T != NULL)
+? T = strdup(...);


### PR DESCRIPTION
Hi,

Please see the following patches which:

1.  Switches `libpkg` over to use the recently added `pkg_fatal_errno` and `pkg_errno` macros.  Now we're standardizing on this.

2.  Updates the `unchecked_malloc.cocci` script to better cover missing NULL checks from various heap-allocation memory tools.

