### PR TITLE
410.pkg-audit should use anticongestion on FreeBSD 12

### DIFF
--- a/scripts/periodic/410.pkg-audit.in
+++ b/scripts/periodic/410.pkg-audit.in
@@ -55,8 +55,12 @@ audit_pkgs() {
 	if [ $rc -ne 0 -o \
 		$(( 86400 \* "${daily_status_security_pkgaudit_expiry:-2}" )) \
 		-le $(( ${now} - ${then} + 600 )) ]; then
-		# Random delay so the mirrors do not get slammed when run by periodic(8)
-		if [ ! -t 0 ]; then
+		# When non-interactive, sleep to reduce congestion on mirrors
+		if [ -n "$anticongestion_sleeptime" ]; then
+			# In FreeBSD 12.0 the anticongestion function should be
+			# used instead of a hard-coded sleep
+			anticongestion
+		else
 			sleep `jot -r 1 0 3600`
 		fi
 		${pkgcmd} ${pkgargs} audit -F $q || { rc=$?; [ $rc -lt 3 ] && rc=3; }


### PR DESCRIPTION
Also, remove the old check for interactive use.  It never worked, since
periodic(8) closes stdin.

See https://svnweb.freebsd.org/changeset/base/316342 for reference