### PR TITLE
pkg-repo: start accepting key files prefixed with "rsa:"

### DIFF
--- a/docs/pkg-repo.8
+++ b/docs/pkg-repo.8
@@ -14,7 +14,7 @@
 .\"
 .\"     @(#)pkg.8
 .\"
-.Dd November 5, 2020
+.Dd January 17, 2021
 .Dt PKG-REPO 8
 .Os
 .Sh NAME
@@ -25,13 +25,13 @@
 .Op Fl lq
 .Op Fl m Ar meta-file
 .Op Fl o Ar output-dir
-.Ao Ar repo-path Ac Op Ao Ar rsa-key Ac | signing_command: Ao Ar the command Ac
+.Ao Ar repo-path Ac Op rsa: Ns Ao Ar rsa-key Ac | signing_command: Ao Ar the command Ac
 .Pp
 .Nm
 .Op Cm --{list-files,quiet}
 .Op Cm --meta-file Ar meta-file
 .Op Cm --output-dir Ar output-dir
-.Ao Ar repo-path Ac Op Ao Ar rsa-key Ac | signing_command: Ao Ar the command Ac
+.Ao Ar repo-path Ac Op rsa: Ns Ao Ar rsa-key Ac | signing_command: Ao Ar the command Ac
 .Sh DESCRIPTION
 .Nm
 is used to create a catalogue of the available

--- a/libpkg/pkg_repo_create.c
+++ b/libpkg/pkg_repo_create.c
@@ -982,6 +982,8 @@ pkg_finish_repo(const char *output_dir, pkg_password_cb *password_cb,
 {
 	char repo_path[MAXPATHLEN];
 	char repo_archive[MAXPATHLEN];
+	char *key_file;
+	const char *key_type;
 	struct rsa_key *rsa = NULL;
 	struct pkg_repo_meta *meta;
 	struct stat st;
@@ -994,7 +996,16 @@ pkg_finish_repo(const char *output_dir, pkg_password_cb *password_cb,
 	}
 
 	if (argc == 1) {
-		rsa_new(&rsa, password_cb, argv[0]);
+		key_type = key_file = argv[0];
+		if (strncmp(key_file, "rsa:", 4) == 0) {
+			key_file += 4;
+			*(key_file - 1) = '\0';
+		} else {
+			key_type = "rsa";
+		}
+
+		pkg_debug(1, "Loading %s key from '%s' for signing", key_type, key_file);
+		rsa_new(&rsa, password_cb, key_file);
 	}
 
 	if (argc > 1 && strcmp(argv[0], "signing_command:") != 0)

--- a/src/repo.c
+++ b/src/repo.c
@@ -51,7 +51,7 @@ void
 usage_repo(void)
 {
 	fprintf(stderr, "Usage: pkg repo [-lqL] [-o output-dir] <repo-path> "
-	    "[<rsa-key>|signing_command: <the command>]\n\n");
+	    "[rsa:<rsa-key>|signing_command: <the command>]\n\n");
 	fprintf(stderr, "For more information see 'pkg help repo'.\n");
 }
 

--- a/tests/frontend/pubkey.sh
+++ b/tests/frontend/pubkey.sh
@@ -3,9 +3,53 @@
 . $(atf_get_srcdir)/test_environment.sh
 
 tests_init \
-	pubkey
+	pubkey \
+	pubkey_legacy
 
+# New format, prefix the key type
 pubkey_body() {
+	atf_check -o ignore -e ignore \
+		openssl genrsa -out repo.key 2048
+	chmod 0400 repo.key
+	atf_check -o ignore -e ignore \
+		openssl rsa -in repo.key -out repo.pub -pubout
+	mkdir fakerepo
+
+	cat >> test.ucl << EOF
+name: test
+origin: test
+version: "1"
+maintainer: test
+categories: [test]
+comment: a test
+www: http://test
+prefix: /
+abi = "*";
+desc: <<EOD
+Yet another test
+EOD
+EOF
+
+	atf_check -o ignore -e ignore \
+		pkg create -M test.ucl -o fakerepo
+	atf_check -o ignore -e ignore \
+		pkg repo fakerepo rsa:repo.key
+	cat >> repo.conf << EOF
+local: {
+	url: file:///${TMPDIR}/fakerepo
+	enabled: true
+	pubkey: ${TMPDIR}/repo.pub
+	signature_type: "pubkey"
+}
+EOF
+	atf_check \
+		-o ignore \
+		pkg -o REPOS_DIR="${TMPDIR}" \
+		-o ${PKG_CACHEDIR}="${TMPDIR}" update
+}
+
+# Legacy format, unprefixed key passed to pkg-repo
+pubkey_legacy_body() {
 	atf_check -o ignore -e ignore \
 		openssl genrsa -out repo.key 2048
 	chmod 0400 repo.key
@@ -45,3 +89,4 @@ EOF
 		pkg -o REPOS_DIR="${TMPDIR}" \
 		-o ${PKG_CACHEDIR}="${TMPDIR}" update
 }
+


### PR DESCRIPTION
Stop describing the old format anywhere, prefer that rsa: be specified going forward to ease transition to a world where pkg also accepts, for example, ed25519.