### PR TITLE
Support flags when installing as user.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -157,6 +157,7 @@ AC_CHECK_HEADER([regex.h], [
 	[#include <sys/types.h>])
 
 AC_CHECK_FUNCS_ONCE([strtofflags])
+AC_CHECK_FUNCS_ONCE([fflagstostr])
 AC_CHECK_FUNCS_ONCE([posix_fallocate])
 AC_CHECK_FUNCS_ONCE([usleep])
 AC_CHECK_FUNCS_ONCE([localtime_r])

--- a/libpkg/metalog.c
+++ b/libpkg/metalog.c
@@ -46,36 +46,52 @@ metalog_open(const char *metalog)
 
 void
 metalog_add(int type, const char *path, const char *uname, const char *gname,
-    int mode, const char *link)
+    int mode, unsigned long fflags, const char *link)
 {
+	char *fflags_buffer = NULL;
+
 	if (metalogfp == NULL) {
 		return;
 	}
+
+#ifdef HAVE_FFLAGSTOSTR
+	if (fflags) {
+		fflags_buffer = fflagstostr(fflags);
+	}
+#endif
 
 	// directory
 	switch (type) {
 	case PKG_METALOG_DIR:
 		if (fprintf(metalogfp,
-		    "./%s type=dir uname=%s gname=%s mode=%3o\n",
-		    path, uname, gname, mode) < 0) {
+		    "./%s type=dir uname=%s gname=%s mode=%3o%s%s\n",
+		    path, uname, gname, mode,
+		    fflags ? " flags=" : "",
+		    fflags_buffer ? fflags_buffer : "") < 0) {
 			pkg_errno("%s", "Unable to write to the metalog");
 		}
 		break;
 	case PKG_METALOG_FILE:
 		if (fprintf(metalogfp,
-		    "./%s type=file uname=%s gname=%s mode=%3o\n",
-		    path, uname, gname, mode) < 0) {
+		    "./%s type=file uname=%s gname=%s mode=%3o%s%s\n",
+		    path, uname, gname, mode,
+		    fflags ? " flags=" : "",
+		    fflags_buffer ? fflags_buffer : "") < 0) {
 			pkg_errno("%s", "Unable to write to the metalog");
 		}
 		break;
 	case PKG_METALOG_LINK:
 		if (fprintf(metalogfp,
-		    "./%s type=link uname=%s gname=%s mode=%3o link=%s\n",
-		    path, uname, gname, mode, link) < 0) {
+		    "./%s type=link uname=%s gname=%s mode=%3o link=%s%s%s\n",
+		    path, uname, gname, mode, link,
+		    fflags ? " flags=" : "",
+		    fflags_buffer ? fflags_buffer : "") < 0) {
 			pkg_errno("%s", "Unable to write to the metalog");
 		}
 		break;
 	}
+
+	free(fflags_buffer);
 }
 
 void

--- a/libpkg/private/pkg.h
+++ b/libpkg/private/pkg.h
@@ -807,7 +807,7 @@ char* pkg_message_to_str(struct pkg *pkg);
 
 int metalog_open(const char *metalog);
 void metalog_add(int type, const char *path, const char *uname,
-    const char *gname, int mode, const char *link);
+    const char *gname, int mode, unsigned long fflags, const char *link);
 void metalog_close();
 enum pkg_metalog_type {
 	PKG_METALOG_FILE = 0,


### PR DESCRIPTION
Add metalog entries and don't try to set file flags when the
INSTALL_AS_USER environment variable is set.

This allows me to do

INSTALL_AS_USER=yes pkg -oMETALOG=log -r newworld install FreeBSD-runtime

as a user and have it succeed. Flags are stored in the metalog, and no failures from trying to change flags as a regular user.