### PR TITLE
pkg-delete: do not leave modified files behind

### DIFF
--- a/libpkg/pkg_delete.c
+++ b/libpkg/pkg_delete.c
@@ -302,23 +302,6 @@ pkg_delete_file(struct pkg *pkg, struct pkg_file *file, unsigned force)
 	while (len > 0 && prefix_rel[len - 1] == '/')
 		len--;
 
-	/* Regular files and links */
-	/* check checksum */
-	if (!force && file->sum != NULL) {
-		ret = pkg_checksum_validate_fileat(pkg->rootfd, path, file->sum);
-		if (ret == ENOENT) {
-			pkg_emit_file_missing(pkg, file);
-			return;
-		}
-		if (ret != 0) {
-			pkg_emit_error("%s%s%s different from original "
-			    "checksum, not removing", pkg->rootpath,
-			    pkg->rootpath[strlen(pkg->rootpath) - 1] == '/' ? "" : "/",
-			    path);
-			return;
-		}
-	}
-
 #ifdef HAVE_CHFLAGS
 	if (fstatat(pkg->rootfd, path, &st, AT_SYMLINK_NOFOLLOW) != -1) {
 		if (st.st_flags & NOCHANGESFLAGS) {


### PR DESCRIPTION
While the check is understandable, it may lead to situations where
plugin-like files may linger in the system, causing problems.  We
have @sample for config files that takes care of this now.