### PR TITLE
libpkg/pkg_add.c: Do not execute post-install script when extract fails

### DIFF
--- a/libpkg/pkg_add.c
+++ b/libpkg/pkg_add.c
@@ -1174,8 +1174,7 @@ pkg_add_common(struct pkgdb *db, const char *path, unsigned flags,
 	pkgdb_update_config_file_content(pkg, db->sqlite);
 
 	retcode = pkg_extract_finalize(pkg);
-cleanup_reg:
-	pkgdb_register_finale(db, retcode, NULL);
+
 	/*
 	 * Execute post install scripts
 	 */
@@ -1243,7 +1242,9 @@ cleanup_reg:
 		xstring_free(message);
 	}
 
-	cleanup:
+cleanup_reg:
+	pkgdb_register_finale(db, retcode, NULL);
+cleanup:
 	if (a != NULL) {
 		archive_read_close(a);
 		archive_read_free(a);

--- a/libpkg/pkg_elf.c
+++ b/libpkg/pkg_elf.c
@@ -284,7 +284,7 @@ analyse_elf(struct pkg *pkg, const char *fpath)
 
 	if ((e = elf_begin(fd, ELF_C_READ, NULL)) == NULL) {
 		ret = EPKG_FATAL;
-		pkg_emit_error("elf_begin() for %s failed: %s", fpath,
+		pkg_debug(1, "elf_begin() for %s failed: %s", fpath,
 		    elf_errmsg(-1));
 		goto cleanup;
 	}


### PR DESCRIPTION
Fixes #1885 
