### PR TITLE
Fix pkg-clean

### DIFF
--- a/libpkg/pkg.h.in
+++ b/libpkg/pkg.h.in
@@ -1715,6 +1715,7 @@ char *pkg_absolutepath(const char *src, char *dest, size_t dest_len, bool fromro
 
 void pkg_cache_full_clean(void);
 
+const char *pkg_get_cachedir(void);
 int pkg_get_cachedirfd(void);
 int pkg_get_dbdirfd(void);
 

--- a/libpkg/pkg_config.c
+++ b/libpkg/pkg_config.c
@@ -1484,6 +1484,13 @@ pkg_set_rootdir(const char *rootdir) {
 	return (EPKG_OK);
 }
 
+const char *
+pkg_get_cachedir(void)
+{
+
+	return (ctx.cachedir);
+}
+
 int
 pkg_get_cachedirfd(void)
 {

--- a/src/clean.c
+++ b/src/clean.c
@@ -337,6 +337,7 @@ exec_clean(int argc, char **argv)
 		}
 	}
 
+	cachedir = pkg_get_cachedir();
 	cachefd = pkg_get_cachedirfd();
 	if (cachefd == -1) {
 		warn("Impossible to open %s", cachedir);


### PR DESCRIPTION
8dd464b255b16 removed the ad-hoc methods of getting the cachedir/cachedirfd in favor of a method in libpkg, but inadvertently left the cachedir itself uninitialized/garbagey. Fix it by adding an accessor for the cachedir name as well, as pkg-clean will at least need/want it for display purposes.

libpkg.ver likely needs regenerated, but there was another change as well when I regenerated it so I deferred for the time being.