### PR TITLE
Gracefully handle conflicts

### DIFF
--- a/libpkg/pkg_jobs_conflicts.c
+++ b/libpkg/pkg_jobs_conflicts.c
@@ -477,7 +477,8 @@ pkg_conflicts_check_chain_conflict(struct pkg_job_universe_item *it,
 			it->pkg->uid);
 
 		if (p != NULL) {
-			pkg_jobs_universe_process_item(j->universe, p, &cun);
+			if (pkg_jobs_universe_process_item(j->universe, p, &cun))
+				continue;
 			assert(cun != NULL);
 			pkg_conflicts_register_chain(j, it, cun, fcur->path);
 		}

--- a/libpkg/pkg_jobs_universe.c
+++ b/libpkg/pkg_jobs_universe.c
@@ -570,6 +570,9 @@ pkg_jobs_universe_process_item(struct pkg_jobs_universe *universe, struct pkg *p
 	 * flag that means that we have already tried to check our universe
 	 */
 	rc = pkg_jobs_universe_add_pkg(universe, pkg, false, &found);
+	if (rc == EPKG_CONFLICT)
+		return (rc);
+
 	if (result)
 		*result = found;
 


### PR DESCRIPTION
I'm sure this is not the best way to handle this, but it at least substitutes a crash with an informative error message. I have a hunch that it should be possible to figure out the conflict earlier (at `Checking integrity... done (0 conflicting)`), but that'll require more pkg-foo than I have.

Before:
```
Checking integrity...Child process pid=40754 terminated abnormally:
Segmentation fault
```

After:
```
Checking integrity... done (0 conflicting)
The following 1 package(s) will be affected (of 0 checked):

New packages to be INSTALLED:
        vim-console: 8.0.1655 [FreeBSD]

Number of packages to be installed: 1

The process will require 23 MiB more space.

Proceed with this action? [y/N]: y
[dev.ptrcrt.ch] [1/1] Installing vim-console-8.0.1655...
pkg-static: vim-console-8.0.1655 conflicts with vim-8.0.1655 (installs files into the same place).  Problematic file: /usr/local/bin/evim
```

Issue #1663