### PR TITLE
pkg-upgrade: don't attempt to install packages matching pattern

### DIFF
--- a/tests/Makefile.autosetup
+++ b/tests/Makefile.autosetup
@@ -44,6 +44,7 @@ TESTS_SH= \
 	frontend/vital.sh \
 	frontend/update.sh \
 	frontend/updating.sh \
+	frontend/upgrade.sh \
 	frontend/issue1374.sh \
 	frontend/issue1425.sh \
 	frontend/issue1440.sh \

--- a/tests/frontend/upgrade.sh
+++ b/tests/frontend/upgrade.sh
@@ -1,0 +1,120 @@
+#! /usr/bin/env atf-sh
+
+. $(atf_get_srcdir)/test_environment.sh
+
+tests_init \
+	issue1881 \
+	issue1881_newdep
+
+issue1881_body() {
+	atf_check -s exit:0 sh ${RESOURCEDIR}/test_subr.sh new_pkg pkg1 pkg_a 1
+	atf_check -s exit:0 sh ${RESOURCEDIR}/test_subr.sh new_pkg pkg2 pkg_a 1_1
+
+	atf_check -s exit:0 sh ${RESOURCEDIR}/test_subr.sh new_pkg pkg3 pkg_b 1
+	atf_check -s exit:0 sh ${RESOURCEDIR}/test_subr.sh new_pkg pkg4 pkg_b 1_1
+
+	atf_check \
+		-o match:".*Installing.*\.\.\.$" \
+		-e empty \
+		-s exit:0 \
+		pkg register -M pkg1.ucl
+
+	atf_check \
+		-o ignore \
+		-e empty \
+		-s exit:0 \
+		pkg create -M ./pkg3.ucl
+
+	atf_check \
+		-o ignore \
+		-e empty \
+		-s exit:0 \
+		pkg create -M ./pkg2.ucl
+
+	atf_check \
+		-o ignore \
+		-e empty \
+		-s exit:0 \
+		pkg create -M ./pkg4.ucl
+
+	atf_check \
+		-o inline:"Creating repository in .:  done\nPacking files for repository:  done\n" \
+		-e empty \
+		-s exit:0 \
+		pkg repo .
+
+	mkdir repoconf
+	cat << EOF > repoconf/repo.conf
+local: {
+	url: file:///$TMPDIR,
+	enabled: true
+}
+EOF
+
+	atf_check \
+		-o not-match:"^[[:space:]]+pkg_b: 1$" \
+		-e ignore \
+		-s exit:0 \
+		pkg -o REPOS_DIR="$TMPDIR/repoconf" -o PKG_CACHEDIR="$TMPDIR" upgrade -yx '^pkg_'
+}
+
+issue1881_newdep_body() {
+	atf_check -s exit:0 sh ${RESOURCEDIR}/test_subr.sh new_pkg pkg1 pkg_a 1
+	atf_check -s exit:0 sh ${RESOURCEDIR}/test_subr.sh new_pkg pkg2 pkg_a 1_1
+
+	atf_check -s exit:0 sh ${RESOURCEDIR}/test_subr.sh new_pkg pkg3 pkg_b 1
+	atf_check -s exit:0 sh ${RESOURCEDIR}/test_subr.sh new_pkg pkg4 pkg_b 1_1
+
+	cat <<EOF >> ./pkg2.ucl
+deps: {
+	pkg_b: {
+		origin: "wedontcare",
+		version: "1"
+	}
+}
+EOF
+
+	atf_check \
+		-o match:".*Installing.*\.\.\.$" \
+		-e empty \
+		-s exit:0 \
+		pkg register -M pkg1.ucl
+
+	atf_check \
+		-o ignore \
+		-e empty \
+		-s exit:0 \
+		pkg create -M ./pkg3.ucl
+
+	atf_check \
+		-o ignore \
+		-e empty \
+		-s exit:0 \
+		pkg create -M ./pkg2.ucl
+
+	atf_check \
+		-o ignore \
+		-e empty \
+		-s exit:0 \
+		pkg create -M ./pkg4.ucl
+
+	atf_check \
+		-o inline:"Creating repository in .:  done\nPacking files for repository:  done\n" \
+		-e empty \
+		-s exit:0 \
+		pkg repo .
+
+	mkdir repoconf
+	cat << EOF > repoconf/repo.conf
+local: {
+	url: file:///$TMPDIR,
+	enabled: true
+}
+EOF
+
+	atf_check \
+		-o match:"^[[:space:]]+pkg_b: 1_1$" \
+		-e ignore \
+		-s exit:0 \
+		pkg -o REPOS_DIR="$TMPDIR/repoconf" -o PKG_CACHEDIR="$TMPDIR" upgrade -yx '^pkg_'
+}


### PR DESCRIPTION
As described in issue #1881, `pkg upgrade -x '^FreeBSD-kernel'` for instance will attempt to install all of the kernels that I haven't installed locally as well as upgrading any that are out of date. The root of the issue is that pkg_jobs_find_remote_pattern() just checks that we've installed any package that matches the pattern, and pkg_jobs_find_upgrade() would not filter out packages that weren't installed from the initial upgrade query.

Do this now. Newly-added dependencies should still get added as needed as those are pulled in deeper down, rather than at the top-level. The tests demonstrate this.

Fixes #1881