### PR TITLE
Add RISC-V ABI aliases

### DIFF
--- a/libpkg/pkg_elf.c
+++ b/libpkg/pkg_elf.c
@@ -1029,6 +1029,23 @@ pkg_get_myarch_elfparse(char *dest, size_t sz, struct os_info *oi)
 		snprintf(dest + strlen(dest), sz - strlen(dest), ":%s:%s:%s:%s",
 		    arch, wordsize_corres_str, endian_corres_str, abi);
 		break;
+#if defined(EM_RISCV) && defined(EF_RISCV_FLOAT_ABI_MASK)
+	case EM_RISCV:
+		switch (elfhdr.e_flags & EF_RISCV_FLOAT_ABI_MASK) {
+			case EF_RISCV_FLOAT_ABI_SOFT:
+				abi = "sf";
+				break;
+			case EF_RISCV_FLOAT_ABI_DOUBLE:
+				abi = "hf";
+				break;
+			default:
+				abi = "unknown";
+				break;
+		}
+		snprintf(dest + strlen(dest), sz - strlen(dest), ":%s:%s:%s",
+		    arch, wordsize_corres_str, abi);
+		break;
+#endif
 	default:
 		snprintf(dest + strlen(dest), sz - strlen(dest), ":%s:%s",
 		    arch, wordsize_corres_str);

--- a/libpkg/private/elf_tables.h
+++ b/libpkg/private/elf_tables.h
@@ -40,6 +40,9 @@ static const struct _elf_corres mach_corres[] = {
 	{ EM_MIPS, "mips" },
 	{ EM_PPC, "powerpc" },
 	{ EM_PPC64, "powerpc" },
+#ifdef EM_RISCV
+	{ EM_RISCV, "riscv" },
+#endif
 	{ EM_SPARCV9, "sparc64" },
 	{ EM_IA_64, "ia64" },
 	{ -1, NULL },
@@ -105,6 +108,11 @@ static struct arch_trans machine_arch_translation[] = {
 	{ "mips:32:eb:n32", "mipsn32" },
 	{ "mips:64:el:n64", "mips64el" },
 	{ "mips:64:eb:n64", "mips64" },
+	/* And RISC-V */
+	{ "riscv:32:hf", "riscv32" },
+	{ "riscv:32:sf", "riscv32sf" },
+	{ "riscv:64:hf", "riscv64" },
+	{ "riscv:64:sf", "riscv64sf" },
 
 	{ NULL, NULL }
 };


### PR DESCRIPTION
This adds recognition of EM_RISCV ELF files, and aliases for the
following common ABIs:

 - riscv64   (lp64d)
 - riscv64sf (lp64)
 - riscv32   (ilp32d)
 - riscv32sf (ilp32)

On FreeBSD we support riscv64 and its soft-float variant, riscv64sf.
There are no plans to support 32-bit RISC-V at this time, but if we did
this is how I would elect to name it.

This does not attempt to solve the problem of how to name and distribute
packages built with different RISC-V ISA extensions. For now it only
groups based on floating point ABI and ISA width.

The e_flags flags used to determine the float ABI are described in the
RISC-V ELF psABI spec:
https://github.com/riscv/riscv-elf-psabi-doc/blob/master/riscv-elf.md#-file-header

### Testing
Before:
```
$ ABI_FILE=/usr/obj/usr/home/mitchell/freebsd/riscv.riscv64/usr.bin/uname/uname pkg config abi
FreeBSD:13:unknown:64
$ ABI_FILE=/usr/obj/usr/home/mitchell/freebsd/riscv.riscv64sf/usr.bin/uname/uname pkg config abi
FreeBSD:13:unknown:64
```

After:
```
$ ABI_FILE=/usr/obj/usr/home/mitchell/freebsd/riscv.riscv64/usr.bin/uname/uname pkg config abi
FreeBSD:13:riscv64
$ ABI_FILE=/usr/obj/usr/home/mitchell/freebsd/riscv.riscv64sf/usr.bin/uname/uname pkg config abi
FreeBSD:13:riscv64sf
```