### PR TITLE
Fix progression display

### DIFF
--- a/src/event.c
+++ b/src/event.c
@@ -172,9 +172,11 @@ job_status_begin(UT_string *msg)
 	}
 
 	if ((nbtodl > 0 || nbactions > 0) && nbdone > 0)
-		utstring_printf(msg, "[%d/%d] ", nbdone, nbactions);
-	if (nbtodl > 0 && nbtodl == nbdone)
+		utstring_printf(msg, "[%d/%d] ", nbdone, (nbtodl) ? nbtodl : nbactions);
+	if (nbtodl > 0 && nbtodl == nbdone) {
+		nbtodl = 0;
 		nbdone = 0;
+	}
 }
 
 static int


### PR DESCRIPTION
When displaying progression, `bdone` contains the number of actions to
action finished, and `nbtodl` and `nbtodl` contains respectively the number
of packages to download and the number of packages to process.

Because `nbtodl` and `nbactions` can have different values, we should check
if we are downloading (progression is `nbdone/nbtodl`) or not (in which
case, the progression is `nbdone/nbactions`).

While here, fix wrapping: when all packages have been downloaded, `nbdone`
is reset to 0, but when processing packages, this condition can happen
again.  So also reset `nbtodl` to 0 to avoid this condition.