### PR TITLE
Prevent potential hang with scripts (take 2)

### DIFF
--- a/libpkg/lua_scripts.c
+++ b/libpkg/lua_scripts.c
@@ -303,7 +303,7 @@ pkg_lua_script_run(struct pkg * const pkg, pkg_lua_script type, bool upgrade)
 
 		f = fdopen(pfd.fd, "r");
 		for (;;) {
-			int pres = poll(&pfd, 1, -1);
+			int pres = poll(&pfd, 1, 1000);
 			if (pres == -1) {
 				if (errno == EINTR)
 					continue;

--- a/libpkg/scripts.c
+++ b/libpkg/scripts.c
@@ -245,7 +245,7 @@ pkg_script_run(struct pkg * const pkg, pkg_script type, bool upgrade)
 
 			f = fdopen(pfd.fd, "r");
 			for (;;) {
-				int pres = poll(&pfd, 1, -1);
+				int pres = poll(&pfd, 1, 1000);
 				if (pres == -1) {
 					if (errno == EINTR)
 						continue;


### PR DESCRIPTION
Note commit a4c28a6 and 0395446 tried to fix the potential hang.  However,
it did not help because poll() does not time out.  See the original patch
set the timeout to 1 second.

https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=245462
https://bz-attachments.freebsd.org/attachment.cgi?id=213235