### PR TITLE
libpkg: open up rootfd for old package cleanup on upgrade

### DIFF
--- a/libpkg/pkg_add.c
+++ b/libpkg/pkg_add.c
@@ -1161,6 +1161,7 @@ pkg_add_common(struct pkgdb *db, const char *path, unsigned flags,
 	}
 
 	if (local != NULL) {
+		pkg_open_root_fd(local);
 		pkg_debug(1, "Cleaning up old version");
 		if (pkg_add_cleanup_old(db, local, pkg, flags) != EPKG_OK) {
 			retcode = EPKG_FATAL;


### PR DESCRIPTION
Otherwise, if there's a lua script involved (e.g. @shell), it won't be able
to open any files because rootfd == -1.

This fixes a problem reported doing `pkg upgrade git`.

Signed-off-by: Kyle Evans <kevans@FreeBSD.org>