### PR TITLE
Add trailing / to install directories

### DIFF
--- a/docs/Makefile.autosetup
+++ b/docs/Makefile.autosetup
@@ -67,9 +67,9 @@ install:
 	install -d $(DESTDIR)$(mandir)/man3
 	install -d $(DESTDIR)$(mandir)/man5
 	install -d $(DESTDIR)$(mandir)/man8
-	install -m 644 *.3.gz $(DESTDIR)$(mandir)/man3
-	install -m 644 *.5.gz $(DESTDIR)$(mandir)/man5
-	install -m 644 *.8.gz $(DESTDIR)$(mandir)/man8
+	install -m 644 *.3.gz $(DESTDIR)$(mandir)/man3/
+	install -m 644 *.5.gz $(DESTDIR)$(mandir)/man5/
+	install -m 644 *.8.gz $(DESTDIR)$(mandir)/man8/
 	ln -sf pkg-delete.8.gz $(DESTDIR)$(mandir)/man8/pkg-remove.8.gz
 	ln -sf pkg.8.gz $(DESTDIR)$(mandir)/man8/pkg-static.8.gz
 	ln -sf pkg-lock.8.gz $(DESTDIR)$(mandir)/man8/pkg-unlock.8.gz

--- a/libpkg/Makefile.autosetup
+++ b/libpkg/Makefile.autosetup
@@ -175,4 +175,4 @@ install: all pkg.h lib$(LIB)$(LIBSOEXT) lib$(LIB).a
 	ln -sf lib$(LIB)$(LIBSOEXT) $(DESTDIR)$(libdir)/lib$(LIB)$(SH_SOEXT)
 	install -m 644 lib$(LIB).a $(DESTDIR)$(libdir)/
 	install -m 644 pkg.h $(DESTDIR)$(includedir)/
-	install -m 644 pkg.pc $(DESTDIR)$(pkgconfigdir)
+	install -m 644 pkg.pc $(DESTDIR)$(pkgconfigdir)/

--- a/scripts/Makefile.autosetup
+++ b/scripts/Makefile.autosetup
@@ -31,13 +31,13 @@ install: $(PDAILY) $(PSECURITY) $(PWEEKLY) $(COMPLETION)
 	install -d -m 755 $(DESTDIR)$(bashcompdir)
 	install -d -m 755 $(DESTDIR)$(zshcompdir)
 	for script in $(PDAILY); do \
-		install -m 755 $$script $(DESTDIR)$(pdailydir) ; \
+		install -m 755 $$script $(DESTDIR)$(pdailydir)/ ; \
 	done
 	for script in $(PSECURITY); do \
-		install -m 755 $$script $(DESTDIR)$(psecuritydir) ; \
+		install -m 755 $$script $(DESTDIR)$(psecuritydir)/ ; \
 	done
 	for script in $(PWEEKLY); do \
-		install -m 755 $$script $(DESTDIR)$(pweeklydir) ; \
+		install -m 755 $$script $(DESTDIR)$(pweeklydir)/ ; \
 	done
 	install -m 644 completion/_pkg.bash $(DESTDIR)$(bashcompdir)/
 	install -m 644 completion/_pkg  $(DESTDIR)$(zshcompdir)/

--- a/src/Makefile.autosetup
+++ b/src/Makefile.autosetup
@@ -105,7 +105,7 @@ $(PROG): $(top_builddir)/libpkg/libpkg_flat.a
 install: $(PROG)
 	install -d -m 755 $(DESTDIR)$(sbindir)
 	install -m 755 pkg $(DESTDIR)$(sbindir)/pkg
-	install -m 644 pkg.conf.sample $(DESTDIR)$(etcdir)
+	install -m 644 pkg.conf.sample $(DESTDIR)$(etcdir)/
 
 clean: clean-pkg-static
 clean-pkg-static:


### PR DESCRIPTION
Otherwise, if the destination directory does not exist for some reason
we can end up installing a file as the desired directory name.  Now we
will produce an error for the missing directory instead.