### PR TITLE
CFLAGS: add -std=gnu99 for GCC compilations

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -30,6 +30,11 @@ AC_SUBST(LIBPKG_SO_VERSION)
 
 AC_GNU_SOURCE
 AC_PROG_CC_C99
+if test "x$ac_cv_prog_cc_c99" = "xno"; then
+	AC_MSG_ERROR([Compiler is not compliant with C99 standard.])
+fi
+CFLAGS="$CFLAGS $ac_cv_prog_cc_c99"
+
 LT_INIT()
 AC_CONFIG_MACRO_DIR([m4])
 AX_CFLAGS_WARN_ALL


### PR DESCRIPTION
When trying to compile pkg with gcc (gcc49 in this case), it fails because the
GCC extensions used in pkg (restrict and typeof) aren't being declared as
such without telling the compiler that we expect these extensions.

Clang also supports -std=gnu99; it's safe to unconditionally declare this
globally in CFLAGS.