### PR TITLE
Add a missing newline after usage information

### DIFF
--- a/src/annotate.c
+++ b/src/annotate.c
@@ -61,7 +61,7 @@ usage_annotate(void)
 	fprintf(stderr,
             "       pkg annotate [-qy] -a [-A|M] <tag> [<value>]\n");
 	fprintf(stderr,
-            "       pkg annotate [-qy] -a [-S|D] <tag>\n");
+            "       pkg annotate [-qy] -a [-S|D] <tag>\n\n");
 	fprintf(stderr,
             "For more information see 'pkg help annotate'.\n");
 }


### PR DESCRIPTION
All the other commands tend to follow the convention of printing 
an empty line before "For more information see 'pkg help annotate'.