### PR TITLE
Silently return when obj is NULL

### DIFF
--- a/libpkg/pkg_repo.c
+++ b/libpkg/pkg_repo.c
@@ -977,6 +977,10 @@ pkg_repo_load_fingerprint(const char *dir, const char *filename)
 	obj = ucl_parser_get_object(p);
 	close(fd);
 
+	/* Silently return if obj is NULL */
+	if (!obj)
+		return(NULL);
+
 	if (obj->type == UCL_OBJECT)
 		f = pkg_repo_parse_fingerprint(obj);
 


### PR DESCRIPTION
pkg_repo_load_fingerprints_from_path() attempts to read all files on
path using pkg_repo_load_fingerprint(). When a file is empty
ucl_parser_get_object() will return NULL and the attempt to access
obj->type crashes pkg

It's simply to reproduce just following these steps:
```
# pkg update -f
Updating FreeBSD repository catalogue...
Fetching meta.txz: 100%    944 B   0.9kB/s    00:01
Fetching packagesite.txz: 100%    6 MiB   1.2MB/s    00:05
Processing entries: 100%
FreeBSD repository update completed. 26418 packages processed.
All repositories are up to date.

# touch /usr/share/keys/pkg/trusted/test

# pkg update -f
Updating FreeBSD repository catalogue...
Fetching meta.txz: 100%    944 B   0.9kB/s    00:01
Child process pid=67210 terminated abnormally: Segmentation fault

# rm /usr/share/keys/pkg/trusted/test

# pkg update -f
Updating FreeBSD repository catalogue...
Fetching meta.txz: 100%    944 B   0.9kB/s    00:01
Fetching packagesite.txz: 100%    6 MiB 997.2kB/s    00:06
Processing entries: 100%
FreeBSD repository update completed. 26418 packages processed.
All repositories are up to date.
```