### PR TITLE
libpkg/pkg_add.c: no execute post-install script when extract fails

### DIFF
--- a/libpkg/pkg_add.c
+++ b/libpkg/pkg_add.c
@@ -1156,7 +1156,8 @@ pkg_add_common(struct pkgdb *db, const char *path, unsigned flags,
 
 			pkg_rollback_pkg(pkg);
 			pkg_delete_dirs(db, pkg, NULL);
-			goto cleanup_reg;
+			pkgdb_register_finale(db, retcode, NULL);
+			goto cleanup;
 		}
 	}
 
@@ -1174,7 +1175,7 @@ pkg_add_common(struct pkgdb *db, const char *path, unsigned flags,
 	pkgdb_update_config_file_content(pkg, db->sqlite);
 
 	retcode = pkg_extract_finalize(pkg);
-cleanup_reg:
+
 	pkgdb_register_finale(db, retcode, NULL);
 	/*
 	 * Execute post install scripts
@@ -1243,7 +1244,7 @@ cleanup_reg:
 		xstring_free(message);
 	}
 
-	cleanup:
+cleanup:
 	if (a != NULL) {
 		archive_read_close(a);
 		archive_read_free(a);


### PR DESCRIPTION
Originally, post-install script is executed even when extraction fails. (Is this intended?)
However, it seems that it should only be executed when extract succeeded.
Cleaned up code logic and indentation, now in case of a failed extraction only do the cleanup and rollback on database register. 
Fixes #1885 