### PR TITLE
Add a debug message for when obtaining a lock fails

### DIFF
--- a/libpkg/pkgdb.c
+++ b/libpkg/pkgdb.c
@@ -2993,6 +2993,10 @@ pkgdb_obtain_lock(struct pkgdb *db, pkgdb_lock_t type)
 
 	ret = pkgdb_try_lock(db, lock_sql, type, false);
 
+	if (ret != EPKG_OK)
+		pkg_debug(1, "failed to obtain the lock: %s",
+		    sqlite3_errmsg(db->sqlite));
+
 	return (ret);
 }
 


### PR DESCRIPTION
In the OpenZFS CI we're seeing LOCK_RETRIES is sometimes not exhausted before pkg bails.
I haven't been able to reproduce this locally. Having a debug message here would be helpful.

Sponsored by: iXsystems, Inc.