### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,7 +557,7 @@ your repository :)
 * [Jenkins instance for pkg][3]
 
 In order to get in contact with us, you can find us in the
-#pkgng@FreeNode IRC channel.
+# pkgng@FreeNode IRC channel.
 
 If you hit a bug when using pkg, you can always submit an issue in the
 [pkg issue tracker][4].

--- a/README.md
+++ b/README.md
@@ -557,7 +557,7 @@ your repository :)
 * [Jenkins instance for pkg][3]
 
 In order to get in contact with us, you can find us in the
-# pkgng@FreeNode IRC channel.
+#pkgng@FreeNode IRC channel.
 
 If you hit a bug when using pkg, you can always submit an issue in the
 [pkg issue tracker][4].

--- a/external/libucl/doc/lua_api.md
+++ b/external/libucl/doc/lua_api.md
@@ -38,7 +38,7 @@ func = "huh";
 --]]
 ~~~
 
-###Brief content:
+### Brief content:
 
 **Functions**:
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
