### PR TITLE
Fix broken `pkg fetch -o`

### DIFF
--- a/libpkg/repo/binary/fetch.c
+++ b/libpkg/repo/binary/fetch.c
@@ -147,7 +147,7 @@ pkg_repo_binary_try_fetch(struct pkg_repo *repo, struct pkg *pkg,
 		else
 			cachedir = ctx.cachedir;
 
-		snprintf(dest, sizeof(dest), "%s/%s", ctx.cachedir, pkg->repopath);
+		snprintf(dest, sizeof(dest), "%s/%s", cachedir, pkg->repopath);
 	}
 	else
 		pkg_repo_binary_get_cached_name(repo, pkg, dest, sizeof(dest));


### PR DESCRIPTION
This fixes a bug which appears to have been introduced by a typo in 8dd464b2 which causes the -o flag in pkg-fetch (custom output directory) to stop working correctly.

This bug affects versions 1.13.0 and 1.13.1 of pkg and causes synth to get "Download failed" errors when "fetch prebuilt packages" is enabled.