### PR TITLE
musl fixes, general fixes

### DIFF
--- a/auto.def
+++ b/auto.def
@@ -271,7 +271,7 @@ cc-with { -libs { -ljail} } {
 # libbsd
 cc-check-includes bsd/err.h bsd/libutil.h bsd/readpassphrase.h \
 	bsd/stdio.h bsd/stdlib.h bsd/strlib.h bsd/string.h \
-	bsd/sys/cdefs.h bsd/unistd.h
+	bsd/sys/cdefs.h bsd/sys/queue.h bsd/unistd.h
  
 if {[opt-bool with-asan]} {
 	define-append ASAN_CFLAGS -O0 -ggdb -fsanitize=address

--- a/compat/bsd_compat.h
+++ b/compat/bsd_compat.h
@@ -188,7 +188,10 @@ FILE * funopen(const void *cookie, int (*readfn)(void *, char *, int),
 #endif
 
 #if !HAVE_GETPROGNAME
-#ifdef __GLIBC__
+#if defined(__linux__)
+extern char *__progname;
+# define getprogname() __progname
+#elif defined(__GLIBC__)
 extern char *program_invocation_short_name;
 # define getprogname() program_invocation_short_name
 #else

--- a/compat/bsd_compat.h
+++ b/compat/bsd_compat.h
@@ -37,7 +37,11 @@
  #endif
 #endif
 
-#ifdef HAVE_BSD_SYS_CDEFS_H
+#ifndef HAVE_BSD_SYS_CDEFS_H
+
+#include <sys/cdefs.h>
+
+#else
 
 /* Deal with broken __DECONST */
 #ifndef __uintptr_t

--- a/compat/strnstr.c
+++ b/compat/strnstr.c
@@ -31,7 +31,6 @@
  * SUCH DAMAGE.
  */
 
-#include <sys/cdefs.h>
 #include <string.h>
 
 #if !HAVE_STRNSTR

--- a/external/libfetch/common.c
+++ b/external/libfetch/common.c
@@ -29,7 +29,6 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <sys/cdefs.h>
 #include "bsd_compat.h"
 __FBSDID("$FreeBSD: head/lib/libfetch/common.c 347050 2019-05-03 06:06:39Z adrian $");
 

--- a/external/libfetch/fetch.c
+++ b/external/libfetch/fetch.c
@@ -28,7 +28,6 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <sys/cdefs.h>
 #include "bsd_compat.h"
 __FBSDID("$FreeBSD: head/lib/libfetch/fetch.c 357212 2020-01-28 18:37:18Z gordon $");
 

--- a/external/libfetch/fetch.h
+++ b/external/libfetch/fetch.h
@@ -90,7 +90,9 @@ struct url_ent {
 #define	FETCH_URL	18
 #define	FETCH_VERBOSE	19
 
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /* FILE-specific functions */
 FILE		*fetchXGetFile(struct url *, struct url_stat *, const char *);
@@ -134,7 +136,9 @@ struct url	*fetchParseURL(const char *);
 struct url	*fetchDupURL(struct url *);
 void		 fetchFreeURL(struct url *);
 
-__END_DECLS
+#ifdef __cplusplus
+}
+#endif
 
 /* Connection caching */
 void fetchConnectionCacheInit(int, int);

--- a/external/libfetch/file.c
+++ b/external/libfetch/file.c
@@ -28,7 +28,6 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <sys/cdefs.h>
 #include "bsd_compat.h"
 __FBSDID("$FreeBSD: head/lib/libfetch/file.c 326219 2017-11-26 02:00:33Z pfg $");
 

--- a/external/libfetch/ftp.c
+++ b/external/libfetch/ftp.c
@@ -28,7 +28,6 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <sys/cdefs.h>
 #include "bsd_compat.h"
 __FBSDID("$FreeBSD: head/lib/libfetch/ftp.c 341013 2018-11-27 10:45:14Z des $");
 

--- a/external/libfetch/ftp.c
+++ b/external/libfetch/ftp.c
@@ -628,14 +628,13 @@ ftp_transfer(conn_t *conn, const char *oper, const char *file,
 	const char *bindaddr;
 	const char *filename;
 	int filenamelen, type;
-	int low, pasv, verbose;
+	int pasv, verbose;
 	int e, sd = -1;
 	socklen_t l;
 	char *s;
 	FILE *df;
 
 	/* check flags */
-	low = CHECK_FLAG('l');
 	pasv = CHECK_FLAG('p') || !CHECK_FLAG('P');
 	verbose = CHECK_FLAG('v');
 
@@ -786,7 +785,11 @@ ftp_transfer(conn_t *conn, const char *oper, const char *file,
 	} else {
 		u_int32_t a;
 		u_short p;
-		int arg, d;
+#if defined(IPV6_PORTRANGE) || defined(IP_PORTRANGE)
+		int arg;
+		int low = CHECK_FLAG('l');
+#endif
+		int d;
 		char *ap;
 		char hname[INET6_ADDRSTRLEN];
 

--- a/external/libfetch/http.c
+++ b/external/libfetch/http.c
@@ -1402,7 +1402,10 @@ http_connect(struct url *URL, struct url *purl, const char *flags, int *cached)
 	http_headerbuf_t headerbuf;
 	const char *p;
 	int verbose;
-	int af, val;
+	int af;
+#ifdef TCP_NOPUSH
+	int val;
+#endif
 	int serrno;
 
 #ifdef INET6
@@ -1507,12 +1510,12 @@ http_get_proxy(struct url * url, const char *flags)
 static void
 http_print_html(FILE *out, FILE *in)
 {
-	size_t len;
-	char *line, *p, *q;
+	size_t len = 0;
+	char *line = NULL, *p, *q;
 	int comment, tag;
 
 	comment = tag = 0;
-	while ((line = fgetln(in, &len)) != NULL) {
+	while (getline(&line, &len, in) >= 0) {
 		while (len && isspace((unsigned char)line[len - 1]))
 			--len;
 		for (p = q = line; q < line + len; ++q) {
@@ -1540,6 +1543,8 @@ http_print_html(FILE *out, FILE *in)
 			fwrite(p, q - p, 1, out);
 		fputc('\n', out);
 	}
+
+	free(line);
 }
 
 

--- a/external/libfetch/http.c
+++ b/external/libfetch/http.c
@@ -28,7 +28,6 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <sys/cdefs.h>
 #include "bsd_compat.h"
 __FBSDID("$FreeBSD: head/lib/libfetch/http.c 351573 2019-08-28 17:01:28Z markj $");
 

--- a/external/linenoise/linenoise.c
+++ b/external/linenoise/linenoise.c
@@ -806,9 +806,11 @@ static int linenoiseEdit(int stdin_fd, int stdout_fd, char *buf, size_t buflen, 
          * there was an error reading from fd. Otherwise it will return the
          * character that should be handled next. */
         if (c == 9 && completionCallback != NULL) {
-            c = completeLine(&l);
+            int cv = completeLine(&l);
             /* Return on errors */
-            if (c < 0) return l.len;
+            if (cv < 0) return l.len;
+            /* char may be unsigned */
+            c = (char)cv;
             /* Read next character when 0 */
             if (c == 0) continue;
         }

--- a/external/picosat/picosat.c
+++ b/external/picosat/picosat.c
@@ -1940,7 +1940,7 @@ fixvar (PS * ps, Var * v)
 {
   Rnk * r;
 
-  assert (VAR2LIT (v) != UNDEF);
+  assert (VAR2LIT (v)->val != UNDEF);
   assert (!v->level);
 
   ps->fixed++;

--- a/libpkg/backup_lib.c
+++ b/libpkg/backup_lib.c
@@ -52,6 +52,9 @@ register_backup(struct pkgdb *db, int fd, const char *path)
 		if (pkgdb_it_next(it, &pkg, PKG_LOAD_BASIC|PKG_LOAD_FILES) != EPKG_OK)
 			rc = EPKG_FATAL;
 		pkgdb_it_free(it);
+		if (rc != EPKG_OK) {
+			return rc;
+		}
 	}
 	if (pkg == NULL) {
 		if (pkg_new(&pkg, PKG_FILE) != EPKG_OK) {

--- a/libpkg/dns_utils.c
+++ b/libpkg/dns_utils.c
@@ -274,6 +274,7 @@ dns_getsrvinfo(const char *zone)
 int
 set_nameserver(const char *nsname) {
 #ifndef HAVE___RES_SETSERVERS
+	(void)nsname;
 	return (-1);
 #else
 	struct __res_state res;

--- a/libpkg/elfhints.c
+++ b/libpkg/elfhints.c
@@ -304,6 +304,8 @@ shlib_list_from_elf_hints(const char *hintsfile)
 {
 #if defined __FreeBSD__ || defined __DragonFly__
 	read_elf_hints(hintsfile, 1);
+#else
+	(void)hintsfile;
 #endif
 
 	return (scan_dirs_for_shlibs(&shlibs, ndirs, dirs, true));

--- a/libpkg/flags.c
+++ b/libpkg/flags.c
@@ -43,6 +43,7 @@ __FBSDID("$FreeBSD: head/lib/libc/stdio/flags.c 326025 2017-11-20 19:49:47Z pfg 
 #include <sys/file.h>
 #include <stdio.h>
 #include <errno.h>
+#include <fcntl.h>
 
 /*
  * Return the (stdio) flags for a given mode.  Store the flags

--- a/libpkg/flags.c
+++ b/libpkg/flags.c
@@ -35,7 +35,6 @@
 #if defined(LIBC_SCCS) && !defined(lint)
 static char sccsid[] = "@(#)flags.c	8.1 (Berkeley) 6/4/93";
 #endif /* LIBC_SCCS and not lint */
-#include <sys/cdefs.h>
 #include "bsd_compat.h"
 __FBSDID("$FreeBSD: head/lib/libc/stdio/flags.c 326025 2017-11-20 19:49:47Z pfg $");
 

--- a/libpkg/lua.c
+++ b/libpkg/lua.c
@@ -45,6 +45,10 @@
 #include "private/event.h"
 #include "private/lua.h"
 
+#ifndef DEFFILEMODE
+#define DEFFILEMODE (S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP|S_IROTH|S_IWOTH)
+#endif
+
 extern char **environ;
 
 lua_CFunction

--- a/libpkg/lua.c
+++ b/libpkg/lua.c
@@ -51,7 +51,7 @@
 
 extern char **environ;
 
-lua_CFunction
+int
 stack_dump(lua_State *L)
 {
 	int i;
@@ -180,7 +180,9 @@ lua_pkg_copy(lua_State *L)
 	int fd1, fd2;
 	struct timespec ts[2];
 
+#ifdef HAVE_CHFLAGSAT
 	bool install_as_user = (getenv("INSTALL_AS_USER") != NULL);
+#endif
 
 	lua_getglobal(L, "rootfd");
 	int rootfd = lua_tointeger(L, -1);

--- a/libpkg/lua_scripts.c
+++ b/libpkg/lua_scripts.c
@@ -186,11 +186,11 @@ pkg_lua_script_to_ucl(struct pkg_lua_script *scripts)
 {
 	struct pkg_lua_script *script;
 	ucl_object_t *array;
-	ucl_object_t *obj;
+	/*ucl_object_t *obj;*/
 
 	array = ucl_object_typed_new(UCL_ARRAY);
 	LL_FOREACH(scripts, script) {
-		obj = ucl_object_typed_new(UCL_OBJECT);
+		/*obj = ucl_object_typed_new(UCL_OBJECT);*/
 
 		ucl_array_append(array, ucl_object_fromstring_common(script->script,
 				strlen(script->script), UCL_STRING_RAW|UCL_STRING_TRIM));

--- a/libpkg/pkg.h.in
+++ b/libpkg/pkg.h.in
@@ -40,7 +40,6 @@ extern "C" {
 
 #include <sys/types.h>
 #include <sys/param.h>
-#include <sys/cdefs.h>
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdio.h>

--- a/libpkg/pkg_add.c
+++ b/libpkg/pkg_add.c
@@ -744,9 +744,11 @@ pkg_extract_finalize(struct pkg *pkg)
 	struct pkg_dir *d = NULL;
 	char path[MAXPATHLEN + 8];
 	const char *fto;
+#ifdef HAVE_CHFLAGSAT
 	bool install_as_user;
 
 	install_as_user = (getenv("INSTALL_AS_USER") != NULL);
+#endif
 
 	while (pkg_files(pkg, &f) == EPKG_OK) {
 		append_touched_file(f->path);
@@ -866,7 +868,7 @@ pkg_add_check_pkg_archive(struct pkgdb *db, struct pkg *pkg,
 	const char	*arch;
 	int	ret, retcode;
 	struct pkg_dep	*dep = NULL;
-	char	bd[MAXPATHLEN], *basedir = NULL;
+	char	bd[MAXPATHLEN - 3], *basedir = NULL;
 	char	dpath[MAXPATHLEN], *ppath;
 	const char	*ext = NULL;
 	struct pkg	*pkg_inst = NULL;
@@ -986,11 +988,11 @@ pkg_add_cleanup_old(struct pkgdb *db, struct pkg *old, struct pkg *new, int flag
 	 * Execute pre deinstall scripts
 	 */
 	if ((flags & PKG_ADD_NOSCRIPT) == 0) {
-		ret = pkg_lua_script_run(old, PKG_SCRIPT_PRE_DEINSTALL, (old != NULL));
+		ret = pkg_lua_script_run(old, PKG_LUA_PRE_DEINSTALL, (old != NULL));
 		if (ret != EPKG_OK && ctx.developer_mode) {
 			return (ret);
 		} else {
-			ret = pkg_script_run(old, PKG_LUA_PRE_DEINSTALL, (old != NULL));
+			ret = pkg_script_run(old, PKG_SCRIPT_PRE_DEINSTALL, (old != NULL));
 			if (ret != EPKG_OK && ctx.developer_mode) {
 				return (ret);
 			} else {
@@ -1146,9 +1148,9 @@ pkg_add_common(struct pkgdb *db, const char *path, unsigned flags,
 	 * Execute pre-install scripts
 	 */
 	if ((flags & PKG_ADD_NOSCRIPT) == 0) {
-		if ((retcode = pkg_lua_script_run(pkg, PKG_SCRIPT_PRE_INSTALL, (local != NULL))) != EPKG_OK)
+		if ((retcode = pkg_lua_script_run(pkg, PKG_LUA_PRE_INSTALL, (local != NULL))) != EPKG_OK)
 			goto cleanup;
-		if ((retcode = pkg_script_run(pkg, PKG_LUA_PRE_INSTALL, (local != NULL))) != EPKG_OK)
+		if ((retcode = pkg_script_run(pkg, PKG_SCRIPT_PRE_INSTALL, (local != NULL))) != EPKG_OK)
 			goto cleanup;
 	}
 
@@ -1196,8 +1198,8 @@ pkg_add_common(struct pkgdb *db, const char *path, unsigned flags,
 	if (retcode != EPKG_OK)
 		goto cleanup;
 	if ((flags & PKG_ADD_NOSCRIPT) == 0) {
-		pkg_lua_script_run(pkg, PKG_SCRIPT_POST_INSTALL, (local != NULL));
-		pkg_script_run(pkg, PKG_LUA_POST_INSTALL, (local != NULL));
+		pkg_lua_script_run(pkg, PKG_LUA_POST_INSTALL, (local != NULL));
+		pkg_script_run(pkg, PKG_SCRIPT_POST_INSTALL, (local != NULL));
 	}
 
 	/*

--- a/libpkg/pkg_audit.c
+++ b/libpkg/pkg_audit.c
@@ -565,6 +565,12 @@ pkg_audit_parse_vulnxml(struct pkg_audit *audit)
 			vulnxml_end_attribute(&ud, &x);
 			/* ignore */
 			break;
+		case YXML_EEOF:
+		case YXML_OK:
+		case YXML_PISTART:
+		case YXML_PICONTENT:
+		case YXML_PIEND:
+			break;
 		}
 	}
 

--- a/libpkg/pkg_checksum.c
+++ b/libpkg/pkg_checksum.c
@@ -211,7 +211,8 @@ pkg_checksum_entry_cmp(struct pkg_checksum_entry *e1,
 
 int
 pkg_checksum_generate(struct pkg *pkg, char *dest, size_t destlen,
-       pkg_checksum_type_t type, bool inc_scripts, bool inc_version, bool inc_files)
+       pkg_checksum_type_t type, bool inc_scripts, bool inc_version,
+       bool inc_files __unused)
 {
 	unsigned char *bdigest;
 	char *olduid, *buf;

--- a/libpkg/pkg_create.c
+++ b/libpkg/pkg_create.c
@@ -310,7 +310,7 @@ pkg_create_set_overwrite(struct pkg_create *pc, bool overwrite)
 }
 
 static int
-hash_file(struct pkg_create *pc, struct pkg *pkg)
+hash_file(struct pkg_create *pc __unused, struct pkg *pkg)
 {
 	char hash_dest[MAXPATHLEN];
 	char filename[MAXPATHLEN];

--- a/libpkg/pkg_delete.c
+++ b/libpkg/pkg_delete.c
@@ -62,7 +62,7 @@ pkg_delete(struct pkg *pkg, struct pkgdb *db, unsigned flags)
 	bool		 handle_rc = false;
 	const unsigned load_flags = PKG_LOAD_RDEPS|PKG_LOAD_FILES|PKG_LOAD_DIRS|
 					PKG_LOAD_SCRIPTS|PKG_LOAD_ANNOTATIONS|PKG_LOAD_LUA_SCRIPTS;
-	bool		head = true;
+	/*bool		head = true;*/
 
 	assert(pkg != NULL);
 	assert(db != NULL);
@@ -92,10 +92,10 @@ pkg_delete(struct pkg *pkg, struct pkgdb *db, unsigned flags)
 	if ((flags & PKG_DELETE_NOSCRIPT) == 0) {
 		pkg_open_root_fd(pkg);
 		if (!(flags & PKG_DELETE_UPGRADE)) {
-			ret = pkg_lua_script_run(pkg, PKG_SCRIPT_PRE_DEINSTALL, false);
+			ret = pkg_lua_script_run(pkg, PKG_LUA_PRE_DEINSTALL, false);
 			if (ret != EPKG_OK && ctx.developer_mode)
 				return (ret);
-			ret = pkg_script_run(pkg, PKG_LUA_PRE_DEINSTALL, false);
+			ret = pkg_script_run(pkg, PKG_SCRIPT_PRE_DEINSTALL, false);
 			if (ret != EPKG_OK && ctx.developer_mode)
 				return (ret);
 		}
@@ -106,8 +106,8 @@ pkg_delete(struct pkg *pkg, struct pkgdb *db, unsigned flags)
 		return (ret);
 
 	if ((flags & (PKG_DELETE_NOSCRIPT | PKG_DELETE_UPGRADE)) == 0) {
-		pkg_lua_script_run(pkg, PKG_SCRIPT_POST_DEINSTALL, false);
-		pkg_script_run(pkg, PKG_LUA_POST_DEINSTALL, false);
+		pkg_lua_script_run(pkg, PKG_LUA_POST_DEINSTALL, false);
+		pkg_script_run(pkg, PKG_SCRIPT_POST_DEINSTALL, false);
 	}
 
 	ret = pkg_delete_dirs(db, pkg, NULL);
@@ -122,7 +122,7 @@ pkg_delete(struct pkg *pkg, struct pkgdb *db, unsigned flags)
 					message = xstring_new();
 					pkg_fprintf(message->fp, "Message from "
 					    "%n-%v:\n", pkg, pkg);
-					head = false;
+					/*head = false;*/
 				}
 				fprintf(message->fp, "%s\n", msg->str);
 			}

--- a/libpkg/pkg_event.c
+++ b/libpkg/pkg_event.c
@@ -1112,7 +1112,8 @@ pkg_emit_trigger(const char *name, bool cleanup)
 	struct pkg_event ev;
 
 	ev.type = PKG_EVENT_TRIGGER;
-	ev.e_trigger.name = name;
+	ev.e_trigger.name = (char *)name;
 	ev.e_trigger.cleanup = cleanup;
 
+	pkg_emit_event(&ev);
 }

--- a/libpkg/pkg_ports.c
+++ b/libpkg/pkg_ports.c
@@ -450,7 +450,7 @@ setgroup(struct plist *p, char *line, struct file_attr *a __unused)
 }
 
 static int
-comment_key(struct plist *p, char *line__unused , struct file_attr *a __unused)
+comment_key(struct plist *p __unused, char *line __unused , struct file_attr *a __unused)
 {
 	/* ignore md5 will be recomputed anyway */
 	return (EPKG_OK);
@@ -618,6 +618,13 @@ append_script(struct plist *p, pkg_script t, const char *cmd)
 		break;
 	case PKG_SCRIPT_POST_DEINSTALL:
 		fprintf(p->post_deinstall_buf->fp, "%s\n", cmd);
+		break;
+	case PKG_SCRIPT_INSTALL:
+	case PKG_SCRIPT_DEINSTALL:
+	case PKG_SCRIPT_UNKNOWN:
+	case __DO_NOT_USE_ME1:
+	case __DO_NOT_USE_ME2:
+	case __DO_NOT_USE_ME3:
 		break;
 	}
 }
@@ -1150,7 +1157,7 @@ ports_parse_plist(struct pkg *pkg, const char *plist, const char *stage)
 
 	pplist->plistdirfd = open_directory_of(plist);
 	if (pplist->plistdirfd == -1) {
-		pkg_emit_error("impossible to open the directory where the plist is", plist);
+		pkg_emit_error("impossible to open the directory where the plist is: %s", plist);
 		plist_free(pplist);
 		return (EPKG_FATAL);
 	}
@@ -1209,8 +1216,8 @@ pkg_add_port(struct pkgdb *db, struct pkg *pkg, const char *input_path,
 
 	if (!testing) {
 		/* Execute pre-install scripts */
-		pkg_lua_script_run(pkg, PKG_SCRIPT_PRE_INSTALL, false);
-		pkg_script_run(pkg, PKG_LUA_PRE_INSTALL, false);
+		pkg_lua_script_run(pkg, PKG_LUA_PRE_INSTALL, false);
+		pkg_script_run(pkg, PKG_SCRIPT_PRE_INSTALL, false);
 
 		if (input_path != NULL) {
 			pkg_register_cleanup_callback(pkg_rollback_cb, pkg);
@@ -1223,8 +1230,8 @@ pkg_add_port(struct pkgdb *db, struct pkg *pkg, const char *input_path,
 		}
 
 		/* Execute post-install scripts */
-		pkg_lua_script_run(pkg, PKG_SCRIPT_POST_INSTALL, false);
-		pkg_script_run(pkg, PKG_LUA_POST_INSTALL, false);
+		pkg_lua_script_run(pkg, PKG_LUA_POST_INSTALL, false);
+		pkg_script_run(pkg, PKG_SCRIPT_POST_INSTALL, false);
 	}
 
 	if (rc == EPKG_OK) {

--- a/libpkg/pkg_repo.c
+++ b/libpkg/pkg_repo.c
@@ -70,7 +70,7 @@ pkg_repo_fetch_remote_tmp(struct pkg_repo *repo,
   const char *filename, const char *extension, time_t *t, int *rc, bool silent)
 {
 	char url[MAXPATHLEN];
-	char tmp[MAXPATHLEN];
+	char tmp[MAXPATHLEN - 3];
 	int fd;
 	const char *tmpdir, *dot;
 

--- a/libpkg/pkg_repo_create.c
+++ b/libpkg/pkg_repo_create.c
@@ -553,8 +553,14 @@ pkg_create_repo_read_pipe(int fd, struct digest_list_entry **dlist)
 	return (EPKG_OK);
 }
 
+#ifdef __linux__
+typedef const FTSENT *FTSENTP;
+#else
+typedef const FTSENT *const FTSENTP;
+#endif
+
 static int
-fts_compare(const FTSENT *const *a, const FTSENT *const *b)
+fts_compare(FTSENTP *a, FTSENTP *b)
 {
 	/* Sort files before directories, then alpha order */
 	if ((*a)->fts_info != FTS_D && (*b)->fts_info == FTS_D)

--- a/libpkg/pkgdb.c
+++ b/libpkg/pkgdb.c
@@ -1088,8 +1088,6 @@ pkgdb_syscall_overload(void)
 void
 pkgdb_nfs_corruption(sqlite3 *db)
 {
-	int dbdirfd = pkg_get_dbdirfd();
-
 	if (sqlite3_errcode(db) != SQLITE_CORRUPT)
 		return;
 
@@ -1100,6 +1098,8 @@ pkgdb_nfs_corruption(sqlite3 *db)
 #if defined(HAVE_SYS_STATVFS_H) && defined(ST_LOCAL)
 	struct statvfs stfs;
 
+	int dbdirfd = pkg_get_dbdirfd();
+
 	if (fstatvfs(dbdirfd, &stfs) == 0) {
 		if ((stfs.f_flag & ST_LOCAL) != ST_LOCAL)
 			pkg_emit_error("You are running on a remote filesystem,"
@@ -1108,6 +1108,8 @@ pkgdb_nfs_corruption(sqlite3 *db)
 	}
 #elif defined(HAVE_FSTATFS) && defined(MNT_LOCAL)
 	struct statfs stfs;
+
+	int dbdirfd = pkg_get_dbdirfd();
 
 	if (fstatfs(dbdirfd, &stfs) == 0) {
 		if ((stfs.f_flags & MNT_LOCAL) != MNT_LOCAL)

--- a/libpkg/private/lua.h
+++ b/libpkg/private/lua.h
@@ -27,7 +27,7 @@
 #include <lauxlib.h>
 #include <lualib.h>
 
-lua_CFunction stack_dump(lua_State *L);
+int stack_dump(lua_State *L);
 int lua_print_msg(lua_State *L);
 int lua_pkg_copy(lua_State *L);
 int lua_pkg_filecmp(lua_State *L);

--- a/libpkg/repo/binary/binary_private.h
+++ b/libpkg/repo/binary/binary_private.h
@@ -376,6 +376,8 @@ static const struct repo_changes repo_upgrades[] = {
 	},
 	{2013,
 	 2014,
+	 "Drop 'pkg_search'",
+
 	 "DROP TABLE pkg_search;"
 	},
 	/* Mark the end of the array */

--- a/libpkg/repo/binary/fetch.c
+++ b/libpkg/repo/binary/fetch.c
@@ -94,7 +94,7 @@ pkg_repo_binary_create_symlink(struct pkg *pkg, const char *fname,
 	const char *dir)
 {
 	const char *ext, *dest_fname;
-	char link_dest_tmp[MAXPATHLEN], link_dest[MAXPATHLEN];
+	char link_dest_tmp[MAXPATHLEN], link_dest[MAXPATHLEN - 4];
 
 	/* Create symlink from full pkgname */
 	ext = strrchr(fname, '.');

--- a/libpkg/repo/binary/init.c
+++ b/libpkg/repo/binary/init.c
@@ -66,8 +66,8 @@ sqlite_file_exists(sqlite3_context *ctx, int argc, sqlite3_value **argv)
 	snprintf(fpath, sizeof(fpath), "%s/%s", path, sqlite3_value_text(argv[0]));
 
 	if (access(fpath, R_OK) == 0) {
-		cksum = pkg_checksum_file(fpath, PKG_HASH_TYPE_SHA256_HEX);
-		if (cksum && strcmp(cksum, sqlite3_value_text(argv[1])) == 0)
+		cksum = (char *)pkg_checksum_file(fpath, PKG_HASH_TYPE_SHA256_HEX);
+		if (cksum && strcmp(cksum, (char *)sqlite3_value_text(argv[1])) == 0)
 			sqlite3_result_int(ctx, 1);
 		else
 			sqlite3_result_int(ctx, 0);

--- a/libpkg/repo/binary/update.c
+++ b/libpkg/repo/binary/update.c
@@ -47,7 +47,7 @@
 #include "binary_private.h"
 
 static int
-pkg_repo_binary_init_update(struct pkg_repo *repo, const char *name)
+pkg_repo_binary_init_update(struct pkg_repo *repo, const char *name __unused)
 {
 	sqlite3 *sqlite;
 	const char update_check_sql[] = ""
@@ -91,7 +91,7 @@ pkg_repo_binary_delete_conflicting(const char *origin, const char *version,
 		ret = EPKG_FATAL;
 		goto cleanup;
 	}
-	oversion = sqlite3_column_text(pkg_repo_binary_stmt_prstatement(REPO_VERSION), 0);
+	oversion = (const char *)sqlite3_column_text(pkg_repo_binary_stmt_prstatement(REPO_VERSION), 0);
 	if (!forced) {
 		switch(pkg_version_cmp(oversion, version)) {
 		case -1:

--- a/libpkg/utils.c
+++ b/libpkg/utils.c
@@ -449,6 +449,7 @@ is_valid_os_version(struct pkg *pkg)
 	}
 	return (true);
 #else
+	(void)pkg;
 	return (true);
 #endif
 

--- a/src/audit.c
+++ b/src/audit.c
@@ -29,7 +29,6 @@
 #include "pkg_config.h"
 
 #include <sys/param.h>
-#include <sys/queue.h>
 #include <sys/stat.h>
 #include <sys/mman.h>
 

--- a/src/check.c
+++ b/src/check.c
@@ -28,7 +28,6 @@
  */
 
 #include <sys/param.h>
-#include <sys/queue.h>
 
 #include <err.h>
 #include <assert.h>

--- a/src/create.c
+++ b/src/create.c
@@ -32,7 +32,6 @@
 #endif
 
 #include <sys/param.h>
-#include <sys/queue.h>
 
 #ifdef PKG_COMPAT
 #include <sys/stat.h>

--- a/src/main.c
+++ b/src/main.c
@@ -36,7 +36,6 @@
 #include <sys/param.h>
 
 #include <sys/stat.h>
-#include <sys/queue.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 #ifdef __FreeBSD__

--- a/src/updating.c
+++ b/src/updating.c
@@ -33,7 +33,11 @@
 #include <sys/capsicum.h>
 #endif
 
+#ifdef HAVE_BSD_SYS_QUEUE_H
+#include <bsd/sys/queue.h>
+#else
 #include <sys/queue.h>
+#endif
 
 #include <err.h>
 #include <errno.h>


### PR DESCRIPTION
i've started fixing things up for musl libc, this batch makes it compile

while at it, i also went through all compiler warnings and addressed them, this resulted in various fixes over the place that may also benefit freebsd, or at least benefit non-freebsd systems (e.g. the previous `funopen` implementation was completely broken at least on big endian systems, and had broken seeking on all systems)

there are some places i wasn't completely sure about so this will need a proper review