### PR TITLE
Remove hacks for old pkg_* tools from periodic scripts.

### DIFF
--- a/scripts/periodic/400.status-pkg.in
+++ b/scripts/periodic/400.status-pkg.in
@@ -78,18 +78,6 @@ status_pkg_all() {
     return $rc
 }
 
-# On 9.x or lower, 400.status-pkg exists in the base system, but using
-# the old pkg_tools commands.  Unfortunately it uses the same
-# configuration variables, so allow the setting of
-# $weekly_status_pkgng_enable to turn on this script without enabling
-# the pkg_tools equivalent
-
-case "$weekly_status_pkgng_enable" in
-        [Yy][Ee][Ss])
-	: ${weekly_status_pkg_enable="$weekly_status_pkgng_enable"}
-	;;
-esac
-
 case "$weekly_status_pkg_enable" in
 	[Yy][Ee][Ss])
 

--- a/scripts/periodic/411.pkg-backup.in
+++ b/scripts/periodic/411.pkg-backup.in
@@ -111,16 +111,6 @@ backup_pkg_all() {
 	return $rc
 }
 
-# $daily_backup_pkgng_{enable,dir} are deprecated -- use
-# daily_backup_pkg_{enable,dir} instead.
-
-case "$daily_backup_pkgng_enable" in
-[Yy][Ee][Ss])
-	: ${daily_backup_pkg_enable:="$daily_backup_pkgng_enable"}
-	: ${daily_backup_pkg_dir:="$daily_backup_pkgng_dir"}
-	;;
-esac
-
 case "${daily_backup_pkg_enable:-YES}" in
 [Nn][Oo])
 	;;

--- a/scripts/periodic/490.status-pkg-changes.in
+++ b/scripts/periodic/490.status-pkg-changes.in
@@ -83,21 +83,6 @@ list_pkgs_all() {
     return $rc
 }
 
-# On 9.x or lower, 490.status-pkg-changes exists in the base system,
-# but using the old pkg_tools commands.  Unfortunately it uses the
-# same configuration variables, so allow the setting of 
-# $daily_status_pkgng_changes_enable to turn on this script without
-# enabling the pkg_tools equivalent
-#
-# $daily_status_pkgng_changes_enable is deprecated: use
-# $daily_status_pkg_changes_enable instead.
-
-case "$daily_status_pkgng_changes_enable" in
-        [Yy][Ee][Ss])
-	: ${daily_status_pkg_changes_enable="$daily_status_pkgng_changes_enable"}
-	;;
-esac
-
 case "$daily_status_pkg_changes_enable" in
 	[Yy][Ee][Ss])
 	pkgcmd=@prefix@/sbin/pkg


### PR DESCRIPTION
Since no supported FreeBSD version has old pkg_* tools in base system anymore, remove hacks for them from periodic scripts.