### PR TITLE
Fix #1566: Add pkg-create(8) -l,--level to set compression level

### DIFF
--- a/docs/pkg-create.8
+++ b/docs/pkg-create.8
@@ -14,7 +14,7 @@
 .\"
 .\"     @(#)pkg.8
 .\"
-.Dd February 26, 2020
+.Dd April 13, 2020
 .Dt PKG-CREATE 8
 .Os
 .\" ---------------------------------------------------------------------------
@@ -26,6 +26,7 @@
 .Nm
 .Op Fl qv
 .Op Fl f Ar format
+.Op Fl l Ar level
 .Op Fl o Ar outdir
 .Op Fl p Ar plist
 .Op Fl r Ar rootdir
@@ -34,6 +35,7 @@
 .Nm
 .Op Fl qv
 .Op Fl f Ar format
+.Op Fl l Ar level
 .Op Fl o Ar outdir
 .Op Fl r Ar rootdir
 .Op Fl t Ar timestamp
@@ -41,6 +43,7 @@
 .Nm
 .Op Fl gnqvx
 .Op Fl f Ar format
+.Op Fl l Ar level
 .Op Fl o Ar outdir
 .Op Fl r Ar rootdir
 .Op Fl t Ar timestamp
@@ -48,6 +51,7 @@
 .Nm
 .Op Fl qv
 .Op Fl f Ar format
+.Op Fl l Ar level
 .Op Fl o Ar outdir
 .Op Fl r Ar rootdir
 .Op Fl t Ar timestamp
@@ -59,6 +63,7 @@
 .Op Cm --quiet
 .Op Cm --verbose
 .Op Cm --format Ar format
+.Op Cm --level Ar level
 .Op Cm --out-dir Ar outdir
 .Op Cm --plist Ar plist
 .Op Cm --root-dir Ar rootdir
@@ -68,6 +73,7 @@
 .Op Cm --quiet
 .Op Cm --verbose
 .Op Cm --format Ar format
+.Op Cm --level Ar level
 .Op Cm --out-dir Ar outdir
 .Op Cm --root-dir Ar rootdir
 .Cm --manifest Ar manifest
@@ -76,6 +82,7 @@
 .Op Cm --quiet
 .Op Cm --verbose
 .Op Cm --format Ar format
+.Op Cm --level Ar level
 .Op Cm --out-dir Ar outdir
 .Op Cm --root-dir Ar rootdir
 .Ar pkg-name ...
@@ -84,6 +91,7 @@
 .Op Cm --quiet
 .Op Cm --verbose
 .Op Cm --format Ar format
+.Op Cm --level Ar level
 .Op Cm --out-dir Ar outdir
 .Op Cm --root-dir Ar rootdir
 .Cm --all
@@ -159,6 +167,23 @@ which are currently the only supported formats.
 If an invalid or no format is specified
 .Ar txz
 is assumed.
+.It Fl l Ar level , Cm --level Ar level
+Set the compression
+.Ar level
+for created packages.
+It can be any valid numeric compression level you might specify to the
+underlying compression
+.Ar format .
+Additionally,
+.Ar level
+may be one of the special words
+.Dv Dq fast
+or
+.Dv Dq best .
+If
+.Ar level
+is one of these special words, the fastest or slowest compression level,
+respectively, for the specified compression format, is used.
 .It Fl m Ar metadatadir , Cm --metadata Ar metadatadir
 Specify the directory containing the package manifest,
 .Pa +MANIFEST

--- a/libpkg/libpkg.ver
+++ b/libpkg/libpkg.ver
@@ -31,6 +31,7 @@ global:
 	pkg_create_new;
 	pkg_create_repo;
 	pkg_create_set_format;
+	pkg_create_set_compression_level;
 	pkg_create_set_output_dir;
 	pkg_create_set_rootdir;
 	pkg_create_set_timestamp;

--- a/libpkg/pkg.h.in
+++ b/libpkg/pkg.h.in
@@ -1698,6 +1698,7 @@ int pkg_namecmp(struct pkg *, struct pkg *);
 struct pkg_create *pkg_create_new(void);
 void pkg_create_free(struct pkg_create *);
 bool pkg_create_set_format(struct pkg_create *, const char *);
+void pkg_create_set_compression_level(struct pkg_create *, int);
 void pkg_create_set_rootdir(struct pkg_create *, const char *);
 void pkg_create_set_output_dir(struct pkg_create *, const char *);
 void pkg_create_set_timestamp(struct pkg_create *, time_t);

--- a/libpkg/pkg_create.c
+++ b/libpkg/pkg_create.c
@@ -190,7 +190,7 @@ pkg_create_archive(struct pkg *pkg, struct pkg_create *pc, unsigned required_fla
 		return (NULL);
 	}
 
-	if (packing_init(&pkg_archive, pkg_path, pc->format, pc->timestamp) != EPKG_OK)
+	if (packing_init(&pkg_archive, pkg_path, pc->format, pc->compression_level, pc->timestamp) != EPKG_OK)
 		pkg_archive = NULL;
 
 	free(pkg_path);
@@ -257,6 +257,12 @@ pkg_create_set_format(struct pkg_create *pc, const char *format)
 	else
 		return (false);
 	return (true);
+}
+
+void
+pkg_create_set_compression_level(struct pkg_create *pc, int clevel)
+{
+	pc->compression_level = clevel;
 }
 
 void

--- a/libpkg/pkg_repo_create.c
+++ b/libpkg/pkg_repo_create.c
@@ -825,7 +825,7 @@ pkg_repo_pack_db(const char *name, const char *archive, char *path,
 	sig = NULL;
 	pub = NULL;
 
-	if (packing_init(&pack, archive, meta->packing_format, (time_t)-1) != EPKG_OK)
+	if (packing_init(&pack, archive, meta->packing_format, 0, (time_t)-1) != EPKG_OK)
 		return (EPKG_FATAL);
 
 	if (rsa != NULL) {

--- a/libpkg/private/pkg.h
+++ b/libpkg/private/pkg.h
@@ -333,7 +333,7 @@ struct pkg {
 };
 
 struct pkg_create {
-	uint8_t	compression_level;
+	int compression_level;
 	pkg_formats format;
 	time_t timestamp;
 	const char *rootdir;
@@ -737,7 +737,7 @@ int pkg_jobs_resolv(struct pkg_jobs *jobs);
 
 struct packing;
 
-int packing_init(struct packing **pack, const char *path, pkg_formats format, time_t timestamp);
+int packing_init(struct packing **pack, const char *path, pkg_formats format, int clevel, time_t timestamp);
 int packing_append_file_attr(struct packing *pack, const char *filepath,
      const char *newpath, const char *uname, const char *gname, mode_t perm,
      u_long fflags);

--- a/scripts/completion/_pkg.bash.in
+++ b/scripts/completion/_pkg.bash.in
@@ -129,7 +129,7 @@ _pkgng_create () {
     local cur prev opts lopts
     COMPREPLY=()
 
-    opts=('-r' '-m' '-f' '-o' '-g' '-x' '-X' '-a')
+    opts=('-r' '-m' '-f' '-l' '-o' '-g' '-x' '-X' '-a')
     lopts=()
     small_info="Creates software package distributions"
     large_info=""

--- a/scripts/completion/_pkg.in
+++ b/scripts/completion/_pkg.in
@@ -289,6 +289,7 @@ _pkg_args() {
 				'(-q --quiet)'{-q,--quiet}'[force quiet output]' \
 				'(-v --verbose)'{-v,--verbose}'[be verbose]' \
 				'(-f --format)'{-f+,--format=}'[specify package output format]:format:(tar tgz tbz txz tzst)' \
+				'(-l --level)'{-l+,--level=}'[specify compression level]:level:(integer fast best)' \
 				'(-o --out-dir)'{-o+,--out-dir=}'[output directory]:outdir:_files -/' \
 				'(-r --root-dir)'{-r+,--root-dir=}'[specify root directory]:rootdir:_files -/' \
 				- '(manifest)' \


### PR DESCRIPTION
Add -l, --level option to pkg-create(8) to allow specifying a numeric
compression level to be used with one of the compressing -f,--formats, such as
txz, tzst, or tgz.  (If -f tar is specified, along with a level, this is
considered a usage error.)

This expands the libpkg ABI slightly with the new function
pkg_create_set_compression_level().

Additionally, a member in struct pkg_create was changed to one of a different
size; however, (1) struct pkg_create is carefully not part of the ABI, and (2)
the space was likely consumed by padding bytes anyway, so this change should
not break consumers.

The CLI has two special non-numeric compression levels: fast, and best.  They
do what you would expect.

The API has three sentinel compression levels: INT_MIN (==fast), 0 (default),
and INT_MAX (=="best").

There is a defaults change here: if '-f tzst' is specified, we no longer
default to level 20.  Level 20 is extremely slow and the choice is dissimilar
to all other compression formats.  If something desires zstd level 20, it can
invoke pkg-create(8) --format tzst --level 20, or use the corresponding
libpkg(3) API.