### PR TITLE
Improve summary of info and query commands

### DIFF
--- a/docs/pkg-query.8
+++ b/docs/pkg-query.8
@@ -19,7 +19,7 @@
 .Os
 .Sh NAME
 .Nm "pkg query"
-.Nd query information for installed packages
+.Nd query information for packages
 .Sh SYNOPSIS
 .Nm
 .Ao query-format Ac Ao pkg-name Ac

--- a/docs/pkg.8
+++ b/docs/pkg.8
@@ -239,7 +239,7 @@ Delete a package from the database and the system.
 .It Ic fetch
 Fetch packages from a remote repository.
 .It Ic info
-Display information about installed packages.
+Display information about installed packages and package files.
 .It Ic install
 Install a package from a remote package repository.
 If a package is found in more than one remote repository,
@@ -251,7 +251,7 @@ Prevent modification or deletion of a package.
 .It Ic plugins
 List the available plugins.
 .It Ic query
-Query information about installed packages.
+Query information about installed packages and package files.
 .It Ic register
 Register a package in the database.
 .It Ic repo


### PR DESCRIPTION
By default, both commands look up installed packages, but they can also
query a package file.  Make this clear in pkg(8) and tweak the
description in pkg-query(8).