### PR TITLE
pkg_config: fix pkg_shutdown

### DIFF
--- a/libpkg/pkg_config.c
+++ b/libpkg/pkg_config.c
@@ -1336,12 +1336,18 @@ pkg_shutdown(void)
 	ucl_object_unref(config);
 	HASH_FREE(repos, pkg_repo_free);
 
-	if (ctx.rootfd != -1)
+	if (ctx.rootfd != -1) {
 		close(ctx.rootfd);
-	if (ctx.cachedirfd != -1)
-		close(ctx.rootfd);
-	if (ctx.pkg_dbdirfd != -1)
+		ctx.rootfd = -1;
+	}
+	if (ctx.cachedirfd != -1) {
+		close(ctx.cachedirfd);
+		ctx.cachedirfd = -1;
+	}
+	if (ctx.pkg_dbdirfd != -1) {
 		close(ctx.pkg_dbdirfd);
+		ctx.pkg_dbdirfd = -1;
+	}
 
 	parsed = false;
 


### PR DESCRIPTION
Close the tested fd and reset the fd variable to -1. Without this a
calling pkg_get_*fd after pkg_close returns a closed fd causing other
operations fail with EBADFD.