### PR TITLE
Makefile: do not strip during install

### DIFF
--- a/libpkg/Makefile.autosetup
+++ b/libpkg/Makefile.autosetup
@@ -163,8 +163,8 @@ install: all pkg.h lib$(LIB)$(LIBSOEXT) lib$(LIB).a
 	install -d -m 755 $(DESTDIR)$(libdir)
 	install -d -m 755 $(DESTDIR)$(includedir)
 	install -d -m 755 $(DESTDIR)$(pkgconfigdir)
-	install -s -m 644 lib$(LIB)$(LIBSOEXT) $(DESTDIR)$(libdir)/
+	install -m 644 lib$(LIB)$(LIBSOEXT) $(DESTDIR)$(libdir)/
 	ln -sf lib$(LIB)$(LIBSOEXT) $(DESTDIR)$(libdir)/lib$(LIB)$(SH_SOEXT)
-	install -s -m 644 lib$(LIB).a $(DESTDIR)$(libdir)/
+	install -m 644 lib$(LIB).a $(DESTDIR)$(libdir)/
 	install -m 644 pkg.h $(DESTDIR)$(includedir)/
 	install -m 644 pkg.pc $(DESTDIR)$(pkgconfigdir)

--- a/src/Makefile.autosetup
+++ b/src/Makefile.autosetup
@@ -92,7 +92,7 @@ pkg-static: $(OBJS) $(top_builddir)/libpkg/libpkg_flat.a
 
 install-static: pkg-static
 	install -d -m 755 $(DESTDIR)$(sbindir)
-	install -s -m 755 pkg-static $(DESTDIR)$(sbindir)/pkg-static
+	install -m 755 pkg-static $(DESTDIR)$(sbindir)/pkg-static
 @endif
 
 ${OBJS}: $(top_builddir)/pkg_config.h
@@ -101,7 +101,7 @@ $(PROG): $(top_builddir)/libpkg/libpkg_flat.a
 
 install: $(PROG)
 	install -d -m 755 $(DESTDIR)$(sbindir)
-	install -s -m 755 pkg $(DESTDIR)$(sbindir)/pkg
+	install -m 755 pkg $(DESTDIR)$(sbindir)/pkg
 	install -m 644 pkg.conf.sample $(DESTDIR)$(etcdir)
 
 clean: clean-pkg-static


### PR DESCRIPTION
install -s requires the use of correct strip binary when cross
compiling. Since there is no portable way to provide the strip
tool on linux and freebsd remove the strip option and keep debug symbols
if compiled with '-g'.