### PR TITLE
info: fix info processing of mutliple compares

### DIFF
--- a/src/info.c
+++ b/src/info.c
@@ -350,7 +350,7 @@ exec_info(int argc, char **argv)
 						pkgversion2++;
 						if (pkgversion2[0] == '=') {
 							pkgversion2++;
-							sign=LE;
+							sign2=LE;
 							j++;
 						}
 					} else {
@@ -372,7 +372,7 @@ exec_info(int argc, char **argv)
 						pkgversion2++;
 						if (pkgversion2[0] == '=') {
 							pkgversion2++;
-							sign=GE;
+							sign2=GE;
 							j++;
 						}
 					} else {
@@ -394,7 +394,7 @@ exec_info(int argc, char **argv)
 						pkgversion2++;
 						if (pkgversion2[0] == '=') {
 							pkgversion2++;
-							sign=EQ;
+							sign2=EQ;
 							j++;
 						}
 					} else {


### PR DESCRIPTION
When processing the right side of a two compare the sign could be
improperly set to the left side sign varible when using <= >= or ==.