### PR TITLE
zsh-completion: disable repo update during package retrival

### DIFF
--- a/scripts/completion/_pkg.in
+++ b/scripts/completion/_pkg.in
@@ -11,9 +11,10 @@ _pkg_installed() {
 }
 
 _pkg_available_name() {
-	local expl
+	local expl scache
+	zstyle -t ":completion:${curcontext}:packages" remote-access || scache=1
 	_wanted packages expl package \
-		compadd "$@" - $(_call_program packages _pkg_cmd rquery "%n")
+		compadd "$@" - $(_call_program packages _pkg_cmd rquery ${scache:+--no-repo-update} "%n")
 }
 
 _pkg_aliases() {
@@ -23,14 +24,15 @@ _pkg_aliases() {
 }
 
 _pkg_available() {
-	local ret=1
+	local ret=1 scache
 	_tags files packages
 	while _tags; do
 		if _requested files; then
 			_files "$@" -g "*.t?z" && ret=0
 		fi
 		if _requested packages; then
-			compadd "$@" - $(_call_program packages _pkg_cmd rquery "%n-%v") && ret=0
+			zstyle -t ":completion:${curcontext}:packages" remote-access || scache=1
+			compadd "$@" - $(_call_program packages _pkg_cmd rquery ${scache:+--no-repo-update} "%n-%v") && ret=0
 		fi
 		(( ret )) || break
 	done


### PR DESCRIPTION
per pkg-rquery(8):
```
Automatic repository catalogue updates are only attempted when the
effective UID of the process has write access to the package database.
Otherwise they are silently ignored.
```

So when a user that can modify the database attempts completion, they
may experience a delay and think zsh or the system may have locked up.

using zstyle, the automatic updates can be re-enabled.
```
zstyle ':completion:*:pkg*:*:packages' remote-access true
zstyle ':completion:*:pkg-install:*:packages' remote-access true # specifically for a single subcommand
```