### PR TITLE
make 'pkg updating' to recognize regular expression package names

### DIFF
--- a/tests/Makefile.autosetup
+++ b/tests/Makefile.autosetup
@@ -43,6 +43,7 @@ TESTS_SH= \
 	frontend/version.sh \
 	frontend/vital.sh \
 	frontend/update.sh \
+	frontend/updating.sh \
 	frontend/issue1374.sh \
 	frontend/issue1425.sh \
 	frontend/issue1440.sh \

--- a/tests/frontend/Kyuafile.in
+++ b/tests/frontend/Kyuafile.in
@@ -33,6 +33,7 @@ atf_test_program{name='rubypuppet'}
 atf_test_program{name='search'}
 atf_test_program{name='set'}
 atf_test_program{name='update'}
+atf_test_program{name='updating'}
 atf_test_program{name='version'}
 atf_test_program{name='vital'}
 atf_test_program{name='issue1374'}

--- a/tests/frontend/updating.sh
+++ b/tests/frontend/updating.sh
@@ -1,0 +1,264 @@
+#! /usr/bin/env atf-sh
+
+. $(atf_get_srcdir)/test_environment.sh
+
+tests_init \
+	updating_all_users \
+        updating_pkg \
+	updating_perl \
+	updating_samba \
+        updating_ilmbase \
+        updating_mysql \
+        updating_postgresql \
+        updating_cupsbase
+
+updating_all_users_body() {
+	cat > UPDATING <<EOF
+20190624:
+  AFFECTS: all users
+  AUTHOR: ports@FreeBSD.org
+
+  Messages...
+20190625:
+  AFFECTS: all ports users
+  AUTHOR: ports@FreeBSD.org
+
+  Messages...
+EOF
+
+	atf_check \
+		-o match:"^20190624:$" \
+		-o match:"^20190625:$" \
+		pkg updating -f UPDATING
+}
+
+updating_pkg_body() {
+	cat > test.ucl << EOF
+name: "pkg"
+origin: "ports-mgmt/pkg"
+version: "1.10.5"
+arch: "*"
+maintainer: "none"
+prefix: "/usr/local"
+www: "unknown"
+comment: "need one"
+desc: "also need one"
+message: [
+	{ message: "Always print" }
+]
+EOF
+	atf_check \
+		-o match:".*Installing.*" \
+		pkg register -M test.ucl
+
+	cat > UPDATING <<EOF
+20190619:
+  AFFECTS: ports-mgmt/pkg
+  AUTHOR: ports@FreeBSD.org
+
+  Messages...
+EOF
+
+	atf_check \
+		-o match:"^20190619:$" \
+		pkg updating -f UPDATING
+}
+
+updating_perl_body() {
+	cat > test.ucl << EOF
+name: "perl5.26"
+origin: "lang/perl5.26"
+version: "5.26_3"
+arch: "*"
+maintainer: "none"
+prefix: "/usr/local"
+www: "unknown"
+comment: "need one"
+desc: "also need one"
+message: [
+	{ message: "Always print" }
+]
+EOF
+	atf_check \
+		-o match:".*Installing.*" \
+		pkg register -M test.ucl
+
+	cat > UPDATING <<EOF
+20190620:
+  AFFECTS: lang/perl5.*
+  AUTHOR: ports@FreeBSD.org
+
+  Messages...
+
+20190621:
+  AFFECTS: lang/perl5*
+  AUTHOR: ports@FreeBSD.org
+
+  Messages...
+EOF
+
+	atf_check \
+		-o match:"^20190620:$" \
+		-o match:"^20190621:$" \
+		pkg updating -f UPDATING
+}
+
+updating_samba_body() {
+	cat > test.ucl << EOF
+name: "samba47"
+origin: "net/samba47"
+version: "4.7.12"
+arch: "*"
+maintainer: "none"
+prefix: "/usr/local"
+www: "unknown"
+comment: "need one"
+desc: "also need one"
+message: [
+	{ message: "Always print" }
+]
+EOF
+	atf_check \
+		-o match:".*Installing.*" \
+		pkg register -M test.ucl
+
+	cat > UPDATING <<EOF
+20190622:
+  AFFECTS: net/samba4[678]
+  AUTHOR: ports@FreeBSD.org
+
+  Messages...
+EOF
+
+	atf_check \
+		-o match:"^20190622:$" \
+		pkg updating -f UPDATING
+}
+
+updating_ilmbase_body() {
+	cat > test.ucl << EOF
+name: "ilmbase"
+origin: "graphics/ilmbase"
+version: "2.3.0_2"
+arch: "*"
+maintainer: "none"
+prefix: "/usr/local"
+www: "unknown"
+comment: "need one"
+desc: "also need one"
+message: [
+	{ message: "Always print" }
+]
+EOF
+	atf_check \
+		-o match:".*Installing.*" \
+		pkg register -M test.ucl
+
+	cat > UPDATING <<EOF
+20190623:
+  AFFECTS: users of graphics/ilmbase, graphics/OpenEXR
+  AUTHOR: ports@FreeBSD.org
+
+  Messages...
+EOF
+
+	atf_check \
+		-o match:"^20190623:$" \
+		pkg updating -f UPDATING
+}
+
+updating_mysql_body() {
+	cat > test.ucl << EOF
+name: "mysql55-server"
+origin: "databases/mysql55-server"
+version: "5.5.62_1"
+arch: "*"
+maintainer: "none"
+prefix: "/usr/local"
+www: "unknown"
+comment: "need one"
+desc: "also need one"
+message: [
+	{ message: "Always print" }
+]
+EOF
+	atf_check \
+		-o match:".*Installing.*" \
+		pkg register -M test.ucl
+
+	cat > UPDATING <<EOF
+20190626:
+  AFFECTS: users of databases/mysql55-(server|client)
+  AUTHOR: ports@FreeBSD.org
+
+  Messages...
+EOF
+
+	atf_check \
+		-o match:"^20190626:$" \
+		pkg updating -f UPDATING
+}
+
+updating_postgresql_body() {
+	cat > test.ucl << EOF
+name: "postgresql95-server"
+origin: "databases/postgresql95-server"
+version: "9.5.17"
+arch: "*"
+maintainer: "none"
+prefix: "/usr/local"
+www: "unknown"
+comment: "need one"
+desc: "also need one"
+message: [
+	{ message: "Always print" }
+]
+EOF
+	atf_check \
+		-o match:".*Installing.*" \
+		pkg register -M test.ucl
+
+	cat > UPDATING <<EOF
+20190627:
+  AFFECTS: users of databases/postgresql??-(server|client)
+  AUTHOR: ports@FreeBSD.org
+
+  Messages...
+EOF
+
+	atf_check \
+		-o match:"^20190627:$" \
+		pkg updating -f UPDATING
+}
+
+updating_cupsbase_body() {
+	cat > test.ucl << EOF
+name: "cups-base"
+origin: "print/cups-base"
+version: "2.2.1"
+arch: "*"
+maintainer: "none"
+prefix: "/usr/local"
+www: "unknown"
+comment: "need one"
+desc: "also need one"
+message: [
+	{ message: "Always print" }
+]
+EOF
+	atf_check \
+		-o match:".*Installing.*" \
+		pkg register -M test.ucl
+
+	cat > UPDATING <<EOF
+20190628:
+  AFFECTS: users of print/cups-{base,client,image}
+  AUTHOR: ports@FreeBSD.org
+
+  Messages...
+EOF
+
+	atf_check \
+		-o match:"^20190628:$" \
+		pkg updating -f UPDATING
+}

--- a/tests/frontend/updating.sh
+++ b/tests/frontend/updating.sh
@@ -10,7 +10,8 @@ tests_init \
         updating_ilmbase \
         updating_mysql \
         updating_postgresql \
-        updating_cupsbase
+        updating_cupsbase \
+        updating_cups \
 
 updating_all_users_body() {
 	cat > UPDATING <<EOF
@@ -260,5 +261,38 @@ EOF
 
 	atf_check \
 		-o match:"^20190628:$" \
+		pkg updating -f UPDATING
+}
+
+updating_cups_body() {
+	cat > test.ucl << EOF
+name: "cups"
+origin: "print/cups"
+version: "2.2.1"
+arch: "*"
+maintainer: "none"
+prefix: "/usr/local"
+www: "unknown"
+comment: "need one"
+desc: "also need one"
+message: [
+	{ message: "Always print" }
+]
+EOF
+	atf_check \
+		-o match:".*Installing.*" \
+		pkg register -M test.ucl
+
+	cat > UPDATING <<EOF
+20190628:
+  AFFECTS: users of print/cups-{base,client,image}
+  AUTHOR: ports@FreeBSD.org
+
+  Messages...
+EOF
+
+	atf_check \
+		-o empty \
+		-e empty \
 		pkg updating -f UPDATING
 }


### PR DESCRIPTION
I added `matcher` function for matching regular expression package names in `AFFECTS:` line.
This function split `AFFECTS:` line into words and each words are checked if it contains regular expression characters or not.
If a word contains regular expression characters, it will be compiled and checked matches to ports origin name.

Compiling a regular expression is relatively slow operation, so I made a cache for compiled objects.

And I added special case of 'AFFECTS: all users' and 'AFFECTS: all ports users'.
The message in these cases should be shown.

This pull request solves [#227193](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=227193) on FreeBSD Bugzilla.