### PR TITLE
binary-repo: fix closing sqlite db

### DIFF
--- a/libpkg/repo/binary/init.c
+++ b/libpkg/repo/binary/init.c
@@ -517,7 +517,7 @@ pkg_repo_binary_close(struct pkg_repo *repo, bool commit)
 	}
 
 	pkg_repo_binary_finalize_prstatements();
-	sqlite3_free(sqlite);
+	sqlite3_close(sqlite);
 
 	repo->priv = NULL;
 


### PR DESCRIPTION
Use the correct sqlite3_close method to realy close the database and
avoid open filehandles.

The issue I needed to fix is the open file handle preventing a umount of the partition after installing. But maybe Fixes #1607 too?