### PR TITLE
segmentation fault with strcmp()

### DIFF
--- a/libpkg/pkg_elf.c
+++ b/libpkg/pkg_elf.c
@@ -130,7 +130,8 @@ add_shlibs_to_pkg(struct pkg *pkg, const char *fpath, const char *name,
 
 		while (pkg_files(pkg, &file) == EPKG_OK) {
 			filepath = file->path;
-			if (strcmp(&filepath[strlen(filepath) - strlen(name)], name) == 0) {
+			if (strlen(filepath) >= strlen(name) &&
+			    strcmp(&filepath[strlen(filepath) - strlen(name)], name) == 0) {
 				pkg_addshlib_required(pkg, name);
 				return (EPKG_OK);
 			}


### PR DESCRIPTION
```
# make packages
... ...
===> Creating FreeBSD-runtime-profile-12.0.s20180114075427
pkg -o ABI_FILE=/usr/obj/usr/src/arm.armv7/worldstage/bin/sh -o ALLOW_BASE_SHLIBS=yes  create -M /usr/obj/usr/src/arm.armv7/worldstage/runtime-profile.ucl  -p /usr/obj/usr/src/arm.armv7/worldstage/runtime-profile.plist  -r /usr/obj/usr/src/arm.armv7/worldstage  -o /usr/obj/usr/src/repo/$(pkg -o ABI_FILE=/usr/obj/usr/src/arm.armv7/worldstage/bin/sh config ABI)/12.0.s20180114075427
===> Creating FreeBSD-runtime-12.0.s20180114075427
pkg -o ABI_FILE=/usr/obj/usr/src/arm.armv7/worldstage/bin/sh -o ALLOW_BASE_SHLIBS=yes  create -M /usr/obj/usr/src/arm.armv7/worldstage/runtime.ucl  -p /usr/obj/usr/src/arm.armv7/worldstage/runtime.plist  -r /usr/obj/usr/src/arm.armv7/worldstage  -o /usr/obj/usr/src/repo/$(pkg -o ABI_FILE=/usr/obj/usr/src/arm.armv7/worldstage/bin/sh config ABI)/12.0.s20180114075427
Child process pid=21315 terminated abnormally: Segmentation fault
*** Error code 139

Stop.
make[5]: stopped in /usr/src
*** Error code 1
```

```
# /usr/local/bin/gdb /usr/local/sbin/pkg /usr/obj/usr/src/arm.armv7/pkg.core
GNU gdb (GDB) 8.0.1 [GDB v8.0.1 for FreeBSD]
Copyright (C) 2017 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.  Type "show copying"
and "show warranty" for details.
This GDB was configured as "armv7-portbld-freebsd12.0".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<http://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
<http://www.gnu.org/software/gdb/documentation/>.
For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from /usr/local/sbin/pkg...done.
[New LWP 100674]
Core was generated by `pkg -o ABI_FILE=/usr/obj/usr/src/arm.armv7/worldstage/bin/sh -o ALLOW_BASE_SHLIB'.
Program terminated with signal SIGSEGV, Segmentation fault.
#0  strcmp () at /usr/src/lib/libc/arm/string/strcmp.S:37
37              ldrb    r2, [r0], #1
(gdb) bt
#0  strcmp () at /usr/src/lib/libc/arm/string/strcmp.S:37
#1  0x201a5b9c in add_shlibs_to_pkg (pkg=0x20ae7000,
    fpath=0xbfbfd680 "/usr/obj/usr/src/arm.armv7/worldstage//usr/sbin/tcpdump",
    name=0x20afc3e6 "libcap_dns.so.0", is_shlib=false) at pkg_elf.c:133
#2  0x201a40f4 in analyse_elf (pkg=0x20ae7000,
    fpath=0xbfbfd680 "/usr/obj/usr/src/arm.armv7/worldstage//usr/sbin/tcpdump")
    at pkg_elf.c:420
#3  0x201a365c in pkg_analyse_files (db=0x0, pkg=0x20ae7000,
    stage=0xbfbfe980 "/usr/obj/usr/src/arm.armv7/worldstage") at pkg_elf.c:495
#4  0x201356a0 in pkg_load_metadata (pkg=0x20ae7000,
    mfile=0xbfbfe914 "/usr/obj/usr/src/arm.armv7/worldstage/runtime.ucl", md_dir=0x0,
    plist=0xbfbfe949 "/usr/obj/usr/src/arm.armv7/worldstage/runtime.plist",
    rootdir=0xbfbfe980 "/usr/obj/usr/src/arm.armv7/worldstage", testing=false)
    at pkg_create.c:383
#5  0x20135238 in pkg_create_from_manifest (
    outdir=0xbfbfe9a9 "/usr/obj/usr/src/repo/FreeBSD:12:armv7/12.0.s20180114075427",
    format=TXZ, rootdir=0xbfbfe980 "/usr/obj/usr/src/arm.armv7/worldstage",
    manifest=0xbfbfe914 "/usr/obj/usr/src/arm.armv7/worldstage/runtime.ucl",
    plist=0xbfbfe949 "/usr/obj/usr/src/arm.armv7/worldstage/runtime.plist")
    at pkg_create.c:238
#6  0x00015e9c in exec_create (argc=0, argv=0xbfbfe708) at create.c:317
#7  0x0001e130 in main (argc=9, argv=0xbfbfe6e4) at main.c:887
(gdb) x/16x $r0
0x20b26ffd:     Cannot access memory at address 0x20b26ffd
(gdb) x/16c $r1
0x20afc3e6:     108 'l' 105 'i' 98 'b'  99 'c'  97 'a'  112 'p' 95 '_'  100 'd'
0x20afc3ee:     110 'n' 115 's' 46 '.'  115 's' 111 'o' 46 '.'  48 '0'  0 '\000'
(gdb) x/16c $r0+3
0x20b27000:     47 '/'  98 'b'  105 'i' 110 'n' 47 '/'  103 'g' 101 'e' 116 't'
0x20b27008:     102 'f' 97 'a'  99 'c'  108 'l' 0 '\000'        0 '\000'        0 '\000'      0 '\000'
```

strlen(/bin/getfacl) + 3 = strlen(libcap_dns.so.0)

