### PR TITLE
Fix typo in pkg-install man page.

### DIFF
--- a/docs/pkg-install.8
+++ b/docs/pkg-install.8
@@ -133,7 +133,7 @@ If any installation scripts (pre-install or post-install) exist for a given
 package, do not execute them.
 When a package is updated, deinstallation
 scripts (pre-deinstall or post-deinstall) are not run either.
-.It Fl i , Cm --case-sensitive
+.It Fl i , Cm --case-insensitive
 Make the standard or the regular expression
 .Fl ( x )
 matching against


### PR DESCRIPTION
This is the only mismatch for any -C/-i option across all man pages.