### PR TITLE
Explicit warning when root is needed to upgrade DB

### DIFF
--- a/libpkg/pkgdb.c
+++ b/libpkg/pkgdb.c
@@ -2510,8 +2510,14 @@ get_pragma(sqlite3 *s, const char *sql, int64_t *res, bool silence)
 
 	pkg_debug(4, "Pkgdb: running '%s'", sql);
 	if (sqlite3_prepare_v2(s, sql, -1, &stmt, NULL) != SQLITE_OK) {
-		if (!silence)
-			ERROR_SQLITE(s, sql);
+		if (!silence) {
+			if(geteuid() != 0) {
+				pkg_emit_error("Database upgrade is needed but pkg doesn't have write access in file %s:%d: %s, "
+					"please run it as root once to upgrade the DB.", __FILE__, __LINE__, sqlite3_errmsg(s));
+			} else {
+				ERROR_SQLITE(s, sql);
+			}
+		}
 		return (EPKG_OK);
 	}
 

--- a/libpkg/repo/binary/init.c
+++ b/libpkg/repo/binary/init.c
@@ -85,7 +85,12 @@ pkg_repo_binary_get_user_version(sqlite3 *sqlite, int *reposcver)
 	const char *sql = "PRAGMA user_version;";
 
 	if (sqlite3_prepare_v2(sqlite, sql, -1, &stmt, NULL) != SQLITE_OK) {
-		ERROR_SQLITE(sqlite, sql);
+		if(geteuid() != 0) {
+			pkg_emit_error("Database upgrade is needed but pkg doesn't have write access in file %s:%d: %s, "
+			    "please run it as root once to upgrade the DB.", __FILE__, __LINE__, sqlite3_errmsg(sqlite));
+		} else {
+			ERROR_SQLITE(sqlite, sql);
+		}
 		return (EPKG_FATAL);
 	}
 


### PR DESCRIPTION
Prints an explicit warning when errmsg has the substring "readonly".  
Fixes #1771 