### PR TITLE
Allow user to specify ignored jails.

### DIFF
--- a/scripts/periodic/410.pkg-audit.in
+++ b/scripts/periodic/410.pkg-audit.in
@@ -156,12 +156,12 @@ audit_pkgs_all() {
 		;;
 	esac
 
-	for j in $jails ; do
+	for j in ${jails} ; do
 		# ignore some jails
 		# we iterate to get exact matches because we want substring matches
 		# foo should not match foo.bar
-		for ignore in $security_status_pkgaudit_jails_ignore ; do
-			if [ "${j%|*}" = "$ignore" ]; then
+		for ignore in ${security_status_pkgaudit_jails_ignore} ; do
+			if [ "${j%|*}" = "${ignore}" ]; then
 				echo
 				echo "ignoring jail: ${j%|*}"
 				# continue with the main loop

--- a/scripts/periodic/410.pkg-audit.in
+++ b/scripts/periodic/410.pkg-audit.in
@@ -42,6 +42,7 @@ fi
 : ${security_status_pkgaudit_quiet:=YES}
 : ${security_status_pkgaudit_chroots=$pkg_chroots}
 : ${security_status_pkgaudit_jails=$pkg_jails}
+: ${security_status_pkgaudit_jails_ignore=""}
 : ${security_status_pkgaudit_expiry:=2}
 
 security_daily_compat_var security_status_pkgaudit_enable
@@ -156,6 +157,19 @@ audit_pkgs_all() {
 	esac
 
 	for j in $jails ; do
+		# ignore some jails
+		if [ -n "$security_status_pkgaudit_jails_ignore" ]; then
+			# we iterate to get exact matches because we want substring matches
+			# foo should not match foo.bar
+			for ignore in $security_status_pkgaudit_jails_ignore ; do
+				if [ "${j%|*}" == "$ignore" ]; then
+					echo
+					echo "ignoring jail: ${j%|*}"
+					# continue with the main loop
+					continue 2
+				fi
+			done
+		fi
 		echo
 		echo "jail: ${j%|*}"
 		for t in audit expiration deprecation; do

--- a/scripts/periodic/410.pkg-audit.in
+++ b/scripts/periodic/410.pkg-audit.in
@@ -42,7 +42,7 @@ fi
 : ${security_status_pkgaudit_quiet:=YES}
 : ${security_status_pkgaudit_chroots=$pkg_chroots}
 : ${security_status_pkgaudit_jails=$pkg_jails}
-: ${security_status_pkgaudit_jails_ignore=""}
+: ${security_status_pkgaudit_jails_ignore+=""}
 : ${security_status_pkgaudit_expiry:=2}
 
 security_daily_compat_var security_status_pkgaudit_enable
@@ -158,18 +158,16 @@ audit_pkgs_all() {
 
 	for j in $jails ; do
 		# ignore some jails
-		if [ -n "$security_status_pkgaudit_jails_ignore" ]; then
-			# we iterate to get exact matches because we want substring matches
-			# foo should not match foo.bar
-			for ignore in $security_status_pkgaudit_jails_ignore ; do
-				if [ "${j%|*}" == "$ignore" ]; then
-					echo
-					echo "ignoring jail: ${j%|*}"
-					# continue with the main loop
-					continue 2
-				fi
-			done
-		fi
+		# we iterate to get exact matches because we want substring matches
+		# foo should not match foo.bar
+		for ignore in $security_status_pkgaudit_jails_ignore ; do
+			if [ "${j%|*}" = "$ignore" ]; then
+				echo
+				echo "ignoring jail: ${j%|*}"
+				# continue with the main loop
+				continue 2
+			fi
+		done
 		echo
 		echo "jail: ${j%|*}"
 		for t in audit expiration deprecation; do


### PR DESCRIPTION
security_status_pkgaudit_jails_ignore is a space delimited list of jails
to ignore.

If non-empty, the code iterates over security_status_pkgaudit_jails_ignore
to avoid partial matches (i.e. ignore foo.bar, but not foo). If there is a
better way to do that without looping, please let me know.