### PR TITLE
Unbreak build with -fno-common

### DIFF
--- a/src/globals.c
+++ b/src/globals.c
@@ -31,6 +31,9 @@ int case_sensitive; /* Case sensitive queries */
 int force; /* Forced operation */
 int quiet; /* Silent output */
 int newpkgversion; /* New package version is available */
+int nbactions;
+int nbdone;
+int nbtodl;
 
 void
 set_globals(void)
@@ -43,5 +46,8 @@ set_globals(void)
 	force = 0;
 	quiet = 0;
 	newpkgversion = 0;
+	nbactions = 0;
+	nbdone = 0;
+	nbtodl = 0;
 }
 

--- a/src/pkgcli.h
+++ b/src/pkgcli.h
@@ -37,12 +37,9 @@
 
 extern bool quiet;
 extern int nbactions;
-int nbactions;
 extern int nbdone;
-int nbdone;
 extern bool newpkgversion;
 extern int nbtodl;
-int nbtodl;
 
 /* pkg add */
 int exec_add(int, char **);


### PR DESCRIPTION
-fno-common is the default in GCC10 and will also be the default in Clang11.

```
ld: error: duplicate symbol: nbactions
>>> defined at add.c
>>>            add.o:(nbactions)
>>> defined at alias.c
>>>            alias.o:(.bss+0x0)

ld: error: duplicate symbol: nbdone
>>> defined at add.c
>>>            add.o:(nbdone)
>>> defined at alias.c
>>>            alias.o:(.bss+0x4)

ld: error: duplicate symbol: nbtodl
>>> defined at add.c
>>>            add.o:(nbtodl)
>>> defined at alias.c
>>>            alias.o:(.bss+0x8)

ld: error: duplicate symbol: nbactions
>>> defined at add.c
>>>            add.o:(nbactions)
>>> defined at annotate.c
>>>            annotate.o:(.bss+0x0)

ld: error: duplicate symbol: nbdone
>>> defined at add.c
>>>            add.o:(nbdone)
>>> defined at annotate.c
>>>            annotate.o:(.bss+0x4)

ld: error: duplicate symbol: nbtodl
>>> defined at add.c
>>>            add.o:(nbtodl)
>>> defined at annotate.c
>>>            annotate.o:(.bss+0x8)

ld: error: duplicate symbol: nbactions
>>> defined at add.c
>>>            add.o:(nbactions)
>>> defined at audit.c
>>>            audit.o:(.bss+0x0)

ld: error: duplicate symbol: nbdone
>>> defined at add.c
>>>            add.o:(nbdone)
>>> defined at audit.c
>>>            audit.o:(.bss+0x4)

ld: error: duplicate symbol: nbtodl
>>> defined at add.c
>>>            add.o:(nbtodl)
>>> defined at audit.c
>>>            audit.o:(.bss+0x8)

ld: error: duplicate symbol: nbactions
>>> defined at add.c
>>>            add.o:(nbactions)
>>> defined at autoremove.c
>>>            autoremove.o:(.bss+0x4)

ld: error: duplicate symbol: nbdone
>>> defined at add.c
>>>            add.o:(nbdone)
>>> defined at autoremove.c
>>>            autoremove.o:(.bss+0x0)

ld: error: duplicate symbol: nbtodl
>>> defined at add.c
>>>            add.o:(nbtodl)
>>> defined at autoremove.c
>>>            autoremove.o:(.bss+0x8)

ld: error: duplicate symbol: nbactions
>>> defined at add.c
>>>            add.o:(nbactions)
>>> defined at backup.c
>>>            backup.o:(.bss+0x0)

ld: error: duplicate symbol: nbdone
>>> defined at add.c
>>>            add.o:(nbdone)
>>> defined at backup.c
>>>            backup.o:(.bss+0x4)

ld: error: duplicate symbol: nbtodl
>>> defined at add.c
>>>            add.o:(nbtodl)
>>> defined at backup.c
>>>            backup.o:(.bss+0x8)

ld: error: duplicate symbol: nbactions
>>> defined at add.c
>>>            add.o:(nbactions)
>>> defined at check.c
>>>            check.o:(.bss+0x4)

ld: error: duplicate symbol: nbdone
>>> defined at add.c
>>>            add.o:(nbdone)
>>> defined at check.c
>>>            check.o:(.bss+0x0)

ld: error: duplicate symbol: nbtodl
>>> defined at add.c
>>>            add.o:(nbtodl)
>>> defined at check.c
>>>            check.o:(.bss+0x8)

ld: error: duplicate symbol: nbactions
>>> defined at add.c
>>>            add.o:(nbactions)
>>> defined at clean.c
>>>            clean.o:(.bss+0x0)

ld: error: duplicate symbol: nbdone
>>> defined at add.c
>>>            add.o:(nbdone)
>>> defined at clean.c
>>>            clean.o:(.bss+0x4)
```