### PR TITLE
Remove autodeps from the example

### DIFF
--- a/docs/pkg.conf.5
+++ b/docs/pkg.conf.5
@@ -572,7 +572,6 @@ repos_dir: [
      "/usr/local/etc/pkg/repos",
 ]
 syslog: true
-autodeps: true
 developer_mode: false
 pkg_env: {
     http_proxy: "http://myproxy:3128",


### PR DESCRIPTION
This property has been removed in 792a178d6d33bf711074bd858ea8c486331df1f0.

While here, we might also want to get rid of https://github.com/freebsd/pkg/blob/master/autosetup/system.tcl#L276.

Bugzilla: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=245554