### PR TITLE
Add ability to upgrade vulnerable packages

### DIFF
--- a/libpkg/pkg.h.in
+++ b/libpkg/pkg.h.in
@@ -5,6 +5,7 @@
  * Copyright (c) 2011 Philippe Pepiot <phil@philpep.org>
  * Copyright (c) 2011-2012 Marin Atanasov Nikolov <dnaeon@gmail.com>
  * Copyright (c) 2013-2014 Matthew Seaman <matthew@FreeBSD.org>
+ * Copyright (c) 2014-2016 Vsevolod Stakhov <vsevolod@FreeBSD.org>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -370,7 +371,8 @@ typedef enum _pkg_flags {
 	PKG_FLAG_FORCE_MISSING = (1U << 9),
 	PKG_FLAG_FETCH_MIRROR = (1U << 10),
 	PKG_FLAG_USE_IPV4 = (1U << 11),
-	PKG_FLAG_USE_IPV6 = (1U << 12)
+	PKG_FLAG_USE_IPV6 = (1U << 12),
+	PKG_FLAG_UPGRADE_VULNERABLE = (1U << 13)
 } pkg_flags;
 
 typedef enum _pkg_stats_t {

--- a/libpkg/pkg_jobs.c
+++ b/libpkg/pkg_jobs.c
@@ -750,7 +750,7 @@ static int
 pkg_jobs_process_remote_pkg(struct pkg_jobs *j, struct pkg *rp,
 	struct pkg_job_request_item **req, int with_version)
 {
-	struct pkg_job_universe_item *nit;
+	struct pkg_job_universe_item *nit, *cur;
 	struct pkg_job_request_item *nrit = NULL;
 	struct pkg *lp = NULL;
 	struct pkg_dep *rdep = NULL;
@@ -777,6 +777,13 @@ pkg_jobs_process_remote_pkg(struct pkg_jobs *j, struct pkg *rp,
 			*req = nrit;
 
 		if (j->flags & PKG_FLAG_UPGRADE_VULNERABLE) {
+			/* Set the proper reason */
+			DL_FOREACH(nit, cur) {
+				if (cur->pkg->type != PKG_INSTALLED) {
+					free(cur->pkg->reason);
+					asprintf(&cur->pkg->reason, "vulnerability found");
+				}
+			}
 			/* Also process all rdeps recursively */
 			while (pkg_rdeps(nrit->pkg, &rdep) == EPKG_OK) {
 				lp = pkg_jobs_universe_get_local(j->universe, rdep->uid, 0);

--- a/libpkg/pkg_jobs.c
+++ b/libpkg/pkg_jobs.c
@@ -204,7 +204,7 @@ pkg_jobs_maybe_match_file(struct job_pattern *jp, const char *pattern)
 				int len = dot_pos - pattern;
 
 				pkg_debug(1, "Jobs> Adding file: %s", pattern);
-				jp->is_file = true;
+				jp->flags |= PKG_PATTERN_FLAG_FILE;
 				jp->path = pkg_path;
 				jp->pattern = malloc(len);
 				strlcpy(jp->pattern, pattern, len);
@@ -217,7 +217,7 @@ pkg_jobs_maybe_match_file(struct job_pattern *jp, const char *pattern)
 		/*
 		 * Read package from stdin
 		 */
-		jp->is_file = true;
+		jp->flags = PKG_PATTERN_FLAG_FILE;
 		jp->path = strdup(pattern);
 		jp->pattern = strdup(pattern);
 	}
@@ -1018,7 +1018,7 @@ pkg_jobs_find_remote_pattern(struct pkg_jobs *j, struct job_pattern *jp)
 	struct pkg_job_request *req;
 	struct job_pattern jfp;
 
-	if (!jp->is_file) {
+	if (!(jp->flags & PKG_PATTERN_FLAG_FILE)) {
 		if (j->type == PKG_JOBS_UPGRADE) {
 			/*
 			 * For upgrade patterns we must ensure that a local package is
@@ -1947,7 +1947,8 @@ pkg_jobs_handle_install(struct pkg_solved *ps, struct pkg_jobs *j,
 	new = ps->items[0]->pkg;
 
 	HASH_FIND_STR(j->request_add, new->uid, req);
-	if (req != NULL && req->item->jp != NULL && req->item->jp->is_file) {
+	if (req != NULL && req->item->jp != NULL &&
+			(req->item->jp->flags & PKG_PATTERN_FLAG_FILE)) {
 		/*
 		 * We have package as a file, set special repository name
 		 */

--- a/libpkg/private/pkg_jobs.h
+++ b/libpkg/private/pkg_jobs.h
@@ -120,11 +120,14 @@ struct pkg_jobs {
 	bool pinning;
 };
 
+#define PKG_PATTERN_FLAG_FILE (1 << 0)
+#define PKG_PATTERN_FLAG_VULN (1 << 1)
+
 struct job_pattern {
 	char		*pattern;
 	char		*path;
 	match_t		match;
-	bool		is_file;
+	int			flags;
 	UT_hash_handle hh;
 };
 

--- a/src/upgrade.c
+++ b/src/upgrade.c
@@ -27,14 +27,26 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <sys/wait.h>
 #include <err.h>
 #include <getopt.h>
 #include <stdio.h>
 #include <sysexits.h>
 #include <unistd.h>
-
+#include <errno.h>
+#include <khash.h>
+#include <utstring.h>
 #include <pkg.h>
 
+#ifdef HAVE_SYS_CAPSICUM_H
+#include <sys/capsicum.h>
+#endif
+
+#ifdef HAVE_CAPSICUM
+#include <sys/capability.h>
+#endif
 #include "pkgcli.h"
 
 void
@@ -42,6 +54,191 @@ usage_upgrade(void)
 {
 	fprintf(stderr, "Usage: pkg upgrade [-fInFqUy] [-r reponame] [-Cgix] <pkg-name> ...\n\n");
 	fprintf(stderr, "For more information see 'pkg help upgrade'.\n");
+}
+
+KHASH_MAP_INIT_STR(pkgs, struct pkg *);
+
+static void
+add_to_check(kh_pkgs_t *check, struct pkg *pkg)
+{
+	const char *uid;
+	int ret;
+	khint_t k;
+
+	pkg_get(pkg, PKG_UNIQUEID, &uid);
+
+	k = kh_put_pkgs(check, uid, &ret);
+	if (ret != 0)
+		kh_value(check, k) = pkg;
+}
+
+static void
+check_vulnerable(struct pkg_audit *audit, struct pkgdb *db, int sock)
+{
+	struct pkgdb_it	*it = NULL;
+	struct pkg		*pkg = NULL;
+	kh_pkgs_t		*check = NULL;
+	const char		*uid;
+	UT_string		*sb;
+	int				ret;
+	FILE			*out;
+
+	out = fdopen (sock, "w");
+	if (out == NULL) {
+		warn("unable to open stream");
+		return;
+	}
+
+	drop_privileges();
+
+	if (pkg_audit_load(audit, NULL) != EPKG_OK) {
+		warn("unable to open vulnxml file");
+		fclose(out);
+		pkg_audit_free(audit);
+		return;
+	}
+
+	if ((it = pkgdb_query(db, NULL, MATCH_ALL)) == NULL) {
+		warnx("Error accessing the package database");
+		pkg_audit_free(audit);
+		fclose(out);
+		return;
+	}
+	else {
+		while ((ret = pkgdb_it_next(it, &pkg, PKG_LOAD_BASIC|PKG_LOAD_RDEPS))
+				== EPKG_OK) {
+			add_to_check(check, pkg);
+			pkg = NULL;
+		}
+		ret = EX_OK;
+	}
+
+	pkg_audit_free(audit);
+	if (db != NULL) {
+		pkgdb_it_free(it);
+		pkgdb_release_lock(db, PKGDB_LOCK_READONLY);
+		pkgdb_close(db);
+		fclose(out);
+	}
+
+	if (ret != EX_OK) {
+		pkg_audit_free(audit);
+		kh_destroy_pkgs(check);
+		fclose(out);
+		return;
+	}
+
+#ifdef HAVE_CAPSICUM
+	if (cap_enter() < 0 && errno != ENOSYS) {
+		warn("cap_enter() failed");
+		pkg_audit_free(audit);
+		kh_destroy_pkgs(check);
+		fclose(out);
+		return;
+	}
+#endif
+
+	if (pkg_audit_process(audit) == EPKG_OK) {
+		kh_foreach_value(check, pkg, {
+				if (pkg_audit_is_vulnerable(audit, pkg, true, &sb)) {
+					pkg_get(pkg, PKG_UNIQUEID, &uid);
+					fprintf(out, "%s\n", uid);
+					utstring_free(sb);
+				}
+				pkg_free(pkg);
+		});
+		kh_destroy_pkgs(check);
+	}
+	else {
+		warnx("cannot process vulnxml");
+		kh_destroy_pkgs(check);
+	}
+
+	fclose(out);
+	pkg_audit_free(audit);
+}
+
+static int
+add_vulnerable_upgrades(struct pkg_jobs	*jobs, struct pkgdb *db)
+{
+	int 				sp[2], retcode;
+	pid_t 				cld;
+	FILE				*in;
+	struct pkg_audit	*audit;
+	char				*line = NULL;
+	size_t				linecap = 0;
+	ssize_t				linelen;
+
+	/* Fetch audit file */
+	/* TODO: maybe, we can skip it somethimes? */
+	audit = pkg_audit_new();
+
+	if (pkg_audit_fetch(NULL, NULL) != EPKG_OK) {
+		pkg_audit_free(audit);
+		return (EX_IOERR);
+	}
+
+	/* Create socketpair to execute audit check in a detached mode */
+	if (socketpair(AF_UNIX, SOCK_STREAM, 0, sp) == -1)  {
+		warnx("Cannot create socketpair");
+
+		return (EPKG_FATAL);
+	}
+
+	cld = fork();
+
+	switch (cld) {
+	case 0:
+		close(sp[1]);
+		check_vulnerable(audit, db, sp[0]);
+		close(sp[0]);
+		exit(EXIT_SUCCESS);
+		break;
+	case -1:
+		warnx("Cannot fork");
+		return (EPKG_FATAL);
+	default:
+		/* Parent code */
+		close(sp[0]);
+		pkg_audit_free(audit);
+		in = fdopen(sp[1], "r");
+
+		if (in == NULL) {
+			warnx("Cannot create stream");
+			close(sp[1]);
+
+			return (EPKG_FATAL);
+		}
+		break;
+	}
+
+	while ((linelen = getline(&line, &linecap, in)) > 0) {
+		if (line[linelen - 1] == '\n') {
+			line[linelen - 1] = '\0';
+		}
+
+		if (pkg_jobs_add(jobs, MATCH_EXACT, &line, 1) == EPKG_FATAL) {
+			warnx("Cannot update %s which is vulnerable", line);
+			/* TODO: assume it non-fatal for now */
+		}
+	}
+
+	fclose(in);
+	close(sp[1]);
+	pkg_audit_free(audit);
+
+	while (waitpid(cld, &retcode, 0) == -1) {
+		if (errno == EINTR) {
+			continue;
+		}
+		else {
+			warnx("Cannot wait");
+
+			return (EPKG_FATAL);
+		}
+	}
+
+	return (EPKG_OK);
 }
 
 int
@@ -72,12 +269,13 @@ exec_upgrade(int argc, char **argv)
 		{ "no-repo-update",	no_argument,		NULL,	'U' },
 		{ "regex",		no_argument,		NULL,	'x' },
 		{ "yes",		no_argument,		NULL,	'y' },
+		{ "vulnerable",		no_argument,		NULL,		'v' },
 		{ NULL,			0,			NULL,	0   },
 	};
 
 	nbactions = nbdone = 0;
 
-	while ((ch = getopt_long(argc, argv, "+CfFgiInqr:Uxy", longopts, NULL)) != -1) {
+	while ((ch = getopt_long(argc, argv, "+CfFgiInqr:Uxyv", longopts, NULL)) != -1) {
 		switch (ch) {
 		case 'C':
 			pkgdb_set_case_sensitivity(true);
@@ -117,6 +315,9 @@ exec_upgrade(int argc, char **argv)
 			break;
 		case 'y':
 			yes = true;
+			break;
+		case 'v':
+			f |= PKG_FLAG_UPGRADE_VULNERABLE;
 			break;
 		default:
 			usage_upgrade();
@@ -174,6 +375,13 @@ exec_upgrade(int argc, char **argv)
 	if (argc > 0)
 		if (pkg_jobs_add(jobs, match, argv, argc) == EPKG_FATAL)
 				goto cleanup;
+
+	if (f & PKG_FLAG_UPGRADE_VULNERABLE) {
+		/* We need to load audit info and add packages that are vulnerable */
+		if (add_vulnerable_upgrades(jobs, db) != EPKG_OK) {
+			goto cleanup;
+		}
+	}
 
 	if (pkg_jobs_solve(jobs) != EPKG_OK)
 		goto cleanup;

--- a/src/upgrade.c
+++ b/src/upgrade.c
@@ -27,6 +27,8 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "pkg_config.h"
+
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/wait.h>
@@ -113,7 +115,6 @@ check_vulnerable(struct pkg_audit *audit, struct pkgdb *db, int sock)
 		ret = EX_OK;
 	}
 
-	pkg_audit_free(audit);
 	if (db != NULL) {
 		pkgdb_it_free(it);
 		pkgdb_release_lock(db, PKGDB_LOCK_READONLY);
@@ -154,8 +155,8 @@ check_vulnerable(struct pkg_audit *audit, struct pkgdb *db, int sock)
 		kh_destroy_pkgs(check);
 	}
 
-	fclose(out);
 	pkg_audit_free(audit);
+	fclose(out);
 }
 
 static int
@@ -225,7 +226,6 @@ add_vulnerable_upgrades(struct pkg_jobs	*jobs, struct pkgdb *db)
 
 	fclose(in);
 	close(sp[1]);
-	pkg_audit_free(audit);
 
 	while (waitpid(cld, &retcode, 0) == -1) {
 		if (errno == EINTR) {


### PR DESCRIPTION
This feature joins `pkg audit` and `pkg upgrade` to upgrade merely those packages that are required to be upgraded due to vulnerabilities.

TODO list:
* Add 'vulnerable' to upgrade reason
* Allow to specify custom vulnxml file
* Think more about `forced` mode
* Update docs