### PR TITLE
Fix issue #1842.

### DIFF
--- a/libpkg/pkg_jobs.c
+++ b/libpkg/pkg_jobs.c
@@ -768,7 +768,7 @@ pkg_jobs_process_remote_pkg(struct pkg_jobs *j, struct pkg *rp,
 				}
 			}
 			/* Also process all rdeps recursively */
-			while (pkg_rdeps(nrit->pkg, &rdep) == EPKG_OK) {
+			while (pkg_rdeps(nit->pkg, &rdep) == EPKG_OK) {
 				lp = pkg_jobs_universe_get_local(j->universe, rdep->uid, 0);
 
 				if (lp) {


### PR DESCRIPTION
Not 100% that this is correct, but nrit is null when it gets called here so I think it is probably a typo.