### PR TITLE
Fix `-y` documentation for `pkg-set`

### DIFF
--- a/docs/pkg-set.8
+++ b/docs/pkg-set.8
@@ -111,7 +111,7 @@ flag, and
 .Ar 1
 to enable it.
 .It Fl y , Cm --yes
-Assume yes rather than asking for confirmation before package autoremoval.
+Assume yes rather than asking for confirmation before modifying package information.
 .El
 .Pp
 If neither the


### PR DESCRIPTION
This was probably copied form `pkg-autoremove`.