### PR TITLE
Fix drop_privileges() on Linux

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -1027,14 +1027,11 @@ drop_privileges(void)
 	if (geteuid() == 0) {
 		nobody = getpwnam("nobody");
 		if (nobody == NULL)
-			err(EXIT_FAILURE, "Unable to drop priviledges");
+			err(EXIT_FAILURE, "Unable to drop privileges");
 		setgroups(1, &nobody->pw_gid);
-		if (setegid(nobody->pw_gid) == -1)
-			err(EXIT_FAILURE, "Unable to setegid");
+		/* setgid also sets egid and setuid also sets euid */
 		if (setgid(nobody->pw_gid) == -1)
 			err(EXIT_FAILURE, "Unable to setgid");
-		if (seteuid(nobody->pw_uid) == -1)
-			err(EXIT_FAILURE, "Unable to seteuid");
 		if (setuid(nobody->pw_uid) == -1)
 			err(EXIT_FAILURE, "Unable to setuid");
 	}


### PR DESCRIPTION
As setuid will set the effective user ID as well as the real user ID, it
is redundant to have to calls to set these IDs.  In the case of Linux,
it is illegal.  Once the effective ID is changed from "root" to
"nobody", pkg(8) no longer has the privilege to run setuid, resulting in
an "Operation not permitted" error when "sudo pkg" is executed.

Similarly, setegid is unnecessary when followed by setgid, but that is
legal.  Remove both redundant steps to fix operation on the Linux
platform and fix a spelling error while here.