### PR TITLE
Fix test case list in tests/fronted/create.sh

### DIFF
--- a/tests/frontend/create.sh
+++ b/tests/frontend/create.sh
@@ -18,7 +18,7 @@ tests_init \
 	create_from_plist_hash \
 	create_from_plist_with_keyword_and_message \
 	create_with_hardlink \
-	create_no_clobber
+	create_no_clobber \
 	time
 
 genmanifest() {


### PR DESCRIPTION
Add a missing line continuation that was forgotten in a8bec7220491046b80ba584359491761816f65fb