### PR TITLE
Link pkg-static against libpthread to fix repository creation after the OpenSSL 1.1.1 update.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -69,6 +69,7 @@ pkg_static_LDADD= @OS_LDFLAGS@ \
 			-lbz2 \
 			-llzma \
 			-lssl \
+			-lpthread \
 			-lcrypto \
 			-lm
 


### PR DESCRIPTION
Sponsored by:	The FreeBSD Foundation