### PR TITLE
Prevent SIGSEGV with 'pkg version' with packaged base.

### DIFF
--- a/src/version.c
+++ b/src/version.c
@@ -694,6 +694,9 @@ validate_origin(const char *portsdir, const char *origin)
 	buf = strrchr(origin, '/');
 	buf++;
 
+	if (strcmp(origin, "base") == 0)
+		return (false);
+
 	k = kh_get_ports(cat->ports, buf);
 
 	return (k != kh_end(cat->ports));


### PR DESCRIPTION
'pkg version' segfaults when the 'origin' is 'base'.  This patch avoids the crash, however the version for 'base' packages is not determined to be greater-than, lesser-than, or equal-to the latest version available for base packages.