### PR TITLE
libpkg/pkg_elf.c: downgrade error to warning 

### DIFF
--- a/libpkg/pkg_elf.c
+++ b/libpkg/pkg_elf.c
@@ -284,7 +284,7 @@ analyse_elf(struct pkg *pkg, const char *fpath)
 
 	if ((e = elf_begin(fd, ELF_C_READ, NULL)) == NULL) {
 		ret = EPKG_FATAL;
-		pkg_emit_error("elf_begin() for %s failed: %s", fpath,
+		pkg_debug(1, "elf_begin() for %s failed: %s", fpath,
 		    elf_errmsg(-1));
 		goto cleanup;
 	}


### PR DESCRIPTION
Downgrade error to warning for elf_begin().
Fixes #1892 