### PR TITLE
Handle error fetching git hash/dirty state

### DIFF
--- a/auto.def
+++ b/auto.def
@@ -35,9 +35,9 @@ define LIBVERSION 4
 define LIBSOEXT [format [get-define SH_SOEXTVER] [get-define LIBVERSION]]
 
 define GITHASH ""
-if {[cc-check-progs git] && [file exists .git]} {
-	catch {exec git rev-parse --short HEAD} gitrev
-	catch {exec git diff-index -m --name-only HEAD} gitdirty
+if {[cc-check-progs git] && [file exists .git] &&
+    ![catch {exec git rev-parse --short HEAD} gitrev] &&
+    ![catch {exec git diff-index -m --name-only HEAD} gitdirty]} {
 	define GITHASH -$gitrev[expr {$gitdirty eq {} ? {} : {-dirty}}]
 }
 


### PR DESCRIPTION
When git was installed and .git existed but was not usable for some
reason the build failed with a confusing error due to GITHASH being
set to "-fatal: not a git repository: <path>".

Check the return value from git commands and leave GITHASH empty if
non-zero.

Issue #1889 