### PR TITLE
Fix invalid JSON when EVENT_PIPE is used

### DIFF
--- a/libpkg/pkg_event.c
+++ b/libpkg/pkg_event.c
@@ -287,11 +287,11 @@ pipeevent(struct pkg_event *ev)
 		break;
 	case PKG_EVENT_NOLOCALDB:
 		utstring_printf(msg, "{ \"type\": \"ERROR_NOLOCALDB\", "
-		    "\"data\": {} ");
+		    "\"data\": {}} ");
 		break;
 	case PKG_EVENT_NEWPKGVERSION:
 		utstring_printf(msg, "{ \"type\": \"INFO_NEWPKGVERSION\", "
-		    "\"data\": {} ");
+		    "\"data\": {}} ");
 		break;
 	case PKG_EVENT_FILE_MISMATCH:
 		pkg_utstring_printf(msg, "{ \"type\": \"ERROR_FILE_MISMATCH\", "


### PR DESCRIPTION
Fix INFO_NEWPKGVERSION and ERROR_NOLOCALDB emitting invalid JSON.

fixes #1857