### PR TITLE
Fixes for "pkg create" error handling on reading files

### DIFF
--- a/libpkg/pkg_create.c
+++ b/libpkg/pkg_create.c
@@ -95,6 +95,12 @@ pkg_create_from_dir(struct pkg *pkg, const char *root,
 			return (EPKG_FATAL);
 		}
 
+		if (!(S_ISREG(st.st_mode) || S_ISLNK(st.st_mode))) {
+			pkg_emit_error("file '%s' is not a regular file", fpath);
+			kh_destroy_hardlinks(hardlinks);
+			return (EPKG_FATAL);
+		}
+
 		if (file->size == 0)
 			file->size = (int64_t)st.st_size;
 

--- a/tests/frontend/create.sh
+++ b/tests/frontend/create.sh
@@ -15,6 +15,7 @@ tests_init \
 	create_from_plist_with_keyword_arguments \
 	create_from_manifest_and_plist \
 	create_from_manifest \
+	create_from_manifest_dir \
 	create_from_plist_pkg_descr \
 	create_from_plist_hash \
 	create_from_plist_with_keyword_and_message \
@@ -539,6 +540,24 @@ EOF
 		-e empty \
 		-s exit:0 \
 		pkg info -R --raw-format=ucl -F test-1.txz
+}
+
+create_from_manifest_dir_body() {
+	genmanifest
+	cat <<EOF >> +MANIFEST
+files: {
+     /testfile: {perm: 0644}
+     /testdir: {perm: 0644}
+}
+EOF
+	touch testfile
+	mkdir testdir
+	atf_check \
+		-o empty \
+		-e not-empty \
+		-s not-exit:0 \
+		pkg create -M ./+MANIFEST -r ${TMPDIR}
+
 }
 
 create_from_plist_pkg_descr_body() {

--- a/tests/frontend/create.sh
+++ b/tests/frontend/create.sh
@@ -14,6 +14,7 @@ tests_init \
 	create_from_plist_fflags create_from_plist_bad_fflags \
 	create_from_plist_with_keyword_arguments \
 	create_from_manifest_and_plist \
+	create_from_manifest \
 	create_from_plist_pkg_descr \
 	create_from_plist_hash \
 	create_from_plist_with_keyword_and_message \
@@ -469,6 +470,48 @@ create_from_manifest_and_plist_body() {
 		-e empty \
 		-s exit:0 \
 		pkg create -M ./+MANIFEST -p test.plist -r ${TMPDIR}
+
+	cat << EOF > output.ucl
+name = "test";
+origin = "test";
+version = "1";
+comment = "a test";
+maintainer = "test";
+www = "http://test";
+abi = "*";
+arch = "*";
+prefix = "/";
+flatsize = 0;
+desc = "Yet another test";
+categories [
+    "test",
+]
+files {
+    /testfile = "1\$e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+}
+
+EOF
+
+	atf_check \
+		-o file:output.ucl \
+		-e empty \
+		-s exit:0 \
+		pkg info -R --raw-format=ucl -F test-1.txz
+}
+
+create_from_manifest_body() {
+	genmanifest
+	cat <<EOF >> +MANIFEST
+files: {
+     /testfile: {perm: 0644}
+}
+EOF
+	touch testfile
+	atf_check \
+		-o empty \
+		-e empty \
+		-s exit:0 \
+		pkg create -M ./+MANIFEST -r ${TMPDIR}
 
 	cat << EOF > output.ucl
 name = "test";


### PR DESCRIPTION
I found two issues:
 * a lack of error handling on file reads when checksumming files for a package
 * if a file in a manifest was actually a directory, pkg would not catch that, and the above error would cause a SIGBUS

This PR includes tests to show the issues and fixes for them.
