### PR TITLE
audit: Drop privileges after opening the files/database but before parsing.

### DIFF
--- a/libpkg/pkg_audit.c
+++ b/libpkg/pkg_audit.c
@@ -884,6 +884,9 @@ pkg_audit_load(struct pkg_audit *audit, const char *fname)
 int
 pkg_audit_process(struct pkg_audit *audit)
 {
+	if (geteuid() == 0)
+		return (EPKG_FATAL);
+
 	if (!audit->loaded)
 		return (EPKG_FATAL);
 

--- a/src/audit.c
+++ b/src/audit.c
@@ -166,7 +166,6 @@ exec_audit(int argc, char **argv)
 		}
 	}
 
-	drop_privileges();
 	if (pkg_audit_load(audit, audit_file) != EPKG_OK) {
 		if (errno == ENOENT)
 			warnx("vulnxml file %s does not exist. "
@@ -262,6 +261,8 @@ exec_audit(int argc, char **argv)
 			return (ret);
 		}
 	}
+
+	drop_privileges();
 
 	/* Now we have vulnxml loaded and check list formed */
 #ifdef HAVE_CAPSICUM

--- a/src/upgrade.c
+++ b/src/upgrade.c
@@ -124,7 +124,6 @@ check_vulnerable(struct pkg_audit *audit, struct pkgdb *db, int sock)
 		return;
 	}
 
-	drop_privileges();
 
 	if (pkg_audit_load(audit, NULL) != EPKG_OK) {
 		warn("unable to open vulnxml file");
@@ -132,6 +131,8 @@ check_vulnerable(struct pkg_audit *audit, struct pkgdb *db, int sock)
 		pkg_audit_free(audit);
 		return;
 	}
+
+	drop_privileges();
 
 #ifdef HAVE_CAPSICUM
 	if (cap_enter() < 0 && errno != ENOSYS) {


### PR DESCRIPTION
Also assert (return EPKG_FATAL) in pkg_audit_process() if running as
root.

This allows setting /var/db/pkg mode 0750.