### PR TITLE
This PR adds a new option to pkg-which which was suggested in #562

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -34,7 +34,7 @@ COCCI_ARGS=	-I ${top_srcdir} \
 		-I ${top_srcdir}/external/libyaml/include \
 		-I ${top_srcdir}/external/libucl/include \
 		-I ${top_srcdir}/external/uthash \
-		-I ${top_srcdir}/external/sqlite  \
+		-I ${top_srcdir}/external/sqlite \
 		-I ${top_srcdir}/external/libelf
 
 1cocci:

--- a/docs/pkg-which.8
+++ b/docs/pkg-which.8
@@ -22,11 +22,11 @@
 .Nd display which package installed a specific file
 .Sh SYNOPSIS
 .Nm
-.Op Fl gopq
+.Op Fl gopqm
 .Ar file
 .Pp
 .Nm
-.Op Cm --{glob,origin,path-search,quiet}
+.Op Cm --{glob,origin,path-search,quiet,show-match}
 .Ar file
 .Sh DESCRIPTION
 .Nm
@@ -40,6 +40,8 @@ The following options are supported by
 Treat
 .Ao file Ac
 as a glob pattern.
+.It Fl m , Cm --show-match
+Show files that matched the glob pattern (requires --glob)
 .It Fl o , Cm --origin
 Show the origin of the package instead of name-version.
 .It Fl p , Cm --path-search

--- a/libpkg/pkg_printf.c
+++ b/libpkg/pkg_printf.c
@@ -43,6 +43,7 @@
 #include <private/pkg_printf.h>
 #include <private/pkg.h>
 
+
 /*
  * Format codes
  *    Arg Type     What

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -54,6 +54,8 @@ pkg_CFLAGS=	 @OS_CFLAGS@ \
 			-I$(top_srcdir)/external/libucl/klib \
 			-I$(top_srcdir)/external/uthash \
 			-I$(top_srcdir)/external/expat/lib \
+			-I$(top_srcdir)/external/sqlite \
+			-I$(top_srcdir)/external/libucl/include \
 			-DGITHASH=\"$(GIT_HEAD)\" 
 pkg_static_SOURCES=
 pkg_static_LDADD= @OS_LDFLAGS@ \


### PR DESCRIPTION
This PR adds a new option to `pkg-which` which was suggested in https://github.com/freebsd/pkg/issues/562

-m --show-match

This shows only files matching the glob pattern

Here's a sample of what it shows
```
 [22:54 morgoth ~/github/pkg[ (git)-[issue_562]-]{}] none %] src/pkg-static -d which -g -m \*bash                                                                                                                                                                     [{ 0.41 - ]
DBG(1)[71794]> pkg initialized
*bash was glob searched and found in package ibus-1.5.11_1
/usr/local/share/bash-completion/completions/ibus.bash
*bash was glob searched and found in package pkg-1.9.4_1
/usr/local/etc/bash_completion.d/_pkg.bash
*bash was glob searched and found in package git-2.11.0_4
/usr/local/share/git-core/contrib/completion/git-completion.bash
*bash was glob searched and found in package bash-4.4.12
/usr/local/bin/bash
/usr/local/bin/rbash
```