### PR TITLE
Faster pkg query -F

### DIFF
--- a/src/query.c
+++ b/src/query.c
@@ -937,8 +937,26 @@ exec_query(int argc, char **argv)
 		return (EX_USAGE);
 
 	if (pkgname != NULL) {
+		/* Use a manifest or compact manifest if possible. */
+		int open_flags = 0;
+		if ((query_flags & ~(PKG_LOAD_DEPS|
+				     PKG_LOAD_OPTIONS|
+				     PKG_LOAD_CATEGORIES|
+				     PKG_LOAD_LICENSES|
+				     PKG_LOAD_USERS|
+				     PKG_LOAD_GROUPS|
+				     PKG_LOAD_SHLIBS_REQUIRED|
+				     PKG_LOAD_SHLIBS_PROVIDED|
+				     PKG_LOAD_ANNOTATIONS|
+				     PKG_LOAD_CONFLICTS|
+				     PKG_LOAD_PROVIDES|
+				     PKG_LOAD_REQUIRES)) == 0) {
+			open_flags = PKG_OPEN_MANIFEST_COMPACT;
+		} else if ((query_flags & PKG_LOAD_FILES) == 0) {
+			open_flags = PKG_OPEN_MANIFEST_ONLY;
+		}
 		pkg_manifest_keys_new(&keys);
-		if (pkg_open(&pkg, pkgname, keys, 0) != EPKG_OK) {
+		if (pkg_open(&pkg, pkgname, keys, open_flags) != EPKG_OK) {
 			return (EX_IOERR);
 		}
 

--- a/tests/frontend/query.sh
+++ b/tests/frontend/query.sh
@@ -31,6 +31,7 @@ files: {
 }
 EOF
 	atf_check -s exit:0 sh ${RESOURCEDIR}/test_subr.sh new_pkg plop plop 1
+	sed -ie 's/comment: a test/comment: Nothing to see here/' plop.ucl
 	cat >> plop.ucl << EOF
 deps: {
     test: {
@@ -40,6 +41,7 @@ deps: {
 
 }
 EOF
+	cat plop.ucl
 
 	atf_check \
 		-o match:".*Installing.*" \
@@ -133,4 +135,47 @@ EOF
 		-e empty \
 		-s exit:0 \
 		test "${sum1}" = "${sum2}"
+
+	# Test 'pkg query -F'
+	atf_check \
+		-o empty \
+		-e empty \
+		-s exit:0 \
+		pkg create -M plop.ucl
+
+	atf_check \
+		-o inline:"${TMPDIR}/plop\n${TMPDIR}/bla\n" \
+		-e empty \
+		-s exit:0 \
+		pkg query -F ./test-1.txz '%Fp'
+
+	atf_check \
+		-o inline:"1\n" \
+		-e empty \
+		-s exit:0 \
+		pkg query -F ./test-1.txz '%?F'
+
+	atf_check \
+		-o inline:"2\n" \
+		-e empty \
+		-s exit:0 \
+		pkg query -F ./test-1.txz '%#F'
+
+	atf_check \
+		-o inline:"test 1\n" \
+		-e empty \
+		-s exit:0 \
+		pkg query -F ./test-1.txz '%n %v'
+
+	atf_check \
+		-o inline:"a test\n" \
+		-e empty \
+		-s exit:0 \
+		pkg query -F ./test-1.txz '%c'
+
+	atf_check \
+		-o inline:"Nothing to see here\n" \
+		-e empty \
+		-s exit:0 \
+		pkg query -F ./plop-1.txz '%c'
 }


### PR DESCRIPTION
Here's another thing I found in my repo, which I'd forgotten about:  changes to make `pkg query -F ...` faster.  It does this by setting flags to `pkg_open()` appropriately.  Our build does this...a lot.
