### PR TITLE
auto.def: fix libelf detection on debian

### DIFF
--- a/auto.def
+++ b/auto.def
@@ -217,6 +217,7 @@ if {[string match *-darwin* [get-define host]]} {
 				define-feature libelf
 				define-append EXTRA_LIBS -lelf
 				define libabidir ""
+				cc-check-types Elf_Note
 			} else {
 				define-feature libelf 0
 				define libabidir "libelf"

--- a/libpkg/pkg_elf.c
+++ b/libpkg/pkg_elf.c
@@ -246,6 +246,10 @@ is_old_freebsd_armheader(const GElf_Ehdr *e)
 }
 #endif
 
+#ifndef HAVE_ELF_NOTE
+typedef Elf32_Nhdr Elf_Note;
+#endif
+
 static int
 analyse_elf(struct pkg *pkg, const char *fpath)
 {


### PR DESCRIPTION
Fix a compile error when having the libelf-dev package installed on
debian. This libelf if incompatible to the libelf from elftoolchain as
it has no Elf_Note struct defined.

 pkg_elf.c: In function 'analyse_elf':
 pkg_elf.c:332:5: error: unknown type name 'Elf_Note'; did you mean 'GElf_Move'?
      Elf_Note *en = (Elf_Note *)data->d_buf;
      ^~~~~~~~

Fix it by checking if Elf_Note is available.