### PR TITLE
Correct typo in description field.

### DIFF
--- a/libpkg/pkg.pc.in
+++ b/libpkg/pkg.pc.in
@@ -3,7 +3,7 @@ libdir=${prefix}/lib
 includedir=${prefix}/include
 
 Name: pkg
-Descriptions: Library to manipulate packages
+Description: Library to manipulate packages
 Version: @VERSION@
 Libs: -L${libdir} -lpkg
 Cflags: -I${includedir}


### PR DESCRIPTION
Over time pkgconf got stricter with validating the pkg-config files,
and now it rejects the pkg pkg-config file with:
 pkg.pc: warning: file does not declare a `Description' field
 pkg.pc: warning: skipping invalid file

The same issue is in the 1.10 branch.