### PR TITLE
Fix ELF note parsing and recognize NT_GNU_ABI_TAG

### DIFF
--- a/libpkg/private/elf_tables.h
+++ b/libpkg/private/elf_tables.h
@@ -73,6 +73,7 @@ static const struct _elf_corres os_corres[] = {
 
 #define NT_VERSION	1
 #define NT_ARCH	2
+#define NT_GNU_ABI_TAG	1
 
 /* All possibilities on FreeBSD as of 5/26/2014 */
 struct arch_trans {


### PR DESCRIPTION
The logic on the ELF note parsing was incorrect.  It happens to work
on *BSD, but the issue shows on other platforms (e.g. Linux ABI gets
set to "GNU:0").

The first mistake is assuming the note always has a namespace and that
this namespace equals the standard name of the operating system.  In
fact, having a namespace is not even required as there are default
definitions for tags: NT_VERSION (=1) and NT_ARCH (=2).

The BSDs (at least FreeBSD, DragonFly, and NetBSD) define their
own namespace (aka "Owner" on readelf" and the NT_VERSION tag, which
is a single word.  Pkg currently assumes the namespace is equal to
the osname and assumes there's a NT_VERSION note defined.  For
correctness, pkg must check that the namespace length is either zero
or equal to an operating system name before assume a n_type value of
1 is equivalent to an NT_VERSION note.

A very popular namespace is "GNU".  The tag values of "GNU" overlap
with with all other namespaces; for example NT_GNU_ABI_TAG is
value 1 (same as NT_VERSION) and  NT_GNU_ABI_TAG is value 2 (same as
the default NT_ARCH).  Thus the namespace has to be checked when
examining n_type of ELF notes.

The second issue is a lack of support for NT_GNU_ABI_TAG.  Linux
does not use NT_VERSION note, the only one pkg supports.  The ELF
note parsing code then mistakenly converts the note namespace "GNU"
into the osname, thus resulting in "GNU:0:..." ABI for Linux.

This code implements NT_GNU_ABI_TAG along side NT_VERSION.  As a
result, this is the output on x86_64 Linux:

ABI = "Linux:2.6.32:amd64";
ALTABI = "linux:2.6.32:x86:64";

This is the correct value in the case of Linux.  The glibc was
compiled with Linux kernel headers from version 2.6.32 and all
later kernels should be binary-compatible with it.

It has been verified that FreeBSD and DragonFly still function as
before with this patch.