### PR TITLE
Constify the buffer passed to pkg_repo_binary_add_from_manifest()

### DIFF
--- a/libpkg/pkg.h.in
+++ b/libpkg/pkg.h.in
@@ -740,7 +740,7 @@ int pkg_addluascript_fileat(int fd, struct pkg *pkg, const char *path);
  * @param buf An NULL-terminated buffer containing the manifest data.
  * @return An error code.
  */
-int pkg_parse_manifest(struct pkg *pkg, char *buf, size_t len, struct pkg_manifest_key *key);
+int pkg_parse_manifest(struct pkg *pkg, const char *buf, size_t len, struct pkg_manifest_key *key);
 int pkg_parse_manifest_file(struct pkg *pkg, const char *, struct pkg_manifest_key *key);
 int pkg_parse_manifest_fileat(int fd, struct pkg *pkg, const char *, struct pkg_manifest_key *key);
 int pkg_manifest_keys_new(struct pkg_manifest_key **k);

--- a/libpkg/pkg_manifest.c
+++ b/libpkg/pkg_manifest.c
@@ -830,7 +830,7 @@ pkg_parse_manifest_ucl (struct pkg *pkg, ucl_object_t *obj, struct pkg_manifest_
 }
 
 int
-pkg_parse_manifest(struct pkg *pkg, char *buf, size_t len, struct pkg_manifest_key *keys)
+pkg_parse_manifest(struct pkg *pkg, const char *buf, size_t len, struct pkg_manifest_key *keys)
 {
 	struct ucl_parser *p = NULL;
 	ucl_object_t *obj = NULL;

--- a/libpkg/repo/binary/update.c
+++ b/libpkg/repo/binary/update.c
@@ -368,7 +368,7 @@ pkg_repo_binary_register_conflicts(const char *origin, char **conflicts,
 }
 
 static int
-pkg_repo_binary_add_from_manifest(char *buf, sqlite3 *sqlite, size_t len,
+pkg_repo_binary_add_from_manifest(const char *buf, sqlite3 *sqlite, size_t len,
 		struct pkg_manifest_key **keys, struct pkg **p __unused,
 		struct pkg_repo *repo)
 {


### PR DESCRIPTION
This buffer is eventually passed down to the `pkg_parse_manifest()` function (thus, its corresponding argument should also be constified) and finally to the `ucl_parser_add_chunk()` function which already takes const pointer.  That is, it does not change existing semantics, just self-documents the code better.