### PR TITLE
libpkg: Fix NULL check in pkg_is_config_file

### DIFF
--- a/libpkg/pkg.c
+++ b/libpkg/pkg.c
@@ -1691,7 +1691,7 @@ pkg_is_config_file(struct pkg *p, const char *path,
 		return (false);
 
 	kh_find(pkg_config_files, p->config_files, path, *cfile);
-	if (cfile == NULL) {
+	if (*cfile == NULL) {
 		*file = NULL;
 		return (false);
 	}


### PR DESCRIPTION
cfile == NULL was checked when indeed it should have been *cfile == NULL.  This
manifested itself as a segfault over in pkg_add.c:attempt_to_merge when
pkg_is_config_file falsely returned 'true'.

Reported by: latest pkgbase upgrade of FreeBSD-runtime package

(If this could hit pkg-devel soon-ish so I can update my machines naturally, I'd be most appreciative =D)