### PR TITLE
Use dependencies formula in solver

### DIFF
--- a/libpkg/pkg_deps.c
+++ b/libpkg/pkg_deps.c
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2015, Vsevolod Stakhov
+ * Copyright (c) 2015-2017, Vsevolod Stakhov
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/libpkg/pkgdb_iterator.c
+++ b/libpkg/pkgdb_iterator.c
@@ -7,7 +7,7 @@
  * Copyright (c) 2012-2014 Matthew Seaman <matthew@FreeBSD.org>
  * Copyright (c) 2012 Bryan Drewery <bryan@shatow.net>
  * Copyright (c) 2013 Gerald Pfeifer <gerald@pfeifer.com>
- * Copyright (c) 2013-2014 Vsevolod Stakhov <vsevolod@FreeBSD.org>
+ * Copyright (c) 2013-2017 Vsevolod Stakhov <vsevolod@FreeBSD.org>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -213,6 +213,7 @@ pkgdb_load_deps(sqlite3 *sqlite, struct pkg *pkg)
 {
 	sqlite3_stmt	*stmt = NULL, *opt_stmt = NULL;
 	int		 ret = EPKG_OK;
+	struct pkg_dep *chain = NULL;
 	struct pkg_dep_formula *f;
 	struct pkg_dep_formula_item *fit;
 	struct pkg_dep_option_item *optit;
@@ -288,6 +289,8 @@ pkgdb_load_deps(sqlite3 *sqlite, struct pkg *pkg)
 					}
 
 					/* Fetch matching packages */
+					chain = NULL;
+
 					while ((ret = sqlite3_step(stmt)) == SQLITE_ROW) {
 						/*
 						 * Load options for a package and check
@@ -333,7 +336,8 @@ pkgdb_load_deps(sqlite3 *sqlite, struct pkg *pkg)
 						}
 
 						if (options_match) {
-							pkg_adddep(pkg, sqlite3_column_text(stmt, 1),
+							chain = pkg_adddep_chain(chain, pkg,
+									sqlite3_column_text(stmt, 1),
 									sqlite3_column_text(stmt, 2),
 									sqlite3_column_text(stmt, 3),
 									sqlite3_column_int64(stmt, 4));

--- a/libpkg/private/pkg.h
+++ b/libpkg/private/pkg.h
@@ -104,14 +104,25 @@
 	data = NULL;                               \
 } while (0)
 
-#define LL_FREE(head, free_func) do {   \
+#define LL_FREE2(head, free_func, next) do {   \
 	__typeof(head) l1, l2;                 \
-	LL_FOREACH_SAFE(head, l1, l2) {       \
-		LL_DELETE(head, l1);          \
+	LL_FOREACH_SAFE2(head, l1, l2, next) {       \
+		LL_DELETE2(head, l1, next);          \
 		free_func(l1);                \
 	}                                     \
 	head = NULL;                          \
 } while (0)
+#define LL_FREE(head, free_func) LL_FREE2(head, free_func, next)
+
+#define DL_FREE2(head, free_func, prev, next) do {   \
+	__typeof(head) l1, l2;                 \
+	DL_FOREACH_SAFE2(head, l1, l2, next) {       \
+		DL_DELETE2(head, l1, prev, next);          \
+		free_func(l1);                \
+	}                                     \
+	head = NULL;                          \
+} while (0)
+#define DL_FREE(head, free_func) DL_FREE2(head, free_func, prev, next)
 
 #define HASH_NEXT(hash, data) do {            \
 		if (data == NULL)             \

--- a/libpkg/private/pkg.h
+++ b/libpkg/private/pkg.h
@@ -2,9 +2,9 @@
  * Copyright (c) 2011-2016 Baptiste Daroussin <bapt@FreeBSD.org>
  * Copyright (c) 2011-2012 Julien Laffaye <jlaffaye@FreeBSD.org>
  * Copyright (c) 2013 Matthew Seaman <matthew@FreeBSD.org>
- * Copyright (c) 2013 Vsevolod Stakhov <vsevolod@FreeBSD.org>
+ * Copyright (c) 2013-2017 Vsevolod Stakhov <vsevolod@FreeBSD.org>
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
@@ -14,7 +14,7 @@
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
  * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
@@ -320,7 +320,8 @@ struct pkg_dep {
 	char		*version;
 	char		*uid;
 	bool		 locked;
-	struct pkg_dep	*next;
+	struct pkg_dep		*alt_next, *alt_prev; /* Chain of alternatives */
+	struct pkg_dep	*next, *prev;
 };
 
 typedef enum {
@@ -816,5 +817,8 @@ int pkg_set_from_fileat(int fd, struct pkg *pkg, pkg_attr attr, const char *file
 void pkg_rollback_cb(void *);
 void pkg_rollback_pkg(struct pkg *);
 int pkg_add_fromdir(struct pkg *, const char *);
+struct pkg_dep* pkg_adddep_chain(struct pkg_dep *chain,
+		struct pkg *pkg, const char *name, const char *origin, const
+		char *version, bool locked);
 
 #endif


### PR DESCRIPTION
This is the proposal of the dependencies formula being applied to the current solver process. It should create chains with `(!A || B1 || B2 || ... || Bn)` for dependencies alternatives. Moreover, the current solver algorithm prefers already installed packages so this perfectly fits for the dependencies alternatives. Options and versions checks are already implemented in the current code. 