### PR TITLE
src/info.c: Make -R behaviour match man page.

### DIFF
--- a/src/info.c
+++ b/src/info.c
@@ -258,6 +258,11 @@ exec_info(int argc, char **argv)
 	if (match == MATCH_ALL && opt == INFO_TAG_NAMEVER)
 		quiet = false;
 
+	if (opt & INFO_RAW) {
+		if ((opt & (INFO_RAW_JSON|INFO_RAW_JSON_COMPACT|INFO_RAW_UCL)) == 0)
+			opt |= INFO_RAW_YAML;
+	}
+
 	if (file != NULL) {
 		if ((fd = open(file, O_RDONLY)) == -1) {
 			warn("Unable to open %s", file);
@@ -282,10 +287,6 @@ exec_info(int argc, char **argv)
 		if (opt == INFO_TAG_NAMEVER)
 			opt |= INFO_FULL;
 		pkg_manifest_keys_new(&keys);
-		if (opt & INFO_RAW) {
-			if ((opt & (INFO_RAW_JSON|INFO_RAW_JSON_COMPACT|INFO_RAW_UCL)) == 0)
-				opt |= INFO_RAW_YAML;
-		}
 
 		if ((opt & (INFO_RAW | INFO_FILES |
 				INFO_DIRS)) == 0)


### PR DESCRIPTION
This commit fixes `pkg info -R <pkg>` so that YAML is the default raw output
format in all cases when `--raw-format` isn't supplied, not only when
`-F` is being used.

This is based on my understanding of the man page when reading:

```
     -R, --raw
             Display the full manifest (raw) for the packages matching pkg-name.

     --raw-format format
             Choose the format of the raw output.  The format can be: json,
             json-compact, yaml (default).
```

Which I parsed as "YAML will be the `-R` output unless something else is specified".