### PR TITLE
Allow a "successful failure" in a post-install script when exiting

### DIFF
--- a/libpkg/scripts.c
+++ b/libpkg/scripts.c
@@ -198,6 +198,9 @@ pkg_script_run(struct pkg * const pkg, pkg_script type)
 			}
 
 			if (WEXITSTATUS(pstat) != 0) {
+				if (WEXITSTATUS(pstat) == 3)
+					exit(0);
+
 				pkg_emit_error("%s script failed", map[i].arg);
 				ret = EPKG_FATAL;
 				goto cleanup;


### PR DESCRIPTION
with status '3'.

The use case here is the 'kernel' package, which after installing
should prompt the user to reboot the system when upgrading with
'pkg upgrade', before the userland packages are upgraded.

With this patch and the following post-install script, 'pkg upgrade'
of a packaged base system installs the kernel package first, emits
a message to reboot the system, and exits properly (however I am
not sure if 'exit(0)' here is the correct way to handle this).

  post-install = <<EOD
    /usr/sbin/kldxref ${PKG_ROOTDIR}/boot/kernel
    echo "The kernel has been upgraded.  Please reboot the system before"
    echo "running 'pkg upgrade' again to upgrade the userland."
    exit 3
  EOD

Sponsored by:	The FreeBSD Foundation