### PR TITLE
(WIP) Add ed25519 support

### DIFF
--- a/auto.def
+++ b/auto.def
@@ -135,6 +135,10 @@ foreach fct [list memmove usleep pread pwrite] {
 	}
 }
 
+cc-with { -includes openssl/evp.h } {
+	cc-check-decls EVP_PKEY_ED25519
+}
+
 cc-with { -includes fcntl.h } {
 	cc-check-decls F_CLOSEM
 }

--- a/libpkg/Makefile.autosetup
+++ b/libpkg/Makefile.autosetup
@@ -7,7 +7,8 @@ SRCS=	backup.c \
 	pkg_deps.c \
 	pkg_repo_meta.c \
 	pkg.c \
-	rsa.c \
+	pkgsign.c \
+	pkgsign_ossl.c \
 	clean_cache.c \
 	metalog.c \
 	pkg_checksum.c \

--- a/libpkg/pkg_repo_create.c
+++ b/libpkg/pkg_repo_create.c
@@ -996,9 +996,13 @@ pkg_finish_repo(const char *output_dir, pkg_password_cb *password_cb,
 	}
 
 	if (argc == 1) {
+		char *cpos;
+
 		key_type = key_file = argv[0];
-		if (strncmp(key_file, "rsa:", 4) == 0) {
-			key_file += 4;
+		cpos = strchr(key_file, ':');
+
+		if (cpos != NULL) {
+			key_file = cpos + 1;
 			*(key_file - 1) = '\0';
 		} else {
 			key_type = "rsa";

--- a/libpkg/pkg_repo_create.c
+++ b/libpkg/pkg_repo_create.c
@@ -936,12 +936,20 @@ pkg_repo_pack_db(const char *name, const char *archive, char *path,
 		return (EPKG_FATAL);
 
 	if (sctx != NULL) {
+		const char *sigtype;
+
 		if (pkgsign_sign(sctx, path, &sigret, &signature_len) != EPKG_OK) {
 			ret = EPKG_FATAL;
 			goto out;
 		}
 
 		if (packing_append_buffer(pack, sigret, "signature", signature_len + 1) != EPKG_OK) {
+			ret = EPKG_FATAL;
+			goto out;
+		}
+
+		sigtype = pkgsign_impl_name(sctx);
+		if (packing_append_buffer(pack, sigtype, "signature_type", strlen(sigtype)) != EPKG_OK) {
 			ret = EPKG_FATAL;
 			goto out;
 		}

--- a/libpkg/pkgsign.c
+++ b/libpkg/pkgsign.c
@@ -51,6 +51,12 @@ static struct pkgsign_impl {
 		.pi_name = "rsa",
 		.pi_ops = &pkgsign_ossl,
 	},
+#ifdef PKGSIGN_ED25519
+	{
+		.pi_name = "ed25519",
+		.pi_ops = &pkgsign_ossl,
+	},
+#endif
 };
 
 int
@@ -146,4 +152,11 @@ pkgsign_verify_cert(struct pkgsign_ctx *ctx, unsigned char *key, size_t keylen,
 
 	return (*ctx->impl->pi_ops->pkgsign_verify_cert)(ctx, key, keylen, sig,
 	    siglen, fd);
+}
+
+const char *
+pkgsign_impl_name(const struct pkgsign_ctx *ctx)
+{
+
+	return (ctx->impl->pi_name);
 }

--- a/libpkg/pkgsign.c
+++ b/libpkg/pkgsign.c
@@ -1,0 +1,149 @@
+/*-
+ * Copyright (c) 2021 Kyle Evans <kevans@FreeBSD.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer
+ *    in this position and unchanged.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <sys/cdefs.h>
+
+#include <assert.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "private/pkgsign.h"
+#include "xmalloc.h"
+
+/* Other parts of libpkg should use pkgsign instead of rsa directly. */
+extern const struct pkgsign_ops	pkgsign_ossl;
+
+/*
+ * The eventual goal is to allow plugins to register their own pkgsign
+ * implementations as needed.  The initial sketch was to add a constructor
+ * to register the builtin pkgsign implementations since there should only be
+ * a couple of them, but this is saved for later work.
+ */
+static struct pkgsign_impl {
+	const char			*pi_name;
+	const struct pkgsign_ops	*pi_ops;
+	int				 pi_refs; /* XXX */
+} pkgsign_builtins[] = {
+	{
+		.pi_name = "rsa",
+		.pi_ops = &pkgsign_ossl,
+	},
+};
+
+int
+pkgsign_new(const char *name, struct pkgsign_ctx **ctx)
+{
+	struct pkgsign_impl *impl;
+	const struct pkgsign_ops *ops;
+	struct pkgsign_ctx *nctx;
+	size_t ctx_size;
+	int ret;
+
+	assert(*ctx == NULL);
+
+	ops = NULL;
+	for (size_t i = 0; i < nitems(pkgsign_builtins); i++) {
+		impl = &pkgsign_builtins[i];
+		if (strcmp(name, impl->pi_name) == 0) {
+			ops = impl->pi_ops;
+			break;
+		}
+	}
+
+	if (ops == NULL)
+		return (ENOENT);
+
+	ctx_size = ops->pkgsign_ctx_size;
+	assert(ctx_size == 0 || ctx_size >= sizeof(struct pkgsign_ctx));
+	if (ctx_size == 0)
+		ctx_size = sizeof(struct pkgsign_ctx);
+
+	nctx = xcalloc(1, ctx_size);
+	nctx->impl = impl;
+
+	ret = 0;
+	if (ops->pkgsign_new != NULL)
+		ret = (*ops->pkgsign_new)(name, nctx);
+
+	if (ret != 0) {
+		free(nctx);
+		return (ret);
+	}
+
+	impl->pi_refs++;
+	*ctx = nctx;
+	return (0);
+}
+
+void
+pkgsign_set(struct pkgsign_ctx *sctx, pkg_password_cb *cb, char *keyfile)
+{
+
+	sctx->pw_cb = cb;
+	sctx->path = keyfile;
+}
+
+void
+pkgsign_free(struct pkgsign_ctx *ctx)
+{
+	struct pkgsign_impl *impl;
+	const struct pkgsign_ops *ops;
+
+	if (ctx == NULL)
+		return;
+	impl = ctx->impl;
+	ops = impl->pi_ops;
+	if (ops->pkgsign_free != NULL)
+		(*ops->pkgsign_free)(ctx);
+
+	impl->pi_refs--;
+	free(ctx);
+}
+
+int
+pkgsign_sign(struct pkgsign_ctx *ctx, char *path, unsigned char **sigret,
+    size_t *siglen)
+{
+
+	return (*ctx->impl->pi_ops->pkgsign_sign)(ctx, path, sigret, siglen);
+}
+
+int
+pkgsign_verify(struct pkgsign_ctx *ctx, const char *key, unsigned char *sig,
+    size_t siglen, int fd)
+{
+
+	return (*ctx->impl->pi_ops->pkgsign_verify)(ctx, key, sig, siglen, fd);
+}
+
+int
+pkgsign_verify_cert(struct pkgsign_ctx *ctx, unsigned char *key, size_t keylen,
+    unsigned char *sig, size_t siglen, int fd)
+{
+
+	return (*ctx->impl->pi_ops->pkgsign_verify_cert)(ctx, key, keylen, sig,
+	    siglen, fd);
+}

--- a/libpkg/pkgsign_ossl.c
+++ b/libpkg/pkgsign_ossl.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2011-2013 Baptiste Daroussin <bapt@FreeBSD.org>
  * Copyright (c) 2011-2012 Julien Laffaye <jlaffaye@FreeBSD.org>
  * All rights reserved.
+ * Copyright (c) 2021 Kyle Evans <kevans@FreeBSD.org>
  * 
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -36,6 +37,7 @@
 #include "pkg.h"
 #include "private/event.h"
 #include "private/pkg.h"
+#include "private/pkgsign.h"
 
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
 /*
@@ -62,21 +64,24 @@ EVP_md_pkg_sha1(void)
 }
 #endif	/* OPENSSL_VERSION_NUMBER >= 0x10100000L */
 
-struct pkg_key {
-	pkg_password_cb *pw_cb;
-	char *path;
+struct ossl_sign_ctx {
+	struct pkgsign_ctx sctx;
 	EVP_PKEY *key;
 };
 
+/* Grab the ossl context from a pkgsign_ctx. */
+#define	OSSL_CTX(c)	((struct ossl_sign_ctx *)(c))
+
 static int
-_load_private_key(struct pkg_key *keyinfo)
+_load_private_key(struct ossl_sign_ctx *keyinfo)
 {
 	FILE *fp;
 
-	if ((fp = fopen(keyinfo->path, "re")) == NULL)
+	if ((fp = fopen(keyinfo->sctx.path, "re")) == NULL)
 		return (EPKG_FATAL);
 
-	keyinfo->key = PEM_read_PrivateKey(fp, 0, keyinfo->pw_cb, keyinfo->path);
+	keyinfo->key = PEM_read_PrivateKey(fp, 0, keyinfo->sctx.pw_cb,
+	    keyinfo->sctx.path);
 	if (keyinfo->key == NULL) {
 		fclose(fp);
 		return (EPKG_FATAL);
@@ -112,7 +117,7 @@ _load_public_key_buf(unsigned char *cert, int certlen)
 	return (pkey);
 }
 
-struct rsa_verify_cbdata {
+struct ossl_verify_cbdata {
 	unsigned char *key;
 	size_t keylen;
 	unsigned char *sig;
@@ -120,9 +125,9 @@ struct rsa_verify_cbdata {
 };
 
 static int
-rsa_verify_cert_cb(int fd, void *ud)
+ossl_verify_cert_cb(int fd, void *ud)
 {
-	struct rsa_verify_cbdata *cbdata = ud;
+	struct ossl_verify_cbdata *cbdata = ud;
 	char *sha256;
 	char *hash;
 	char errbuf[1024];
@@ -198,13 +203,13 @@ rsa_verify_cert_cb(int fd, void *ud)
 	return (EPKG_OK);
 }
 
-int
-rsa_verify_cert(unsigned char *key, int keylen,
-    unsigned char *sig, int siglen, int fd)
+static int
+ossl_verify_cert(struct pkgsign_ctx *ctx __unused, unsigned char *key,
+    size_t keylen, unsigned char *sig, size_t siglen, int fd)
 {
 	int ret;
 	bool need_close = false;
-	struct rsa_verify_cbdata cbdata;
+	struct ossl_verify_cbdata cbdata;
 
 	(void)lseek(fd, 0, SEEK_SET);
 
@@ -217,7 +222,7 @@ rsa_verify_cert(unsigned char *key, int keylen,
 	OpenSSL_add_all_algorithms();
 	OpenSSL_add_all_ciphers();
 
-	ret = pkg_emit_sandbox_call(rsa_verify_cert_cb, fd, &cbdata);
+	ret = pkg_emit_sandbox_call(ossl_verify_cert_cb, fd, &cbdata);
 	if (need_close)
 		close(fd);
 
@@ -225,9 +230,9 @@ rsa_verify_cert(unsigned char *key, int keylen,
 }
 
 static int
-rsa_verify_cb(int fd, void *ud)
+ossl_verify_cb(int fd, void *ud)
 {
-	struct rsa_verify_cbdata *cbdata = ud;
+	struct ossl_verify_cbdata *cbdata = ud;
 	char *sha256;
 	char errbuf[1024];
 	EVP_PKEY *pkey = NULL;
@@ -319,17 +324,18 @@ rsa_verify_cb(int fd, void *ud)
 	return (EPKG_OK);
 }
 
-int
-rsa_verify(const char *key, unsigned char *sig, unsigned int sig_len, int fd)
+static int
+ossl_verify(struct pkgsign_ctx *sctx __unused, const char *keypath,
+    unsigned char *sig, size_t sig_len, int fd)
 {
 	int ret;
 	bool need_close = false;
-	struct rsa_verify_cbdata cbdata;
+	struct ossl_verify_cbdata cbdata;
 	char *key_buf;
 	off_t key_len;
 
-	if (file_to_buffer(key, (char**)&key_buf, &key_len) != EPKG_OK) {
-		pkg_emit_errno("rsa_verify", "cannot read key");
+	if (file_to_buffer(keypath, (char**)&key_buf, &key_len) != EPKG_OK) {
+		pkg_emit_errno("ossl_verify", "cannot read key");
 		return (EPKG_FATAL);
 	}
 
@@ -344,7 +350,7 @@ rsa_verify(const char *key, unsigned char *sig, unsigned int sig_len, int fd)
 	OpenSSL_add_all_algorithms();
 	OpenSSL_add_all_ciphers();
 
-	ret = pkg_emit_sandbox_call(rsa_verify_cb, fd, &cbdata);
+	ret = pkg_emit_sandbox_call(ossl_verify_cb, fd, &cbdata);
 	if (need_close)
 		close(fd);
 
@@ -353,27 +359,28 @@ rsa_verify(const char *key, unsigned char *sig, unsigned int sig_len, int fd)
 	return (ret);
 }
 
-int
-rsa_sign(char *path, struct pkg_key *keyinfo, unsigned char **sigret,
-    unsigned int *osiglen)
+static int
+ossl_sign(struct pkgsign_ctx *sctx, char *path, unsigned char **sigret,
+    size_t *siglen)
 {
 	char errbuf[1024];
+	struct ossl_sign_ctx *keyinfo = OSSL_CTX(sctx);
 	int max_len = 0, ret;
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
 	EVP_PKEY_CTX *ctx;
-	size_t siglen;
 #else
 	RSA *rsa;
+	unsigned int ssiglen;
 #endif
 	char *sha256;
 
-	if (access(keyinfo->path, R_OK) == -1) {
-		pkg_emit_errno("access", keyinfo->path);
+	if (access(keyinfo->sctx.path, R_OK) == -1) {
+		pkg_emit_errno("access", keyinfo->sctx.path);
 		return (EPKG_FATAL);
 	}
 
 	if (keyinfo->key == NULL && _load_private_key(keyinfo) != EPKG_OK) {
-		pkg_emit_error("can't load key from %s", keyinfo->path);
+		pkg_emit_error("can't load key from %s", keyinfo->sctx.path);
 		return (EPKG_FATAL);
 	}
 
@@ -409,19 +416,19 @@ rsa_sign(char *path, struct pkg_key *keyinfo, unsigned char **sigret,
 		return (EPKG_FATAL);
 	}
 
-	siglen = max_len;
-	ret = EVP_PKEY_sign(ctx, *sigret, &siglen, sha256,
+	*siglen = max_len;
+	ret = EVP_PKEY_sign(ctx, *sigret, siglen, sha256,
 	    pkg_checksum_type_size(PKG_HASH_TYPE_SHA256_HEX));
 #else
 	rsa = EVP_PKEY_get1_RSA(keyinfo->key);
 
 	ret = RSA_sign(NID_sha1, sha256,
 	    pkg_checksum_type_size(PKG_HASH_TYPE_SHA256_HEX),
-	    *sigret, osiglen, rsa);
+	    *sigret, &ssiglen, rsa);
 #endif
 	free(sha256);
 	if (ret <= 0) {
-		pkg_emit_error("%s: %s", keyinfo->path,
+		pkg_emit_error("%s: %s", keyinfo->sctx.path,
 		   ERR_error_string(ERR_get_error(), errbuf));
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
 		EVP_PKEY_CTX_free(ctx);
@@ -432,43 +439,44 @@ rsa_sign(char *path, struct pkg_key *keyinfo, unsigned char **sigret,
 	}
 
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
-	assert(siglen <= INT_MAX);
-	*osiglen = siglen;
 	EVP_PKEY_CTX_free(ctx);
 #else
 	RSA_free(rsa);
+	*siglen = ssiglen;
 #endif
 
 	return (EPKG_OK);
 }
 
-int
-rsa_new(struct pkg_key **keyinfo, pkg_password_cb *cb, char *path)
+static int
+ossl_new(const char *name __unused, struct pkgsign_ctx *ctx __unused)
 {
-	assert(*keyinfo == NULL);
-
-	*keyinfo = xcalloc(1, sizeof(struct pkg_key));
-	(*keyinfo)->path = path;
-	(*keyinfo)->pw_cb = cb;
 
 	SSL_load_error_strings();
 
 	OpenSSL_add_all_algorithms();
 	OpenSSL_add_all_ciphers();
 
-	return (EPKG_OK);
+	return (0);
 }
 
-void
-rsa_free(struct pkg_key *keyinfo)
+static void
+ossl_free(struct pkgsign_ctx *sctx)
 {
-	if (keyinfo == NULL)
-		return;
+	struct ossl_sign_ctx *keyinfo = OSSL_CTX(sctx);
 
 	if (keyinfo->key != NULL)
 		EVP_PKEY_free(keyinfo->key);
 
-	free(keyinfo);
 	ERR_free_strings();
 }
 
+const struct pkgsign_ops pkgsign_ossl = {
+	.pkgsign_ctx_size = sizeof(struct ossl_sign_ctx),
+	.pkgsign_new = ossl_new,
+	.pkgsign_free = ossl_free,
+
+	.pkgsign_sign = ossl_sign,
+	.pkgsign_verify = ossl_verify,
+	.pkgsign_verify_cert = ossl_verify_cert,
+};

--- a/libpkg/private/pkgsign.h
+++ b/libpkg/private/pkgsign.h
@@ -26,6 +26,10 @@
 #ifndef _PKGSIGN_H
 #define _PKGSIGN_H
 
+#ifdef HAVE_CONFIG_H
+#include "pkg_config.h"
+#endif
+
 #include <pkg.h>
 
 struct pkgsign_ctx;
@@ -97,5 +101,11 @@ int pkgsign_verify(struct pkgsign_ctx *, const char *, unsigned char *, size_t,
     int);
 int pkgsign_verify_cert(struct pkgsign_ctx *, unsigned char *, size_t,
     unsigned char *, size_t, int);
+
+const char *pkgsign_impl_name(const struct pkgsign_ctx *);
+
+#ifdef HAVE_DECL_EVP_PKEY_ED25519
+#define	PKGSIGN_ED25519
+#endif
 
 #endif

--- a/libpkg/private/pkgsign.h
+++ b/libpkg/private/pkgsign.h
@@ -1,0 +1,101 @@
+/*-
+ * Copyright (c) 2021 Kyle Evans <kevans@FreeBSD.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer
+ *    in this position and unchanged.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _PKGSIGN_H
+#define _PKGSIGN_H
+
+#include <pkg.h>
+
+struct pkgsign_ctx;
+struct pkgsign_ops;
+struct pkgsign_impl;
+
+/*
+ * This should be embedded at the beginning of your pkgsign implementation's
+ * context as needed.
+ */
+struct pkgsign_ctx {
+	struct pkgsign_impl		*impl;
+	pkg_password_cb			*pw_cb;
+	char				*path;
+};
+
+/* pkgsign request initialization/finalization. */
+typedef int pkgsign_new_cb(const char *, struct pkgsign_ctx *);
+typedef void pkgsign_free_cb(struct pkgsign_ctx *);
+
+/* Sign (pkg_checksum), pass back signature and signature length. */
+typedef int pkgsign_sign_cb(struct pkgsign_ctx *, char *, unsigned char **,
+    size_t *);
+
+/* Validate the checksum against the expected signature. */
+typedef int pkgsign_verify_cb(struct pkgsign_ctx *, const char *,
+    unsigned char *, size_t, int);
+
+/*
+ * Validate the checksum against the fingerprint's expected signature.  This
+ * differs from the above for historical reasons, so it is both acceptable and
+ * expected for them to be one and the same implementation.
+ *
+ * The longer explanation is that pkg historically signed the ShA256 hash of
+ * a repo's contents as if it were SHA1, rather than SHA256.  This is largely
+ * irrelevant, except that it's not interoperable with other implementations
+ * that want to reproduce pkg's results because the hash function is physically
+ * embedded in the resulting signature.
+ */
+typedef int pkgsign_verify_cert_cb(struct pkgsign_ctx *, unsigned char *,
+    size_t, unsigned char *, size_t, int);
+
+
+struct pkgsign_ops {
+	/*
+	 * pkgsign_ctx_size <= sizeof(pkgsign_ctx) is wrong, but
+	 * pkgsign_ctx_size == 0 will allocate just a pkgsign_ctx.
+	 */
+	size_t				 pkgsign_ctx_size;
+
+	/* Optional request initialization/finalization handlers. */
+	pkgsign_new_cb			*pkgsign_new;
+	pkgsign_free_cb			*pkgsign_free;
+
+	/* Non-optional. */
+	pkgsign_sign_cb			*pkgsign_sign;
+
+	/* Non-optional, and may be the same function. */
+	pkgsign_verify_cb		*pkgsign_verify;
+	pkgsign_verify_cert_cb		*pkgsign_verify_cert;
+};
+
+int pkgsign_new(const char *, struct pkgsign_ctx **);
+void pkgsign_set(struct pkgsign_ctx *, pkg_password_cb *, char *);
+void pkgsign_free(struct pkgsign_ctx *);
+
+int pkgsign_sign(struct pkgsign_ctx *, char *, unsigned char **, size_t *);
+int pkgsign_verify(struct pkgsign_ctx *, const char *, unsigned char *, size_t,
+    int);
+int pkgsign_verify_cert(struct pkgsign_ctx *, unsigned char *, size_t,
+    unsigned char *, size_t, int);
+
+#endif

--- a/libpkg/private/utils.h
+++ b/libpkg/private/utils.h
@@ -59,8 +59,6 @@ struct dns_srvinfo {
 	struct dns_srvinfo *next;
 };
 
-struct pkg_key;
-
 int32_t string_hash_func(const char *);
 
 int mkdirs(const char *path);
@@ -70,14 +68,6 @@ int format_exec_cmd(char **, const char *, const char *, const char *, char *,
     int argc, char **argv, bool lua);
 int is_dir(const char *);
 int is_link(const char *);
-
-int rsa_new(struct pkg_key **, pkg_password_cb *, char *path);
-void rsa_free(struct pkg_key *);
-int rsa_sign(char *path, struct pkg_key *keyinfo, unsigned char **sigret,
-    unsigned int *siglen);
-int rsa_verify(const char *key, unsigned char *sig, unsigned int sig_len, int fd);
-int rsa_verify_cert(unsigned char *cert,
-    int certlen, unsigned char *sig, int sig_len, int fd);
 
 bool check_for_hardlink(hardlinks_t *hl, struct stat *st);
 bool is_valid_abi(const char *arch, bool emit_error);

--- a/tests/frontend/pubkey.sh
+++ b/tests/frontend/pubkey.sh
@@ -3,11 +3,53 @@
 . $(atf_get_srcdir)/test_environment.sh
 
 tests_init \
-	pubkey \
+	pubkey_ed25519 \
+	pubkey_rsa \
 	pubkey_legacy
 
-# New format, prefix the key type
-pubkey_body() {
+pubkey_ed25519_body() {
+	atf_check -o ignore -e ignore \
+		openssl genpkey -out repo.key -algorithm ED25519
+	chmod 0400 repo.key
+	atf_check -o ignore -e ignore \
+		openssl pkey -in repo.key -out repo.pub -pubout
+	mkdir fakerepo
+
+	cat >> test.ucl << EOF
+name: test
+origin: test
+version: "1"
+maintainer: test
+categories: [test]
+comment: a test
+www: http://test
+prefix: /
+abi = "*";
+desc: <<EOD
+Yet another test
+EOD
+EOF
+
+	atf_check -o ignore -e ignore \
+		pkg create -M test.ucl -o fakerepo
+	atf_check -o ignore -e ignore \
+		pkg repo fakerepo ed25519:repo.key
+	cat >> repo.conf << EOF
+local: {
+	url: file:///${TMPDIR}/fakerepo
+	enabled: true
+	pubkey: ${TMPDIR}/repo.pub
+	signature_type: "pubkey"
+}
+EOF
+	atf_check \
+		-o ignore \
+		pkg -o REPOS_DIR="${TMPDIR}" \
+		-o ${PKG_CACHEDIR}="${TMPDIR}" update
+}
+
+
+pubkey_rsa_body() {
 	atf_check -o ignore -e ignore \
 		openssl genrsa -out repo.key 2048
 	chmod 0400 repo.key


### PR DESCRIPTION
This ended up with a little more churn after the rsa refactoring we already landed as I got a clearer view of the pkgsign API. I'll break this PR up into some more consumable bits, but I wanted to get a draft up to make sure there's no glaring issues with the high-level overview. FreeBSD 11 is also likely still broken for the time being, but I will fix that. There are also some comments that I'll need to go back and revise now that my understanding has evolved.

## pkgsign API

The new pkgsign API in libpkg is modelled after the RSA API that it's replacing. The main difference is that a consumer only needs to know which signer it wants up-front, it does not need to supply a password callback or key path. These are supplied after the fact to make it less awkward for those consumers that just want to do verification; before they did ad-hoc direct calls to rsa_verify() and rsa_verify_cert(), but now they're forced to create a pkgsign context and dispatch verification requests through the API.

The API does not currently support dynamic registration of pkgsign implementations, but that's something I'd like to eventually support so that a plugin could add different or experimental support for new signers.

## RSA signer

The existing RSA signer has been abstracted further and lives in pkgsign_ossl.c. The OpenSSL signer internally has 'profiles' that are selected based on the name that was used to create the pkgsign context (see: `ossl_new`) which describe how it needs to work and must match the name provided to pkg-repo. The internals of verification has been refactored out of verify_cert and verify to make it easier to ensure we got it right.

PKG_HASH_TYPE_SHA256_HEX is supported as a hash method solely for legacy rsa compatibility, but it should not be used for any other going forward. Signing commands are currently expected to sign a sha256 of the sha256 hex checksum; the latter has been hardcoded in ossl_verify_cert_cb because this is not configurable. See TODO below.

There are two ways to verify/sign which are toggled between with PFLAG_RAW in the profile: raw op or one-shot digest. 

### Raw op

This matches what the previous implementation was doing, directly using EVP_PKEY_{sign,verify}. The underlying API assumes that the data has been pre-hashed, so the digest method must always be specified.

### One-shot digest

One-shot uses the EVP_Digest{Verify,Sign}* methods for the underlying operation. ed25519 can only work specifically with EVP_Digest{Sign,Verify}() rather than the 'streaming' digest mode.

## TODO

What's still needed?

- [ ] ossl_verify_cert_cb should avoid using sprof->cert_hash if we're doing a one-shot digest operatiion
- [ ] fingerprints: "function" configuration to verify_cert ("function" doesn't seem to be used beyond setting HASH_SHA256)
- [ ] fingerprints:  add a "signature_type" field (it looks like old pkg will just ignore unknown fields in the fingerprint file)
- [ ] documentation
- [ ] probably more