### PR TITLE
query: Add %X to get the internal checksum of the package

### DIFF
--- a/docs/pkg-query.8
+++ b/docs/pkg-query.8
@@ -146,6 +146,8 @@ The name of the repository from which the package was installed if
 available, or
 .Dq unknown-repository
 otherwise.
+.It Cm \&%X
+Internal package checksum
 .It Cm \&%\&? Ns Op drCFODLUGBbA
 Returns 0 if the list is empty and 1 if the list has information to display.
 .Bl -tag -width indent

--- a/libpkg/pkg.c
+++ b/libpkg/pkg.c
@@ -1490,7 +1490,7 @@ pkg_validate(struct pkg *pkg, struct pkgdb *db)
 			strlen(pkg->digest))) {
 		/* Calculate new digest */
 		if (pkgdb_ensure_loaded(db, pkg, flags)) {
-			return (pkg_checksum_calculate(pkg, db));
+			return (pkg_checksum_calculate(pkg, db, false));
 		}
 		return (EPKG_FATAL);
 	}

--- a/libpkg/pkg_jobs.c
+++ b/libpkg/pkg_jobs.c
@@ -739,7 +739,7 @@ pkg_jobs_process_remote_pkg(struct pkg_jobs *j, struct pkg *rp,
 	struct pkg_dep *rdep = NULL;
 
 	if (rp->digest == NULL) {
-		if (pkg_checksum_calculate(rp, j->db) != EPKG_OK) {
+		if (pkg_checksum_calculate(rp, j->db, false) != EPKG_OK) {
 			return (EPKG_FATAL);
 		}
 	}

--- a/libpkg/pkg_jobs_universe.c
+++ b/libpkg/pkg_jobs_universe.c
@@ -163,7 +163,7 @@ pkg_jobs_universe_add_pkg(struct pkg_jobs_universe *universe, struct pkg *pkg,
 	if (pkg->digest == NULL) {
 		pkg_debug(3, "no digest found for package %s (%s-%s)",
 		    pkg->uid, pkg->name, pkg->version);
-		if (pkg_checksum_calculate(pkg, universe->j->db) != EPKG_OK) {
+		if (pkg_checksum_calculate(pkg, universe->j->db, false) != EPKG_OK) {
 			*found = NULL;
 			return (EPKG_FATAL);
 		}
@@ -420,7 +420,7 @@ pkg_jobs_universe_handle_provide(struct pkg_jobs_universe *universe,
 		if (unit == NULL) {
 			if (rpkg->digest == NULL) {
 				pkg_debug(3, "no digest found for package %s", rpkg->uid);
-				if (pkg_checksum_calculate(rpkg, universe->j->db) != EPKG_OK) {
+				if (pkg_checksum_calculate(rpkg, universe->j->db, false) != EPKG_OK) {
 					return (EPKG_FATAL);
 				}
 			}

--- a/libpkg/pkg_printf.c
+++ b/libpkg/pkg_printf.c
@@ -114,7 +114,7 @@
  *
  * V  pkg          old version
  * W
- * X
+ * X  pkg          Internal Checksum
  * Y  pkg          List of requires
  * Yn pkg_provide  Name of the require
  * Z
@@ -798,6 +798,15 @@ static const struct pkg_printf_fmt	fmt[] = {
 		PP_ALL,
 		&format_short_checksum,
 	},
+	[PP_PKG_INT_CHECKSUM] =
+	{
+		'X',
+		'\0',
+		false,
+		true,
+		PP_ALL,
+		&format_int_checksum,
+	},
 	[PP_LITERAL_PERCENT] =
 	{
 		'%',
@@ -1477,6 +1486,18 @@ format_old_version(UT_string *buf, const void *data, struct percent_esc *p)
 	const struct pkg	*pkg = data;
 
 	return (string_val(buf, pkg->old_version, p));
+}
+
+/*
+ * %X -- Package checksum. string. Accepts field width, left align
+ */
+UT_string *
+format_int_checksum(UT_string *buf, const void *data, struct percent_esc *p)
+{
+	struct pkg	*pkg = (struct pkg *)data;
+
+	pkg_checksum_calculate(pkg, NULL, true);
+	return (string_val(buf, pkg->digest, p));
 }
 
 /*

--- a/libpkg/pkg_repo_create.c
+++ b/libpkg/pkg_repo_create.c
@@ -396,7 +396,7 @@ pkg_create_repo_worker(struct pkg_fts_item *start, size_t nelts,
 			if (meta->version == 1) {
 				if (pkg_checksum_generate(pkg, mdigest,
 				    pkg_checksum_type_size(meta->digest_format),
-				    meta->digest_format) != EPKG_OK) {
+				    meta->digest_format, false) != EPKG_OK) {
 					pkg_emit_error("Cannot generate digest for a package");
 					ret = EPKG_FATAL;
 

--- a/libpkg/pkgdb.c
+++ b/libpkg/pkgdb.c
@@ -3167,7 +3167,7 @@ pkgdb_begin_solver(struct pkgdb *db)
 	if (it != NULL) {
 		kv_init(pkglist);
 		while (pkgdb_it_next(it, &p, PKG_LOAD_BASIC|PKG_LOAD_OPTIONS) == EPKG_OK) {
-			pkg_checksum_calculate(p, NULL);
+			pkg_checksum_calculate(p, NULL, false);
 			kv_prepend(typeof(p), pkglist, p);
 			p = NULL;
 			cnt ++;

--- a/libpkg/private/pkg.h
+++ b/libpkg/private/pkg.h
@@ -793,7 +793,7 @@ bool ucl_object_emit_file(const ucl_object_t *obj, enum ucl_emitter emit_type,
 pkg_object* pkg_emit_object(struct pkg *pkg, short flags);
 
 int pkg_checksum_generate(struct pkg *pkg, char *dest, size_t destlen,
-	pkg_checksum_type_t type);
+       pkg_checksum_type_t type, bool inc_scripts);
 
 /*
  * Calculates checksum for any data.
@@ -818,7 +818,7 @@ pkg_checksum_type_t pkg_checksum_file_get_type(const char *cksum, size_t clen);
 pkg_checksum_type_t pkg_checksum_type_from_string(const char *name);
 const char* pkg_checksum_type_to_string(pkg_checksum_type_t type);
 size_t pkg_checksum_type_size(pkg_checksum_type_t type);
-int pkg_checksum_calculate(struct pkg *pkg, struct pkgdb *db);
+int pkg_checksum_calculate(struct pkg *pkg, struct pkgdb *db, bool inc_scripts);
 char *pkg_checksum_generate_file(const char *path, pkg_checksum_type_t type);
 char *pkg_checksum_generate_fileat(int fd, const char *path,
     pkg_checksum_type_t type);

--- a/libpkg/private/pkg_printf.h
+++ b/libpkg/private/pkg_printf.h
@@ -147,7 +147,8 @@ typedef enum _fmt_code_t {
 	PP_PKG_PROVIDED,
 	PP_PKG_PROVIDED_NAME,
 	PP_PKG_SHORT_CHECKSUM,
-	PP_LAST_FORMAT = PP_PKG_SHORT_CHECKSUM,
+	PP_PKG_INT_CHECKSUM,
+	PP_LAST_FORMAT = PP_PKG_INT_CHECKSUM,
 	PP_LITERAL_PERCENT,
 	PP_UNKNOWN,
 	PP_END_MARKER
@@ -232,6 +233,7 @@ _static UT_string *format_unknown(UT_string *, __unused const void *, __unused s
 _static UT_string *format_provided(UT_string *, const void *, struct percent_esc *);
 _static UT_string *format_required(UT_string *, const void *, struct percent_esc *);
 _static UT_string *format_provide_name(UT_string *, const void *, struct percent_esc *);
+_static UT_string *format_int_checksum(UT_string *, const void *, struct percent_esc *);
 
 /* Other static function prototypes */
 

--- a/libpkg/repo/binary/update.c
+++ b/libpkg/repo/binary/update.c
@@ -387,7 +387,7 @@ pkg_repo_binary_add_from_manifest(const char *buf, sqlite3 *sqlite, size_t len,
 	}
 
 	if (pkg->digest == NULL || !pkg_checksum_is_valid(pkg->digest, strlen(pkg->digest)))
-		pkg_checksum_calculate(pkg, NULL);
+		pkg_checksum_calculate(pkg, NULL, false);
 	abi = pkg->abi != NULL ? pkg->abi : pkg->arch;
 	if (abi == NULL || !is_valid_abi(abi, true)) {
 		rc = EPKG_FATAL;

--- a/src/query.c
+++ b/src/query.c
@@ -76,6 +76,7 @@ static struct query_flags accepted_query_flags[] = {
 	{ 't', "",		0, PKG_LOAD_BASIC },
 	{ 'R', "",              0, PKG_LOAD_ANNOTATIONS },
 	{ 'V', "",		0, PKG_LOAD_BASIC },
+	{ 'X', "",		0, PKG_LOAD_BASIC | PKG_LOAD_SCRIPTS | PKG_LOAD_LUA_SCRIPTS },
 };
 
 static void
@@ -298,6 +299,9 @@ format_str(struct pkg *pkg, UT_string *dest, const char *qstr, const void *data)
 			case 'V':
 				pkg_get(pkg, PKG_VITAL, &vital);
 				utstring_printf(dest, "%d", vital);
+				break;
+			case 'X':
+				pkg_utstring_printf(dest, "%X", pkg);
 				break;
 			case '%':
 				utstring_printf(dest, "%c", '%');


### PR DESCRIPTION
In addition to the normal checksum used internally we also add the scripts
and lua scripts to the calculation.
This is mostly used for pkgbase where we need to know when only the scripts
have changed to bump the package version.

Signed-off-by: Emmanuel Vadot <manu@FreeBSD.org>