### PR TITLE
Fix pkg audit output

### DIFF
--- a/scripts/periodic/410.pkg-audit.in
+++ b/scripts/periodic/410.pkg-audit.in
@@ -75,7 +75,7 @@ expiration_pkgs() {
 	output=$(${pkgcmd} ${pkgargs} annotate -a -S expiration_date)
 
 	if [ -n "${output}" ]; then
-		echo $output
+		echo "${output}"
 		return 3
 	fi
 }
@@ -86,7 +86,7 @@ deprecation_pkgs() {
 	output=$(${pkgcmd} ${pkgargs} annotate -a -S deprecated)
 
 	if [ -n "${output}" ]; then
-		echo $output
+		echo "${output}"
 		return 3
 	fi
 }


### PR DESCRIPTION
Due to missing quotes, both the expiration and deprecation reports
produce a single line, making the output painful to read:

```
Checking for packages with security vulnerabilities:
Database fetched: dim.  8 janv. 2017 04:12:38 CET
p5-Net-SMTP-SSL-1.04: Tag: expiration_date Value: 2017-03-31 puppet38-3.8.7_1: Tag: expiration_date Value: 2017-02-05
p5-Net-SMTP-SSL-1.04: Tag: deprecated Value: Deprecated by upstream, use Net::SMTP instead puppet38-3.8.7_1: Tag: deprecated Value: Upstream support ended, see http://tinyurl.com/puppet3eol
```

This patch improves this point:

```
Checking for packages with security vulnerabilities:
Database fetched: dim.  8 janv. 2017 04:12:38 CET
p5-Net-SMTP-SSL-1.04: Tag: expiration_date Value: 2017-03-31
puppet38-3.8.7_1: Tag: expiration_date Value: 2017-02-05
p5-Net-SMTP-SSL-1.04: Tag: deprecated Value: Deprecated by upstream, use Net::SMTP instead
puppet38-3.8.7_1: Tag: deprecated Value: Upstream support ended, see http://tinyurl.com/puppet3eol
```