### PR TITLE
libpkg: fix ABI on FreeBSD

### DIFF
--- a/libpkg/pkg_elf.c
+++ b/libpkg/pkg_elf.c
@@ -803,7 +803,7 @@ elf_note_analyse(Elf_Data *data, GElf_Ehdr *elfhdr, struct os_info *oi)
 #else
 		xasprintf(&oi->version_major, "%d", version / 100000);
 		xasprintf(&oi->version_minor, "%d", (((version / 100 % 1000)+1)/2)*2);
-		xasprintf(&oi->version, "%d.%d", version / 100000, (((version / 100 % 1000)+1)/2)*2);
+		xasprintf(&oi->version, "%d", version / 100000);
 #endif
 	}
 


### PR DESCRIPTION
FreeBSD doesn't include the minor version in the ABI; doing so induces some
breakage as this isn't expected.

This fixes up d313276ff3d3d207de to hopefully unbreak -CURRENT package repos.

Signed-off-by: Kyle Evans <kevans@FreeBSD.org>