### PR TITLE
Complain more clearly about read-only FS errors.

### DIFF
--- a/libpkg/pkgdb.c
+++ b/libpkg/pkgdb.c
@@ -827,7 +827,7 @@ pkgdb_check_access(unsigned mode, const char* dbdir, const char *dbname)
 	if (retval != 0) {
 		if (errno == ENOENT)
 			return (EPKG_ENODB);
-		else if (errno == EACCES)
+		else if (errno == EACCES || errno == EROFS)
 			return (EPKG_ENOACCESS);
 		else
 			return (EPKG_FATAL);


### PR DESCRIPTION
If `eaccess(2)` on the pkgdb fails because the filesystem is read-only,
expose this to the user via an "Insufficient privileges" message
(implied by `EPKG_ENOACCESS`) rather than failing silently with
`EPKG_FATAL`.