### PR TITLE
Export dynamic symbols for plugins.

### DIFF
--- a/src/Makefile.autosetup
+++ b/src/Makefile.autosetup
@@ -67,7 +67,11 @@ OTHER_LIBS+=	-lresolv
 @if libabidir == libmachista
 LOCAL_LDFLAGS=	$(LIBS) $(OTHER_LIBS)
 @else
-LOCAL_LDFLAGS=	-Wl,-Bstatic $(LIBS) -Wl,-Bdynamic $(OTHER_LIBS)
+LOCAL_LDFLAGS=	-Wl,-Bstatic \
+		-Wl,--whole-archive $(LIBS) -Wl,--no-whole-archive \
+		-Wl,-Bdynamic $(OTHER_LIBS) \
+		-Wl,--export-dynamic \
+		-Wl,--version-script=$(top_builddir)/libpkg/libpkg.ver
 @endif
 
 STATIC_LDFLAGS=	$(LIBS) $(OTHER_LIBS)


### PR DESCRIPTION
Export the same symbols as libpkg.so, so the semi-static pkg can
still load plugins that depend on former libpkg symbols.