### PR TITLE
Allow building with -Werror=implicit-function-declaration

### DIFF
--- a/compat/bsd_compat.h
+++ b/compat/bsd_compat.h
@@ -165,6 +165,16 @@ char * strnstr(const char *s, const char *find, size_t slen);
 #endif
 #endif
 
+#ifndef __unreachable
+# if defined(__GNUC__) && ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 6))
+#  define __unreachable() __builtin_unreachable()
+# elif defined(__clang__) && __has_builtin(__builtin_unreachable)
+#  define __unreachable() __builtin_unreachable()
+# else
+#  define __unreachable() ((void)0)
+# endif
+#endif
+
 #if !HAVE_FUNOPEN
 #if !HAVE_FOPENCOOKIE
 # error "Your system has neither funopen nor fopencookie, cannot continue"

--- a/libpkg/packing.c
+++ b/libpkg/packing.c
@@ -29,6 +29,7 @@
 #include <archive.h>
 #include <archive_entry.h>
 #include <assert.h>
+#include <bsd_compat.h>
 #include <fcntl.h>
 #include <fts.h>
 #include <string.h>

--- a/mk/common.mk
+++ b/mk/common.mk
@@ -3,6 +3,8 @@ OBJS=	${SRCS:.c=.o}
 SHOBJS?=	${SRCS:.c=.pico}
 DEPFILES=	${OBJS:.o=.Po} ${SHOBJS:.pico=.Ppico}
 CFLAGS+=	$(CPPFLAGS)
+CFLAGS+=	-Werror=implicit-function-declaration
+CFLAGS+=	-Werror=return-type
 
 -include $(DEPFILES)
 

--- a/src/event.c
+++ b/src/event.c
@@ -49,6 +49,7 @@
 #include <string.h>
 #include <unistd.h>
 #include <errno.h>
+#include <time.h>
 #include <signal.h>
 #ifdef HAVE_LIBUTIL_H
 #include <libutil.h>


### PR DESCRIPTION
This fixes linking on macOS which would previously fail with

Undefined symbols for architecture x86_64:
  "___unreachable", referenced from:
      _packing_set_format in packing.pico