### PR TITLE
Fix fetch checksum logic

### DIFF
--- a/libpkg/repo/binary/fetch.c
+++ b/libpkg/repo/binary/fetch.c
@@ -199,7 +199,9 @@ pkg_repo_binary_try_fetch(struct pkg_repo *repo, struct pkg *pkg,
 	}
 
 	retcode = pkg_fetch_file(repo, url, dest, 0, offset, pkg->pkgsize);
-	fetched = true;
+
+	if (offset == -1)
+		fetched = true;
 
 	if (retcode != EPKG_OK)
 		goto cleanup;


### PR DESCRIPTION
Fix https://github.com/freebsd/pkg/issues/1807

I believe what is happening is files have been changed and grown slightly. The old good downloads are being appended to which is creating a garbage file, fetch is being set to true, and we're exiting with an error when the checksum comes up wrong.

This change allows to reattempt a full download before giving up.