### PR TITLE
Unbreak non-freebsd platforms after 59f590 (Stop relying on elf notes ...)

### DIFF
--- a/libpkg/pkg_elf.c
+++ b/libpkg/pkg_elf.c
@@ -347,12 +347,6 @@ analyse_elf(struct pkg *pkg, const char *fpath)
 		goto cleanup; /* Invalid ABI */
 	}
 
-	if (elfhdr.e_ident[EI_OSABI] != ELFOSABI_FREEBSD &&
-	    !is_old_freebsd_armheader(&elfhdr)) {
-		ret = EPKG_END;
-		goto cleanup;
-	}
-
 	if ((data = elf_getdata(dynamic, NULL)) == NULL) {
 		ret = EPKG_END; /* Some error occurred, ignore this file */
 		goto cleanup;


### PR DESCRIPTION
After the method of checking ELF notes to determine supported platforms
was removed (May 14, 2016), SHLIBS support on DragonFly broke (and
remained broken on all other platforms like Linux).

What remained was a fallback check that only evaluates tree on FreeBSD
platforms.  This check has to either be expanded to compensate for the
removed elf-note checks or just removed as well.  This commit takes the
latter approach which allows all platforms to proceed. (NetBSD,
DragonFly, Linux among others)

Analyzed by François Tigeot