### PR TITLE
Prevent potential hang with scripts (take 3)

### DIFF
--- a/libpkg/private/pkg.h
+++ b/libpkg/private/pkg.h
@@ -729,6 +729,7 @@ int pkg_start_stop_rc_scripts(struct pkg *, pkg_rc_attr attr);
 int pkg_script_run(struct pkg *, pkg_script type, bool upgrade);
 int pkg_lua_script_run(struct pkg *, pkg_lua_script type, bool upgrade);
 ucl_object_t *pkg_lua_script_to_ucl(struct pkg_lua_script *);
+int pkg_script_run_child(int pid, int *pstat, int inputfd, const char* script_name);
 
 int pkg_open2(struct pkg **p, struct archive **a, struct archive_entry **ae,
 	      const char *path, struct pkg_manifest_key *keys, int flags, int fd);


### PR DESCRIPTION
@juikim last tried to fix this in #1843.  However, we're still having problems with hangs from pkg when background processes remain and hold `PKG_MSGFD` open.

When I looked at the code in `pkg_run_scripts()`, I found several problems:

 * `getline()` is used to read input, this will hang if input is not terminated with LF.
 * The code handles the ordering of testing process termination and input availability incorrectly.  If a script starts a daemon that holds `PKG_MSGFD` open and exits, the code will fall into `getline()` and wait forever.
 * The `line`/`linecap` variables allocated the input line buffer only once at the start of the loop; longer lines in input after that wouldn't have been completely read by `getline()`.

I reworked the code to check `waitpid()`, then check for input, then read any input, then continue or terminate the loop.  Now, it will wait and read any input until the child exits, then it will read any available input but not wait.  Once the child has terminated and we know that from `waitpid()`, any leftover output from the child will be buffered in kernel and immediately available; once we have read that we can exit the loop.  It also removes use of stdio and line blocking for the input reads.

One minor point:  I looked at `pkg_emit_msg()` and the event code and I saw no obvious requirement that the message needs to be terminated by an LF.  Is this correct?

I also added a test to verify this issue and the fix.
