### PR TITLE
Fix fetching of local repo's (file://) meta.conf

### DIFF
--- a/libpkg/pkg_repo.c
+++ b/libpkg/pkg_repo.c
@@ -793,6 +793,8 @@ pkg_repo_fetch_meta(struct pkg_repo *repo, time_t *t)
 			return (EPKG_FATAL);
 		}
 		goto load_meta;
+	} else if (rc == EPKG_UPTODATE) {
+		return (EPKG_UPTODATE);
 	}
 
 	/* TODO: remove this backward compatibility some day */

--- a/libpkg/repo/binary/update.c
+++ b/libpkg/repo/binary/update.c
@@ -624,8 +624,8 @@ pkg_repo_binary_update(struct pkg_repo *repo, bool force)
 
 		snprintf(filepath, sizeof(filepath), "%s/%s", ctx.dbdir,
 			pkg_repo_binary_get_filename(pkg_repo_name(repo)));
-		if (stat(filepath, &st) != -1) {
-			if (!got_meta && !force)
+		if (got_meta && stat(filepath, &st) != -1) {
+			if (!force)
 				t = st.st_mtime;
 		}
 	}


### PR DESCRIPTION
There were two issues here:

1.) pkg_repo_fetch_meta did not handle EPKG_UPTODATE and instead fell back to trying meta.txz -- which failed, because I started using .tzst locally. This fixes #1886, which is the same issue reported by RhToad in #bsdports recently.

2.) If the meta got blown away, we should re-fetch it regardless of the timestamp on the database. The repo update then proceeds as it normally would. I chased my tail on this one for a little bit when I was trying to test the first, because it absolutely refused to re-fetch the meta.conf after I blew it away.