### PR TITLE
floating point exception when packaging weird elf files

### DIFF
--- a/libpkg/pkg_elf.c
+++ b/libpkg/pkg_elf.c
@@ -327,6 +327,10 @@ analyse_elf(struct pkg *pkg, const char *fpath)
 		case SHT_DYNAMIC:
 			dynamic = scn;
 			sh_link = shdr.sh_link;
+			if (shdr.sh_entsize == 0) {
+				ret = EPKG_END;
+				goto cleanup;
+			}
 			numdyn = shdr.sh_size / shdr.sh_entsize;
 			break;
 		}


### PR DESCRIPTION
This patch is from wjenkner@inode.at in FreeBSD Bugzilla PR 193995:

https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=193995
https://bugs.freebsd.org/bugzilla/attachment.cgi?id=147750