### PR TITLE
Fix daemon hang error handling

### DIFF
--- a/libpkg/Makefile.autosetup
+++ b/libpkg/Makefile.autosetup
@@ -154,7 +154,7 @@ $(OBJS) $(SHOBJS): $(top_builddir)/pkg_config.h
 all: lib$(LIB)_flat.a
 
 @if libmachista
-lib$(LIB)_flat.a:
+lib$(LIB)_flat.a: $(STATIC_LIBS)
 	libtool -static -o lib$(LIB)_flat.a $(STATIC_LIBS)
 @else
 lib$(LIB)_flat.a: mergelib_script


### PR DESCRIPTION
I tried CI on MacOS, which found a Mac-specific problem with ECONNRESET, and I saw a potential spin on EAGAIN for all platforms (not sure why this doesn't happen, actually).  Also some minor style cleanup.
