### PR TITLE
Accept DT_SONAME anywhere in .dynamic

### DIFF
--- a/libpkg/pkg_elf.c
+++ b/libpkg/pkg_elf.c
@@ -256,6 +256,7 @@ analyse_elf(struct pkg *pkg, const char *fpath)
 	size_t dynidx;
 	const char *myarch;
 	const char *shlib;
+	char *rpath = NULL;
 
 	bool is_shlib = false;
 
@@ -398,13 +399,12 @@ analyse_elf(struct pkg *pkg, const char *fpath)
 				pkg_addshlib_provided(pkg, shlib);
 		}
 
-		if (dyn->d_tag != DT_RPATH && dyn->d_tag != DT_RUNPATH)
-			continue;
-		
-		shlib_list_from_rpath(elf_strptr(e, sh_link, dyn->d_un.d_val),
-				      bsd_dirname(fpath));
-		break;
+		if ((dyn->d_tag == DT_RPATH || dyn->d_tag == DT_RUNPATH) &&
+		    rpath == NULL)
+			rpath = elf_strptr(e, sh_link, dyn->d_un.d_val);
 	}
+	if (rpath != NULL)
+		shlib_list_from_rpath(rpath, bsd_dirname(fpath));
 
 	/* Now find all of the NEEDED shared libraries. */
 


### PR DESCRIPTION
Previously analyse_elf() iterated over the .dynamic section to process
DT_SONAME, DT_RPATH, and DT_RUNPATH, and it exited the loop after
encountering either DT_RPATH or DT_RUNPATH.  This worked only if
DT_SONAME appears before DT_RPATH/DT_RUNPATH.  It appears this is always
true for GNU bfd ld, but not for LLVM's lld linker (which emitted
DT_RUNPATH, DT_NEEDED, then DT_SONAME).

Now, keep track of the DT_RPATH or DT_RUNPATH string while iterating
over .dynamic, but do not exit the loop.

This can probably be simplified further, but initially I want to keep
the same semantics and function call ordering.

FreeBSD PR:	223776