### PR TITLE
Finish 'hash' mode for pkg create

### DIFF
--- a/docs/pkg-create.8
+++ b/docs/pkg-create.8
@@ -24,7 +24,7 @@
 .\" ---------------------------------------------------------------------------
 .Sh SYNOPSIS
 .Nm
-.Op Fl qv
+.Op Fl hqv
 .Op Fl f Ar format
 .Op Fl o Ar outdir
 .Op Fl p Ar plist
@@ -32,21 +32,21 @@
 .Op Fl t Ar timestamp
 .Fl m Ar metadatadir
 .Nm
-.Op Fl qv
+.Op Fl hqv
 .Op Fl f Ar format
 .Op Fl o Ar outdir
 .Op Fl r Ar rootdir
 .Op Fl t Ar timestamp
 .Fl M Ar manifest
 .Nm
-.Op Fl gnqvx
+.Op Fl hgnqvx
 .Op Fl f Ar format
 .Op Fl o Ar outdir
 .Op Fl r Ar rootdir
 .Op Fl t Ar timestamp
 .Ar pkg-name ...
 .Nm
-.Op Fl qv
+.Op Fl hqv
 .Op Fl f Ar format
 .Op Fl o Ar outdir
 .Op Fl r Ar rootdir
@@ -56,6 +56,7 @@
 .Pp
 .Nm
 .Op Cm --no-clobber
+.Op Cm --hash
 .Op Cm --quiet
 .Op Cm --verbose
 .Op Cm --format Ar format
@@ -65,6 +66,7 @@
 .Cm --metadata Ar metadatadir
 .Nm
 .Op Cm --no-clobber
+.Op Cm --hash
 .Op Cm --quiet
 .Op Cm --verbose
 .Op Cm --format Ar format
@@ -73,6 +75,7 @@
 .Cm --manifest Ar manifest
 .Nm
 .Op Cm --{glob,no-clobber,regex}
+.Op Cm --hash
 .Op Cm --quiet
 .Op Cm --verbose
 .Op Cm --format Ar format
@@ -81,6 +84,7 @@
 .Ar pkg-name ...
 .Nm
 .Op Cm --no-clobber
+.Op Cm --hash
 .Op Cm --quiet
 .Op Cm --verbose
 .Op Cm --format Ar format
@@ -218,6 +222,15 @@ Only has any effect when used with
 See
 .Sx "PLIST FORMAT"
 for details.
+.It Fl h , Cm --hash
+Create the package with a short hash of the contents in the filename,
+also creates a symlink to the regular filename.
+Can be enabled by setting
+.Cm PKG_CREATE_HASH
+to
+.Ar yes
+in
+.Pa pkg.conf .
 .It Fl q , Cm --quiet
 Force quiet output.
 This is the default, unless

--- a/docs/pkg.conf.5
+++ b/docs/pkg.conf.5
@@ -202,6 +202,22 @@ Default: NO.
 Specifies the cache directory for packages.
 Default:
 .Pa /var/cache/pkg
+.It Cm PKG_CREATE_HASH: boolean
+When set to a
+.Sy true
+value, make
+.Xr pkg-create 8
+name created packages with the short hash of contents appended to the filename.
+Default:
+.Sy false
+.It Cm PKG_CREATE_SYMLINK: boolean
+When set to a
+.Sy true
+value, make
+.Xr pkg-create 8
+create a symlink between the short hash filename and the regular filename.
+Default:
+.Sy false
 .It Cm PKG_CREATE_VERBOSE: boolean
 When set to a
 .Sy true

--- a/libpkg/libpkg.ver
+++ b/libpkg/libpkg.ver
@@ -34,6 +34,8 @@ global:
 	pkg_create_set_output_dir;
 	pkg_create_set_rootdir;
 	pkg_create_set_timestamp;
+	pkg_create_set_hash;
+	pkg_create_set_hash_symlink;
 	pkg_create_staged;
 	pkg_dep_get;
 	pkg_dep_is_locked;

--- a/libpkg/pkg.h.in
+++ b/libpkg/pkg.h.in
@@ -1701,6 +1701,8 @@ bool pkg_create_set_format(struct pkg_create *, const char *);
 void pkg_create_set_rootdir(struct pkg_create *, const char *);
 void pkg_create_set_output_dir(struct pkg_create *, const char *);
 void pkg_create_set_timestamp(struct pkg_create *, time_t);
+void pkg_create_set_hash(struct pkg_create *, bool);
+void pkg_create_set_hash_symlink(struct pkg_create *, bool);
 int pkg_create(struct pkg_create *, const char *, const char *, bool);
 int pkg_create_i(struct pkg_create *, struct pkg *, bool);
 /* deprecated */

--- a/libpkg/pkg_config.c
+++ b/libpkg/pkg_config.c
@@ -376,6 +376,18 @@ static struct config_entry c[] = {
 	},
 	{
 		PKG_BOOL,
+		"PKG_CREATE_HASH",
+		"NO",
+		"Name created packages with the hash of contents",
+	},
+	{
+		PKG_BOOL,
+		"PKG_CREATE_SYMLINK",
+		"NO",
+		"Create symlinks from the hashed filename to the regular filename",
+	},
+	{
+		PKG_BOOL,
 		"PKG_CREATE_VERBOSE",
 		"NO",
 		"Enable verbose mode for 'pkg create'",

--- a/libpkg/private/pkg.h
+++ b/libpkg/private/pkg.h
@@ -51,6 +51,9 @@
 #define PKG_NUM_SCRIPTS 9
 #define PKG_NUM_LUA_SCRIPTS 5
 
+#define PKG_HASH_SEP '~'
+#define PKG_HASH_SEPSTR "~"
+
 /*
  * Some compatibility checks
  */
@@ -338,6 +341,8 @@ struct pkg_create {
 	time_t timestamp;
 	const char *rootdir;
 	const char *outdir;
+	bool hash;
+	bool symlink;
 };
 
 struct pkg_dep {

--- a/libpkg/repo/binary/fetch.c
+++ b/libpkg/repo/binary/fetch.c
@@ -75,15 +75,15 @@ pkg_repo_binary_get_cached_name(struct pkg_repo *repo, struct pkg *pkg,
 		 * The real naming scheme:
 		 * <cachedir>/<name>-<version>-<checksum>.txz
 		 */
-		pkg_snprintf(dest, destlen, "%S/%n-%v-%z%S",
-				ctx.cachedir, pkg, pkg, pkg, ext);
+		pkg_snprintf(dest, destlen, "%S/%n-%v%S%z%S",
+		    ctx.cachedir, pkg, pkg, PKG_HASH_SEPSTR, pkg, ext);
 		if (stat (dest, &st) == -1 || pkg->pkgsize != st.st_size)
 			return (EPKG_FATAL);
 
 	}
 	else {
-		pkg_snprintf(dest, destlen, "%S/%n-%v-%z",
-				ctx.cachedir, pkg, pkg, pkg);
+		pkg_snprintf(dest, destlen, "%S/%n-%v%S%z", ctx.cachedir, pkg,
+		    pkg, PKG_HASH_SEPSTR, pkg);
 	}
 
 	return (EPKG_OK);

--- a/scripts/completion/_pkg.in
+++ b/scripts/completion/_pkg.in
@@ -138,6 +138,8 @@ _pkg_config_opts() {
 		'OSVERSION[FreeBSD OS version]:version' \
 		'PERMISSIVE[ignore conflicts while registering a package]:boolean:(yes no)' \
 		'PKG_CACHEDIR[specify cache directory for packages]:directory:_files -/' \
+		'PKG_CREATE_HASH[make pkg_create(8) name files using a short hash]:boolean:(yes no)' \
+		'PKG_CREATE_SYMLINK[make pkg_create(8) symlink the hashed filename to the regular package filename]:boolean:(yes no)' \
 		'PKG_CREATE_VERBOSE[make pkg_create(8) use verbose mode]:boolean:(yes no)' \
 		'PKG_DBDIR[specify directory to use for storing package database files]:directory:_files -/' \
 		'PKG_ENABLE_PLUGINS[activate plugin support]:boolean:(yes no)' \

--- a/src/create.c
+++ b/src/create.c
@@ -174,6 +174,7 @@ exec_create(int argc, char **argv)
 	char	*endptr;
 	int		 ch;
 	bool		 hash = false;
+	bool		 hash_symlink = false;
 	time_t		 ts = (time_t)-1;
 
 
@@ -182,6 +183,8 @@ exec_create(int argc, char **argv)
 	 * historical reasons. */
 
 	quiet = !pkg_object_bool(pkg_config_get("PKG_CREATE_VERBOSE"));
+	hash = pkg_object_bool(pkg_config_get("PKG_CREATE_HASH"));
+	hash_symlink = pkg_object_bool(pkg_config_get("PKG_CREATE_SYMLINK"));
 
 	struct option longopts[] = {
 		{ "all",	no_argument,		NULL,	'a' },
@@ -214,6 +217,7 @@ exec_create(int argc, char **argv)
 			break;
 		case 'h':
 			hash = true;
+			hash_symlink = true;
 			break;
 		case 'm':
 			metadatadir = optarg;
@@ -281,12 +285,14 @@ exec_create(int argc, char **argv)
 
 	pkg_create_set_rootdir(pc, rootdir);
 	pkg_create_set_output_dir(pc, outdir);
+	pkg_create_set_hash(pc, hash);
+	pkg_create_set_hash_symlink(pc, hash_symlink);
 	if (ts != (time_t)-1)
 		pkg_create_set_timestamp(pc, ts);
 
 	if (metadatadir == NULL && manifest == NULL)
 		return (pkg_create_matches(argc, argv, match, pc) == EPKG_OK ? EX_OK : EX_SOFTWARE);
-	return (pkg_create(pc, metadatadir != NULL ? metadatadir : manifest, plist,
-	    hash) == EPKG_OK ? EX_OK : EX_SOFTWARE);
+	return (pkg_create(pc, metadatadir != NULL ? metadatadir : manifest,
+	    plist, hash_symlink) == EPKG_OK ? EX_OK : EX_SOFTWARE);
 }
 


### PR DESCRIPTION
Add two new configuration knobs to control creating packages with
the short hash appended to the package name.

PKG_CREATE_HASH renames the packages to use the short hash
PKG_CREATE_SYMLINK creates a symlink from the original pkg filename

This builds upon b9f1e054731d3dab452cc87c628928033713ee2b and adds
the missing documentation

Also:
pkg create should write to .pkgname first then rename on success

This allows the ports tree to have pkg create output directly to the
destination directory, instead of copying the file afterwards

The hash is separated from the version by a ~ since this character
is not already used as part of a version numbers. Many places in the
code assume the version is everything after the last - character.