### PR TITLE
Fix fetch checksum logic

### DIFF
--- a/libpkg/repo/binary/fetch.c
+++ b/libpkg/repo/binary/fetch.c
@@ -225,7 +225,7 @@ checksum:
 		return (pkg_repo_binary_try_fetch(repo, pkg, true, mirror, destdir));
 	}
 	if (pkg_checksum_validate_file(dest, pkg->sum) != 0) {
-		if (already_tried || fetched) {
+		if (already_tried && fetched) {
 			pkg_emit_error("%s-%s failed checksum "
 			    "from repository", pkg->name, pkg->version);
 			retcode = EPKG_FATAL;


### PR DESCRIPTION
I believe this addresses https://github.com/freebsd/pkg/issues/1807. If I'm not mistaken fetch is always true if we get here so we would never get to the else statement and always error. It seems like it probably makes sense to only error if we've already been here and the checksum is still bad.

In my testing at least it seems to work a lot better.