### PR TITLE
README.md: s/sudo/doas/ for OpenBSD and Bitrig

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ get on.
 	./autogen.sh
 	./configure
 	make
-	sudo make install
+	doas make install
 	
 	# install pkg
 	cd ~/git
@@ -319,7 +319,7 @@ get on.
 	./autogen.sh
 	./configure
 	make
-	sudo make install
+	doas make install
 
 <a name="usageintro"></a>
 ## A quick usage introduction to pkg


### PR DESCRIPTION
This patch update the building from source instructions to reflect the
fact that both OpenBSD and Bitrig have switched from sudo to doas.