### PR TITLE
audit: fix --quiet/-q behavior.

### DIFF
--- a/src/audit.c
+++ b/src/audit.c
@@ -471,15 +471,18 @@ exec_audit(int argc, char **argv)
 		if (ret == EPKG_END && vuln == 0)
 			ret = EXIT_SUCCESS;
 
-		if (top == NULL && !quiet) {
-			printf("%u problem(s) in %u installed package(s) found.\n",
-			   affected, vuln);
-	
+		if (top == NULL) {
+			if (!quiet) {
+				printf("%u problem(s) in %u installed package(s) found.\n",
+				affected, vuln);
+			}
 		} else {
-			ucl_object_insert_key(top, ucl_object_fromint(vuln), "pkg_count", 9, false );
-			ucl_object_insert_key(top, vuln_objs, "packages", 8, false);
-			fprintf(stdout, "%s\n", ucl_object_emit(top, raw));
-			ucl_object_unref(top);
+			if (!quiet || vuln > 0) {
+				ucl_object_insert_key(top, ucl_object_fromint(vuln), "pkg_count", 9, false );
+				ucl_object_insert_key(top, vuln_objs, "packages", 8, false);
+				fprintf(stdout, "%s\n", ucl_object_emit(top, raw));
+				ucl_object_unref(top);
+			}
 		}
 	} else {
 		warnx("cannot process vulnxml");


### PR DESCRIPTION
After Commit 3f8834c121a6be5464a71c57dc9d8c9e99276f49, pkg started to show
"(null)" even with --quiet option is set and no vulnerable packages.

Let me make pkg print something with --quiet only if there is vulnerable
packages.