### PR TITLE
In pkg update test package's abi field

### DIFF
--- a/libpkg/repo/binary/update.c
+++ b/libpkg/repo/binary/update.c
@@ -374,6 +374,7 @@ pkg_repo_binary_add_from_manifest(char *buf, sqlite3 *sqlite, size_t len,
 {
 	int rc = EPKG_OK;
 	struct pkg *pkg;
+	const char *abi;
 
 	rc = pkg_new(&pkg, PKG_REMOTE);
 	if (rc != EPKG_OK)
@@ -387,10 +388,11 @@ pkg_repo_binary_add_from_manifest(char *buf, sqlite3 *sqlite, size_t len,
 
 	if (pkg->digest == NULL || !pkg_checksum_is_valid(pkg->digest, strlen(pkg->digest)))
 		pkg_checksum_calculate(pkg, NULL);
-	if (pkg->arch == NULL || !is_valid_abi(pkg->arch, true)) {
+	abi = pkg->abi != NULL ? pkg->abi : pkg->arch;
+	if (abi == NULL || !is_valid_abi(abi, true)) {
 		rc = EPKG_FATAL;
 		pkg_emit_error("repository %s contains packages with wrong ABI: %s",
-			repo->name, pkg->arch);
+			repo->name, abi);
 		goto cleanup;
 	}
 

--- a/libpkg/utils.c
+++ b/libpkg/utils.c
@@ -331,6 +331,7 @@ is_valid_abi(const char *arch, bool emit_error) {
 	myarch_legacy = pkg_object_string(pkg_config_get("ALTABI"));
 
 	if (fnmatch(arch, myarch, FNM_CASEFOLD) == FNM_NOMATCH &&
+	    fnmatch(arch, myarch_legacy, FNM_CASEFOLD) == FNM_NOMATCH &&
 	    strncasecmp(arch, myarch, strlen(myarch)) != 0 &&
 	    strncasecmp(arch, myarch_legacy, strlen(myarch_legacy)) != 0) {
 		if (emit_error)


### PR DESCRIPTION
`pkg add` tests `abi` field when installing a package, and if it is unavailable falls back to `arch`. I changed behavior of `pkg update` to be the same. See #1601 for details.