### PR TITLE
Always use anticongestion function in 410.pkg-audit

### DIFF
--- a/scripts/periodic/410.pkg-audit.in
+++ b/scripts/periodic/410.pkg-audit.in
@@ -69,13 +69,7 @@ audit_pkgs() {
 		$(( 86400 \* "${security_status_pkgaudit_expiry}" )) \
 		-le $(( ${now} - ${then} + 600 )) ]; then
 		# When non-interactive, sleep to reduce congestion on mirrors
-		if [ -n "$anticongestion_sleeptime" ]; then
-			# In FreeBSD 12.0 the anticongestion function should be
-			# used instead of a hard-coded sleep
-			anticongestion
-		else
-			sleep `jot -r 1 0 3600`
-		fi
+		anticongestion
 		${pkgcmd} ${pkgargs} audit -F $q || { rc=$?; [ $rc -lt 3 ] && rc=3; }
 	else
 		echo -n 'Database fetched: '


### PR DESCRIPTION
Since all supported FreeBSD versions have anticongestion function in `/etc/default/periodic.conf`, always use it to insert random sleep with non-interactive mode.