### PR TITLE
(lua_)scripts.c: gather remaining output after loop exits

### DIFF
--- a/libpkg/lua_scripts.c
+++ b/libpkg/lua_scripts.c
@@ -341,6 +341,10 @@ pkg_lua_script_run(struct pkg * const pkg, pkg_lua_script type, bool upgrade)
 			if (feof(f))
 				break;
 		}
+		/* Gather any remaining output */
+		while (!feof(f) && !ferror(f) && getline(&line, &linecap, f) > 0) {
+			pkg_emit_message(line);
+		}
 		fclose(f);
 
 		while (should_waitpid && waitpid(pid, &pstat, 0) == -1) {

--- a/libpkg/scripts.c
+++ b/libpkg/scripts.c
@@ -283,6 +283,10 @@ pkg_script_run(struct pkg * const pkg, pkg_script type, bool upgrade)
 				if (feof(f))
 					break;
 			}
+			/* Gather any remaining output */
+			while (!feof(f) && !ferror(f) && getline(&line, &linecap, f) > 0) {
+				pkg_emit_message(line);
+			}
 			fclose(f);
 
 			while (should_waitpid && waitpid(pid, &pstat, 0) == -1) {


### PR DESCRIPTION
I added a new exit case in 722c3a98456b0e4e2bd0aaa8621e6a5fce1cabc6 that
could result in lines being dropped if the child process exits just after
poll timed out. This should hopefully fix the failures on CirrusCI.