### PR TITLE
Fix a typo

### DIFF
--- a/docs/pkg.conf.5
+++ b/docs/pkg.conf.5
@@ -121,7 +121,7 @@ Makes certain errors immediately fatal.
 Adds various warnings and
 suggestions to the output of
 .Xr pkg 1
-as an aide to port maintainers, including indicating when the port
+as an aid to port maintainers, including indicating when the port
 might be marked as architecture independent.
 Default: NO.
 .It Cm EVENT_PIPE: string


### PR DESCRIPTION
"Aide" should be "aid".