### PR TITLE
Add the standard description of the -x / --regex option to pkg-upgrade(8)

### DIFF
--- a/docs/pkg-upgrade.8
+++ b/docs/pkg-upgrade.8
@@ -14,7 +14,7 @@
 .\"
 .\"     @(#)pkg.8
 .\"
-.Dd April 17, 2015
+.Dd May 14, 2019
 .Dt PKG-UPGRADE 8
 .Os
 .Sh NAME
@@ -173,6 +173,10 @@ from remote.
 Automatic repository catalogue updates are only attempted when the
 effective UID of the process has write access to the package database.
 Otherwise they are silently ignored.
+.It Fl x , Cm --regex
+Treat the package names as regular expressions according to the
+"modern" or "extended" syntax of
+.Xr re_format 7 .
 .It Fl y , Cm --yes
 Assume yes when asked for confirmation before package installation.
 .El


### PR DESCRIPTION


This omission was noticed by tech-lists <tech-lists@zyxst.net> on the freebsd-pkg@ mailing list.