### PR TITLE
Allow command line to override options from the config file

### DIFF
--- a/docs/pkg.8
+++ b/docs/pkg.8
@@ -83,7 +83,8 @@ will override any other command line arguments.
 Set configuration option for
 .Nm
 from the command line.
-Options that are set from the environment are redefined.
+Options that are set from the environment or the configuration file are
+redefined.
 It is permitted to specify this option multiple times.
 .It Fl N
 Activation status check mode.

--- a/src/main.c
+++ b/src/main.c
@@ -628,6 +628,13 @@ main(int argc, char **argv)
 		{ NULL,			0,			NULL,	0   },
 	};
 
+	struct env_option {
+		char *assignment;
+		struct env_option *next;
+	};
+	static struct env_option *arg_options = NULL;
+	struct env_option *o;
+
 	/* Set stdout unbuffered */
 	setvbuf(stdout, NULL, _IONBF, 0);
 
@@ -685,7 +692,9 @@ main(int argc, char **argv)
 			version++;
 			break;
 		case 'o':
-			export_arg_option (optarg);
+			o = malloc(sizeof(struct env_option));
+			o->assignment = optarg;
+			LL_APPEND(arg_options, o);
 			break;
 		case '4':
 			init_flags = PKG_INIT_FLAG_USE_IPV4;
@@ -767,6 +776,10 @@ main(int argc, char **argv)
 
 	if (pkg_ini(conffile, reposdir, init_flags) != EPKG_OK)
 		errx(EXIT_FAILURE, "Cannot parse configuration file!");
+
+	if (arg_options != NULL)
+		LL_FOREACH(arg_options, o)
+			export_arg_option (o->assignment);
 
 	if (debug > 0)
 		pkg_set_debug_level(debug);


### PR DESCRIPTION
Usually, the generally accepted priority for configuration items are:

    command line > environment vars > config file
or
    command line > config file > environment vars

depending on how general are the env vars. E.g.: you generally want the second form in case of http_proxy, but the first one in case of an hypotetic PKGNG_PROXY

That means:
command line can redefine configuration items set via environment variables, that in turn can redefine config items set via config file (first case)
or
command line can redefine configuration items set in the config file that in turn can redefine config items set via environment variables (second case)

Instead, the current priority list used by pkgng is:

    config file > command line > env vars

That is: there's no way to temporarily override a configuration item set in the config file beside modifying the file itself or telling pkgng to use another config file.

The proposed patch modify the priority list to be:

    command line > config file > env vars