### PR TITLE
When the glob bool was true, the pattern was not pushed into patterns kv

### DIFF
--- a/src/which.c
+++ b/src/which.c
@@ -195,6 +195,7 @@ exec_which(int argc, char **argv)
 				retcode = EX_USAGE;
 				goto cleanup;
                         }
+			kv_push(char *, patterns, strdup(pathabs));
 		}
 
 


### PR DESCRIPTION
The -g flag supposed to enable glob patterns in package search was broken since d7c19100db11dd341972dda371d233a1613dea03. This PR fixes it.