### PR TITLE
libpkg: don't create .pkgnew if the file didn't exist

### DIFF
--- a/libpkg/pkg_add.c
+++ b/libpkg/pkg_add.c
@@ -733,7 +733,8 @@ pkg_extract_finalize(struct pkg *pkg)
 		if (*f->temppath == '\0')
 			continue;
 		fto = f->path;
-		if (f->config && f->config->status == MERGE_FAILED) {
+		if (f->config && f->config->status == MERGE_FAILED &&
+		    f->previous != PKG_FILE_NONE) {
 			snprintf(path, sizeof(path), "%s.pkgnew", f->path);
 			fto = path;
 		}

--- a/tests/frontend/configmerge.sh
+++ b/tests/frontend/configmerge.sh
@@ -4,6 +4,7 @@
 tests_init \
 	config \
 	config_fileexist \
+	config_filenotexist \
 	config_fileexist_notinpkg \
 	config_hardlink \
 	config_morecomplicated
@@ -83,6 +84,44 @@ config_fileexist_body()
 		pkg -o REPOS_DIR=${TMPDIR}/reposconf -r ${TMPDIR}/target upgrade -qy test
 
 	test -f ${TMPDIR}/target/${TMPDIR}/a.pkgnew || atf_fail "file overwritten when it should not have"
+}
+
+config_filenotexist_body()
+{
+	atf_check -s exit:0 sh ${RESOURCEDIR}/test_subr.sh new_pkg "test" "test" "1"
+	echo "${TMPDIR}/a" > plist
+
+	echo "entry" > a
+
+	atf_check \
+		pkg create -M test.ucl -p plist
+
+	mkdir ${TMPDIR}/target
+	unset PKG_DBDIR
+	atf_check \
+		pkg -o REPOS_DIR=/dev/null -r ${TMPDIR}/target install -qy ${TMPDIR}/test-1.txz
+	test -f ${TMPDIR}/target/${TMPDIR}/a || atf_fail "file absent"
+	echo "addition" >> ${TMPDIR}/target/${TMPDIR}/a
+	atf_check \
+		-o inline:"entry\naddition\n" \
+		cat ${TMPDIR}/target/${TMPDIR}/a
+
+	atf_check -s exit:0 sh ${RESOURCEDIR}/test_subr.sh new_pkg "test" "test" "2"
+	echo "entry 2" > a
+	echo "@config ${TMPDIR}/a" > plist
+
+	atf_check \
+		pkg create -M test.ucl -p plist
+
+	pkg repo .
+	mkdir reposconf
+	echo "local: { url: file://${TMPDIR} }" > reposconf/local.conf
+	rm ${TMPDIR}/target/${TMPDIR}/a
+	atf_check \
+		pkg -o REPOS_DIR=${TMPDIR}/reposconf -r ${TMPDIR}/target upgrade -qy test
+
+	test ! -f ${TMPDIR}/target/${TMPDIR}/a.pkgnew || atf_fail "redundant pkgnew left hanging"
+	test -f ${TMPDIR}/target/${TMPDIR}/a || atf_fail "config file not installed"
 }
 
 config_hardlink_body()


### PR DESCRIPTION
In this case, we can just install the file into the correct location and there's no need to create a .pkgnew. 