### PR TITLE
When extracting files and they already exists on the local filesystem

### DIFF
--- a/libpkg/private/pkg.h
+++ b/libpkg/private/pkg.h
@@ -377,6 +377,7 @@ typedef enum {
 	MERGE_NOTNEEDED = 0,
 	MERGE_FAILED,
 	MERGE_SUCCESS,
+	MERGE_NOT_LOCAL,
 } merge_status;
 
 struct pkg_config_file {

--- a/tests/frontend/configmerge.sh
+++ b/tests/frontend/configmerge.sh
@@ -151,7 +151,7 @@ config_fileexist_notinpkg_body()
 	atf_check \
 		pkg -o REPOS_DIR=${TMPDIR} -r ${TMPDIR}/target install -qy test
 
-	test -f ${TMPDIR}/target/${TMPDIR}/a.pkgnew || atf_fail "file overwritten when it should not have"
+	test -f ${TMPDIR}/target/${TMPDIR}/a.pkgsave || atf_fail "file overwritten when it should not have"
 }
 
 config_morecomplicated_body()

--- a/tests/frontend/conflicts.sh
+++ b/tests/frontend/conflicts.sh
@@ -4,6 +4,7 @@
 
 tests_init \
 	complex_conflicts \
+	fileexists_notinpkg \
 	find_conflicts
 
 # install foo
@@ -168,6 +169,27 @@ Number of packages to be upgraded: 1
 		-e empty \
 		-s exit:0 \
 		pkg info
+}
+
+fileexists_notinpkg_body()
+{
+	mkdir -p ${TMPDIR}/target/${TMPDIR}
+	echo "entry" > ${TMPDIR}/target/${TMPDIR}/a
+	unset PKG_DBDIR
+
+	atf_check -s exit:0 sh ${RESOURCEDIR}/test_subr.sh new_pkg "test" "test" "2"
+	echo "entry 2" > a
+	echo "${TMPDIR}/a" > plist
+
+	atf_check \
+		pkg create -M test.ucl -p plist
+
+	pkg repo .
+	echo "local: { url: file://${TMPDIR} }" > local.conf
+	atf_check \
+		pkg -o REPOS_DIR=${TMPDIR} -r ${TMPDIR}/target install -qy test
+
+	test -f ${TMPDIR}/target/${TMPDIR}/a.pkgsave || atf_fail "file not saved when it should not have"
 }
 
 find_conflicts_body() {


### PR DESCRIPTION
but aren't part of any local package, save the current file as .pkgsave

Fixes: 1781

Signed-off-by: Emmanuel Vadot <manu@freebsd.org>