### PR TITLE
configure.ac: silence default warnings from ar(1)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -12,6 +12,9 @@ AC_CONFIG_SRCDIR([configure.ac])
 AM_INIT_AUTOMAKE([1.11 foreign -Wno-portability no-dist-gzip dist-xz])
 AM_SILENT_RULES([yes])
 
+# Silence warning: ar: 'u' modifier ignored since 'D' is the default
+AC_SUBST(AR_FLAGS, [cr])
+
 AM_MAINTAINER_MODE([enable])
 
 dnl Here are rules for setting version-info for libpkg


### PR DESCRIPTION
Until automake fix this upstream, for now, set the ARFLAGS variable to the
default values.  Silences the following:

	ar: `u' modifier ignored since `D' is the default (see `U')