### PR TITLE
Add FreeBSD:13:powerpc64le.

### DIFF
--- a/external/libelf/_libelf_config.h
+++ b/external/libelf/_libelf_config.h
@@ -91,6 +91,16 @@
 #endif
 #define	LIBELF_CLASS		ELFCLASS32
 
+#elif defined(__powerpc64__)
+
+#define LIBELF_ARCH EM_PPC64
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#define LIBELF_BYTEORDER ELFDATA2LSB
+#else
+#define LIBELF_BYTEORDER ELFDATA2MSB
+#endif
+#define LIBELF_CLASS ELFCLASS64
+
 #elif	defined(__powerpc__)
 
 #define	LIBELF_ARCH		EM_PPC

--- a/libpkg/pkg_elf.c
+++ b/libpkg/pkg_elf.c
@@ -1046,6 +1046,14 @@ pkg_get_myarch_elfparse(char *dest, size_t sz, struct os_info *oi)
 		    arch, wordsize_corres_str, abi);
 		break;
 #endif
+	case EM_PPC:
+	case EM_PPC64:
+		endian_corres_str = elf_corres_to_string(endian_corres,
+		    (int)elfhdr.e_ident[EI_DATA]);
+
+		snprintf(dest + strlen(dest), sz - strlen(dest), ":%s:%s:%s",
+		    arch, wordsize_corres_str, endian_corres_str);
+		break;
 	default:
 		snprintf(dest + strlen(dest), sz - strlen(dest), ":%s:%s",
 		    arch, wordsize_corres_str);

--- a/libpkg/private/elf_tables.h
+++ b/libpkg/private/elf_tables.h
@@ -87,8 +87,9 @@ struct arch_trans {
 static struct arch_trans machine_arch_translation[] = {
 	{ "x86:32", "i386" },
 	{ "x86:64", "amd64" },
-	{ "powerpc:32", "powerpc" },
-	{ "powerpc:64", "powerpc64" },
+	{ "powerpc:32:eb", "powerpc" },
+	{ "powerpc:64:eb", "powerpc64" },
+	{ "powerpc:64:el", "powerpc64le" },
 	{ "sparc64:64", "sparc64" },
 	{ "ia64:64", "ia64" },
 	/* All the ARM stuff */


### PR DESCRIPTION
Notes:

* The libelf changes are in base already, and I sent them to elftoolchain-devlopers yesterday.
* Needs `-DSQLITE_BYTEORDER=1234` in CFLAGS when building natively due to sqlite3 not detecting powerpc64le currently.