### PR TITLE
Kernel Update Sanity Check

### DIFF
--- a/docs/pkg-upgrade.8
+++ b/docs/pkg-upgrade.8
@@ -22,13 +22,14 @@
 .Nd perform upgrades of package software distributions
 .Sh SYNOPSIS
 .Nm
-.Op Fl fInFqUy
+.Op Fl bfInFqUy
 .Op Fl r Ar reponame
 .Op Fl Cgix
 .Op Ar <pkg-origin|pkg-name|pkg-name-version> ...
 .Pp
 .Nm
-.Op Cm --{force,no-install-scripts,dry-run,fetch-only}
+.Op Cm --{bypass-kernel,force}
+.Op Cm --{no-install-scripts,dry-run,fetch-only}
 .Op Cm --{quiet,no-repo-update,yes}
 .Op Cm --repository Ar reponame
 .Op Cm --{case-sensitive,glob,case-insensitive,regex}
@@ -124,6 +125,12 @@ work list.
 The following options are supported by
 .Nm :
 .Bl -tag -width repository
+.It Fl b , Cm --bypass-kernel
+Skip the safety checks that force updating kernel first. Enforced by default
+unless
+.Ev BYBASS_KERNEL
+is set to true in
+.Pa pkg.conf .
 .It Fl C , Cm --case-sensitive
 Make the standard or the regular expression
 .Fl ( x )

--- a/docs/pkg.conf.5
+++ b/docs/pkg.conf.5
@@ -94,6 +94,11 @@ the
 .Fl y
 flag was specified.
 Default: NO.
+.It Cm BYPASS_KERNEL: boolean
+When this option is enabled
+.Xr pkg-upgrade 8
+will skip safety check that forces kernel updates be performed first
+Default: NO.
 .It Cm CONSERVATIVE_UPGRADE: boolean
 Ensure in multi repository mode that the priority is given as much as possible
 to the repository where a package was first installed from.

--- a/libpkg/libpkg.ver
+++ b/libpkg/libpkg.ver
@@ -65,6 +65,7 @@ global:
 	pkg_jobs_destdir;
 	pkg_jobs_free;
 	pkg_jobs_has_lockedpkgs;
+	pkg_jobs_has_kernel_update;
 	pkg_jobs_iter;
 	pkg_jobs_iter_lockedpkgs;
 	pkg_jobs_new;

--- a/libpkg/pkg.h.in
+++ b/libpkg/pkg.h.in
@@ -1075,6 +1075,11 @@ int pkg_jobs_cudf_parse_output(struct pkg_jobs *j, FILE *f);
 bool pkg_jobs_has_lockedpkgs(struct pkg_jobs *j);
 
 /**
+ * Returns if the pending job has kernel updates
+ */
+bool pkg_jobs_has_kernel_update(struct pkg_jobs *jobs);
+
+/**
  * Iterate through the locked packages, calling the passed in function pointer
  * on each.
  */

--- a/libpkg/pkg_config.c
+++ b/libpkg/pkg_config.c
@@ -228,6 +228,12 @@ static struct config_entry c[] = {
 		"Automatically update repository catalogues prior to package updates",
 	},
 	{
+		PKG_BOOL,
+		"BYPASS_KERNEL",
+		"NO",
+		"Skip the safety checks which normally force kernel updates first",
+	},
+	{
 		PKG_STRING,
 		"NAMESERVER",
 		NULL,

--- a/libpkg/pkg_jobs.c
+++ b/libpkg/pkg_jobs.c
@@ -95,6 +95,7 @@ pkg_jobs_new(struct pkg_jobs **j, pkg_jobs_t t, struct pkgdb *db)
 	(*j)->db = db;
 	(*j)->type = t;
 	(*j)->solved = 0;
+	(*j)->kernel_update = false;
 	(*j)->pinning = true;
 	(*j)->flags = PKG_FLAG_NONE;
 	(*j)->conservative = pkg_object_bool(pkg_config_get("CONSERVATIVE_UPGRADE"));
@@ -1589,6 +1590,10 @@ jobs_solve_install_upgrade(struct pkg_jobs *j)
 					/* Do not test we ignore what doesn't exists remotely */
 					pkg_jobs_find_upgrade(j, pkg->uid, MATCH_EXACT);
 				}
+				if (strcmp(pkg->origin, "os/kernel") == 0) {
+					/* Kernel needs updating */
+					j->kernel_update = true;
+				}
 				pkg_free(pkg);
 				pkgdb_it_free(it);
 			}
@@ -2326,4 +2331,10 @@ pkg_jobs_iter_lockedpkgs(struct pkg_jobs *j, locked_pkgs_cb cb, void * ctx)
 	pkgs_job_lockedpkg = &foo;
 
 	twalk(j->lockedpkgs, pkg_jobs_visit_lockedpkgs);
+}
+
+bool
+pkg_jobs_has_kernel_update(struct pkg_jobs *j)
+{
+	return j->kernel_update;
 }

--- a/libpkg/pkg_jobs.c
+++ b/libpkg/pkg_jobs.c
@@ -1590,9 +1590,11 @@ jobs_solve_install_upgrade(struct pkg_jobs *j)
 					/* Do not test we ignore what doesn't exists remotely */
 					pkg_jobs_find_upgrade(j, pkg->uid, MATCH_EXACT);
 				}
-				if (strcmp(pkg->origin, "os/kernel") == 0) {
-					/* Kernel needs updating */
-					j->kernel_update = true;
+				if ((j->flags & PKG_FLAG_FORCE) != PKG_FLAG_FORCE) {
+					if (strcmp(pkg->origin, "os/kernel") == 0) {
+						/* Kernel needs updating */
+						j->kernel_update = true;
+					}
 				}
 				pkg_free(pkg);
 				pkgdb_it_free(it);

--- a/libpkg/private/pkg_jobs.h
+++ b/libpkg/private/pkg_jobs.h
@@ -112,6 +112,7 @@ struct pkg_jobs {
 	int total;
 	int conflicts_registered;
 	bool need_fetch;
+	bool kernel_update;
 	const char *reponame;
 	const char *destdir;
 	TREE_HEAD(, pkg_jobs_conflict_item) *conflict_items;

--- a/scripts/completion/_pkg.in
+++ b/scripts/completion/_pkg.in
@@ -113,6 +113,7 @@ _pkg_config_opts() {
 		'AUTOMERGE[automatically merge configuration files]:boolean:(yes no)' \
 		'DEFAULT_ALWAYS_YES[default to "yes" for all questions requiring user confirmation]:boolean:(yes no)' \
 		'ASSUME_ALWAYS_YES[assume "yes" to all questions requiring user confirmation]:boolean:(yes no)' \
+		'BYPASS_KERNEL[skup safety checks that require kernel updates first]:boolean:(yes no)' \
 		'CONSERVATIVE_UPGRADE[give priority to repo where a package was first installed from]:boolean:(yes no)' \
 		'CUDF_SOLVER[experimental\: use an external CUDF solver]:CUDF solver:_files' \
 		'CASE_SENSITIVE_MATCH[case-sensitive package matching]:boolean:(yes no)' \

--- a/src/globals.c
+++ b/src/globals.c
@@ -27,6 +27,7 @@ int default_yes; /* Default always yes */
 int yes; /* Assume always yes */
 int dry_run; /* Do not perform any actions */
 bool auto_update; /* Do not update repo */
+bool bypass_kernel; /* Do not force updating kernel first */
 int case_sensitive; /* Case sensitive queries */
 int force; /* Forced operation */
 int quiet; /* Silent output */
@@ -39,6 +40,7 @@ set_globals(void)
 	yes = pkg_object_bool(pkg_config_get("ASSUME_ALWAYS_YES"));
 	dry_run = 0;
 	auto_update = pkg_object_bool(pkg_config_get("REPO_AUTOUPDATE"));
+	bypass_kernel = pkg_object_bool(pkg_config_get("BYPASS_KERNEL"));
 	case_sensitive = pkg_object_bool(pkg_config_get("CASE_SENSITIVE_MATCH"));
 	force = 0;
 	quiet = 0;

--- a/src/pkg.conf.sample
+++ b/src/pkg.conf.sample
@@ -35,6 +35,7 @@
 #PLUGINS_CONF_DIR = "/usr/local/etc/pkg/";
 #PERMISSIVE = false;
 #REPO_AUTOUPDATE = true;
+#BYPASS_KERNEL = false;
 #NAMESERVER = "";
 #HTTP_USER_AGENT = "Custom_User_Manager";
 #EVENT_PIPE = "";

--- a/src/pkgcli.h
+++ b/src/pkgcli.h
@@ -302,6 +302,7 @@ extern int default_yes;
 extern int yes;
 extern int dry_run;
 extern bool auto_update;
+extern bool bypass_kernel;
 extern int case_sensitive;
 extern int force;
 extern bool quiet;

--- a/src/upgrade.c
+++ b/src/upgrade.c
@@ -413,7 +413,15 @@ exec_upgrade(int argc, char **argv)
 	while ((nbactions = pkg_jobs_count(jobs)) > 0) {
 		/* print a summary before applying the jobs */
 		rc = yes;
-		if ( pkg_jobs_has_kernel_update(jobs) && !bypass_kernel ) {
+		static int jailed = 0;
+#ifdef HAVE_LIBJAIL
+		size_t intlen;
+		intlen = sizeof(jailed);
+		if (sysctlbyname("security.jail.jailed", &jailed, &intlen,
+			NULL, 0) != -1)
+			jailed = -1;
+#endif
+		if ( pkg_jobs_has_kernel_update(jobs) && !bypass_kernel && jailed == -1 ) {
 			warnx("Kernel update must be performed first or set '-b' to bypass.");
 			retcode = EXIT_FAILURE;
 			goto cleanup;

--- a/tests/frontend/pkg.sh
+++ b/tests/frontend/pkg.sh
@@ -39,6 +39,7 @@ pkg_config_defaults_body()
 	    -o match:'^ *PLUGINS_CONF_DIR = ".*/etc/pkg/";$' \
 	    -o match:'^ *PERMISSIVE = false;$' \
 	    -o match:'^ *REPO_AUTOUPDATE = true;$' \
+	    -o match:'^ *BYPASS_KERNEL = false;$' \
 	    -o match:'^ *NAMESERVER = "";$' \
 	    -o match:'^ *EVENT_PIPE = "";$' \
 	    -o match:'^ *FETCH_TIMEOUT = 30;$' \


### PR DESCRIPTION
This adds a sanity check to pkg, when there is a new kernel to install, we want to prompt the user to install that first and reboot. Includes new '-b' bypass flag and BYPASS_KERNEL conf option which can skip this safety if the user so chooses.