### PR TITLE
Make -e option independent of other filter options

### DIFF
--- a/libpkg/pkg.h.in
+++ b/libpkg/pkg.h.in
@@ -189,10 +189,6 @@ typedef enum {
 	 * case insensitive according to pkgdb_case_sensitive()
 	 */
 	MATCH_REGEX,
-	/**
-	 * The argument is a WHERE clause to use as condition
-	 */
-	MATCH_CONDITION,
 } match_t;
 
 /**
@@ -909,8 +905,12 @@ bool pkgdb_case_sensitive(void);
  */
 struct pkgdb_it * pkgdb_query(struct pkgdb *db, const char *pattern,
     match_t type);
+struct pkgdb_it * pkgdb_query_cond(struct pkgdb *db, const char *cond,
+    const char *pattern, match_t type);
 struct pkgdb_it * pkgdb_repo_query(struct pkgdb *db, const char *pattern,
     match_t type, const char *reponame);
+struct pkgdb_it *pkgdb_repo_query_cond(struct pkgdb *db, const char *cond,
+	const char *pattern, match_t type, const char *reponame);
 struct pkgdb_it * pkgdb_repo_search(struct pkgdb *db, const char *pattern,
     match_t type, pkgdb_field field, pkgdb_field sort, const char *reponame);
 

--- a/libpkg/pkgdb.c
+++ b/libpkg/pkgdb.c
@@ -3107,8 +3107,8 @@ pkgdb_begin_solver(struct pkgdb *db)
 	int rc = EPKG_OK;
 	int64_t cnt = 0, cur = 0;
 
-	it = pkgdb_query(db, " WHERE manifestdigest IS NULL OR manifestdigest==''",
-		MATCH_CONDITION);
+	it = pkgdb_query_cond(db, " WHERE manifestdigest IS NULL OR manifestdigest==''",
+		NULL, MATCH_ALL);
 	if (it != NULL) {
 		kv_init(pkglist);
 		while (pkgdb_it_next(it, &p, PKG_LOAD_BASIC|PKG_LOAD_OPTIONS) == EPKG_OK) {

--- a/libpkg/pkgdb.c
+++ b/libpkg/pkgdb.c
@@ -1581,7 +1581,7 @@ static sql_prstmt sql_prepared_statements[PRSTMT_LAST] = {
 		" (SELECT id FROM packages WHERE name = ?1 ),"
 		" (SELECT annotation_id FROM annotation WHERE annotation = ?2),"
 		" (SELECT annotation_id FROM annotation WHERE annotation = ?3))",
-		"TTTT",
+		"TTTT", // "TTT"???
 	},
 	[ANNOTATE_DEL1] = {
 		NULL,
@@ -1590,7 +1590,7 @@ static sql_prstmt sql_prepared_statements[PRSTMT_LAST] = {
                 " (SELECT id FROM packages WHERE name = ?1) "
 		"AND tag_id IN"
 		" (SELECT annotation_id FROM annotation WHERE annotation = ?2)",
-		"TTT",
+		"TTT", // "TT"???
 	},
 	[ANNOTATE_DEL2] = {
 		NULL,

--- a/libpkg/pkgdb_query.c
+++ b/libpkg/pkgdb_query.c
@@ -361,7 +361,7 @@ pkgdb_repo_query_cond(struct pkgdb *db, const char *cond, const char *pattern, m
 
 	LL_FOREACH(db->repos, cur) {
 		if (repo == NULL || strcasecmp(cur->repo->name, repo) == 0) {
-			rit = cur->repo->ops->query(cur->repo, NULL, pattern, match);
+			rit = cur->repo->ops->query(cur->repo, cond, pattern, match);
 			if (rit != NULL)
 				pkgdb_it_repo_attach(it, rit);
 		}

--- a/libpkg/pkgdb_query.c
+++ b/libpkg/pkgdb_query.c
@@ -79,9 +79,9 @@ pkgdb_get_pattern_query(const char *pattern, match_t match)
 		if (pkgdb_case_sensitive()) {
 			if (checkuid == NULL) {
 				if (checkorigin == NULL)
-					comp = " WHERE name = ?1 "
+					comp = " WHERE (name = ?1 "
 					    "OR (name = SPLIT_VERSION('name', ?1) AND "
-					    " version = SPLIT_VERSION('version', ?1))";
+					    " version = SPLIT_VERSION('version', ?1)))";
 				else
 					comp = " WHERE origin = ?1";
 			} else {
@@ -90,9 +90,9 @@ pkgdb_get_pattern_query(const char *pattern, match_t match)
 		} else {
 			if (checkuid == NULL) {
 				if (checkorigin == NULL)
-					comp = " WHERE name = ?1 COLLATE NOCASE "
+					comp = " WHERE (name = ?1 COLLATE NOCASE "
 							"OR (name = SPLIT_VERSION('name', ?1) COLLATE NOCASE AND "
-							" version = SPLIT_VERSION('version', ?1))";
+							" version = SPLIT_VERSION('version', ?1)))";
 				else
 					comp = " WHERE origin = ?1 COLLATE NOCASE";
 			} else {
@@ -103,8 +103,8 @@ pkgdb_get_pattern_query(const char *pattern, match_t match)
 	case MATCH_GLOB:
 		if (checkuid == NULL) {
 			if (checkorigin == NULL)
-				comp = " WHERE name GLOB ?1 "
-					"OR name || '-' || version GLOB ?1";
+				comp = " WHERE (name GLOB ?1 "
+					"OR name || '-' || version GLOB ?1)";
 			else
 				comp = " WHERE origin GLOB ?1";
 		} else {
@@ -114,16 +114,13 @@ pkgdb_get_pattern_query(const char *pattern, match_t match)
 	case MATCH_REGEX:
 		if (checkuid == NULL) {
 			if (checkorigin == NULL)
-				comp = " WHERE name REGEXP ?1 "
-				    "OR name || '-' || version REGEXP ?1";
+				comp = " WHERE (name REGEXP ?1 "
+				    "OR name || '-' || version REGEXP ?1)";
 			else
 				comp = " WHERE origin REGEXP ?1";
 		} else {
 			comp = " WHERE name = ?1";
 		}
-		break;
-	case MATCH_CONDITION:
-		comp = pattern;
 		break;
 	}
 
@@ -131,7 +128,7 @@ pkgdb_get_pattern_query(const char *pattern, match_t match)
 }
 
 struct pkgdb_it *
-pkgdb_query(struct pkgdb *db, const char *pattern, match_t match)
+pkgdb_query_cond(struct pkgdb *db, const char *cond, const char *pattern, match_t match)
 {
 	char		 sql[BUFSIZ];
 	sqlite3_stmt	*stmt;
@@ -144,14 +141,24 @@ pkgdb_query(struct pkgdb *db, const char *pattern, match_t match)
 
 	comp = pkgdb_get_pattern_query(pattern, match);
 
-	sqlite3_snprintf(sizeof(sql), sql,
-			"SELECT id, origin, name, name as uniqueid, "
-				"version, comment, desc, "
-				"message, arch, maintainer, www, "
-				"prefix, flatsize, licenselogic, automatic, "
-				"locked, time, manifestdigest, vital "
-			"FROM packages AS p%s "
-			"ORDER BY p.name;", comp);
+	if (cond)
+		sqlite3_snprintf(sizeof(sql), sql,
+				"SELECT id, origin, name, name as uniqueid, "
+					"version, comment, desc, "
+					"message, arch, maintainer, www, "
+					"prefix, flatsize, licenselogic, automatic, "
+					"locked, time, manifestdigest, vital "
+					"FROM packages AS p%s %s (%s) ORDER BY p.name;",
+					comp, pattern == NULL ? "WHERE" : "AND", cond + 7);
+	else
+		sqlite3_snprintf(sizeof(sql), sql,
+				"SELECT id, origin, name, name as uniqueid, "
+					"version, comment, desc, "
+					"message, arch, maintainer, www, "
+					"prefix, flatsize, licenselogic, automatic, "
+					"locked, time, manifestdigest, vital "
+				"FROM packages AS p%s "
+				"ORDER BY p.name;", comp);
 
 	pkg_debug(4, "Pkgdb: running '%s'", sql);
 	if (sqlite3_prepare_v2(db->sqlite, sql, -1, &stmt, NULL) != SQLITE_OK) {
@@ -159,10 +166,16 @@ pkgdb_query(struct pkgdb *db, const char *pattern, match_t match)
 		return (NULL);
 	}
 
-	if (match != MATCH_ALL && match != MATCH_CONDITION)
+	if (match != MATCH_ALL || cond != NULL)
 		sqlite3_bind_text(stmt, 1, pattern, -1, SQLITE_TRANSIENT);
 
 	return (pkgdb_it_new_sqlite(db, stmt, PKG_INSTALLED, PKGDB_IT_FLAG_ONCE));
+}
+
+struct pkgdb_it *
+pkgdb_query(struct pkgdb *db, const char *pattern, match_t match)
+{
+	return pkgdb_query_cond(db, NULL, pattern, match);
 }
 
 bool
@@ -335,7 +348,7 @@ pkgdb_query_provide(struct pkgdb *db, const char *req)
 }
 
 struct pkgdb_it *
-pkgdb_repo_query(struct pkgdb *db, const char *pattern, match_t match,
+pkgdb_repo_query_cond(struct pkgdb *db, const char *cond, const char *pattern, match_t match,
     const char *repo)
 {
 	struct pkgdb_it *it;
@@ -348,13 +361,19 @@ pkgdb_repo_query(struct pkgdb *db, const char *pattern, match_t match,
 
 	LL_FOREACH(db->repos, cur) {
 		if (repo == NULL || strcasecmp(cur->repo->name, repo) == 0) {
-			rit = cur->repo->ops->query(cur->repo, pattern, match);
+			rit = cur->repo->ops->query(cur->repo, NULL, pattern, match);
 			if (rit != NULL)
 				pkgdb_it_repo_attach(it, rit);
 		}
 	}
 
 	return (it);
+}
+
+struct pkgdb_it *pkgdb_repo_query(struct pkgdb *db, const char *pattern,
+	match_t match, const char *repo)
+{
+	return pkgdb_repo_query_cond(db, NULL, pattern, match, repo);
 }
 
 struct pkgdb_it *

--- a/libpkg/private/pkg.h
+++ b/libpkg/private/pkg.h
@@ -565,7 +565,7 @@ struct pkg_repo_ops {
 
 	/* Query repo */
 	struct pkg_repo_it * (*query)(struct pkg_repo *,
-					const char *, match_t);
+					const char*, const char *, match_t);
 	struct pkg_repo_it * (*shlib_required)(struct pkg_repo *,
 					const char *);
 	struct pkg_repo_it * (*shlib_provided)(struct pkg_repo *,

--- a/libpkg/repo/binary/binary.h
+++ b/libpkg/repo/binary/binary.h
@@ -40,7 +40,7 @@ int pkg_repo_binary_create(struct pkg_repo *repo);
 int pkg_repo_binary_open(struct pkg_repo *repo, unsigned mode);
 
 struct pkg_repo_it *pkg_repo_binary_query(struct pkg_repo *repo,
-	const char *pattern, match_t match);
+	const char *cond, const char *pattern, match_t match);
 struct pkg_repo_it *pkg_repo_binary_shlib_provide(struct pkg_repo *repo,
 	const char *require);
 struct pkg_repo_it *pkg_repo_binary_provide(struct pkg_repo *repo,

--- a/libpkg/repo/binary/binary_private.h
+++ b/libpkg/repo/binary/binary_private.h
@@ -376,7 +376,9 @@ static const struct repo_changes repo_upgrades[] = {
 	},
 	{2013,
 	 2014,
-	 "DROP TABLE pkg_search;"
+	 "DROP TABLE pkg_search;",
+
+	 NULL,
 	},
 	/* Mark the end of the array */
 	{ -1, -1, NULL, NULL, }

--- a/libpkg/repo/binary/binary_private.h
+++ b/libpkg/repo/binary/binary_private.h
@@ -378,7 +378,7 @@ static const struct repo_changes repo_upgrades[] = {
 	 2014,
 	 "Drop 'pkg_search'",
 
-	 "DROP TABLE pkg_search;",
+	 "DROP TABLE pkg_search;"
 	},
 	/* Mark the end of the array */
 	{ -1, -1, NULL, NULL, }

--- a/libpkg/repo/binary/binary_private.h
+++ b/libpkg/repo/binary/binary_private.h
@@ -376,9 +376,9 @@ static const struct repo_changes repo_upgrades[] = {
 	},
 	{2013,
 	 2014,
-	 "DROP TABLE pkg_search;",
+	 "Drop 'pkg_search'",
 
-	 NULL,
+	 "DROP TABLE pkg_search;",
 	},
 	/* Mark the end of the array */
 	{ -1, -1, NULL, NULL, }

--- a/libpkg/repo/binary/init.c
+++ b/libpkg/repo/binary/init.c
@@ -386,7 +386,7 @@ pkg_repo_binary_open(struct pkg_repo *repo, unsigned mode)
 
 	repo->priv = sqlite;
 	/* Check digests format */
-	if ((it = pkg_repo_binary_query(repo, NULL, MATCH_ALL)) == NULL)
+	if ((it = pkg_repo_binary_query(repo, NULL, NULL, MATCH_ALL)) == NULL)
 		return (EPKG_OK);
 
 	if (it->ops->next(it, &pkg, PKG_LOAD_BASIC) != EPKG_OK) {

--- a/libpkg/repo/binary/query.c
+++ b/libpkg/repo/binary/query.c
@@ -118,7 +118,8 @@ pkg_repo_binary_query(struct pkg_repo *repo, const char *cond, const char *patte
 	if (cond == NULL)
 		xasprintf(&sql, basesql, repo->name, comp ? comp : "", "", "", "");
 	else
-		xasprintf(&sql, basesql, repo->name, comp ? comp : "", "AND (", cond + 7, ")");
+		xasprintf(&sql, basesql, repo->name, comp ? comp : "",
+		    comp[0] ? "AND (" : "WHERE (", cond + 7, ")");
 
 	pkg_debug(4, "Pkgdb: running '%s' query for %s", sql,
 	     pattern == NULL ? "all": pattern);

--- a/libpkg/repo/binary/query.c
+++ b/libpkg/repo/binary/query.c
@@ -96,7 +96,7 @@ pkg_repo_binary_it_reset(struct pkg_repo_it *it)
 }
 
 struct pkg_repo_it *
-pkg_repo_binary_query(struct pkg_repo *repo, const char *pattern, match_t match)
+pkg_repo_binary_query(struct pkg_repo *repo, const char *cond, const char *pattern, match_t match)
 {
 	sqlite3 *sqlite = PRIV_GET(repo);
 	sqlite3_stmt	*stmt = NULL;
@@ -122,7 +122,7 @@ pkg_repo_binary_query(struct pkg_repo *repo, const char *pattern, match_t match)
 	if (stmt == NULL)
 		return (NULL);
 
-	if (match != MATCH_ALL && match != MATCH_CONDITION)
+	if (match != MATCH_ALL && cond == NULL)
 		sqlite3_bind_text(stmt, 1, pattern, -1, SQLITE_TRANSIENT);
 
 	return (pkg_repo_binary_it_new(repo, stmt, PKGDB_IT_FLAG_ONCE));
@@ -266,10 +266,6 @@ pkg_repo_binary_search_how(match_t match)
 		break;
 	case MATCH_REGEX:
 		how = "%s REGEXP ?1";
-		break;
-	case MATCH_CONDITION:
-		/* Should not be called by pkgdb_get_match_how(). */
-		assert(0);
 		break;
 	}
 

--- a/libpkg/repo/binary/query.c
+++ b/libpkg/repo/binary/query.c
@@ -115,11 +115,13 @@ pkg_repo_binary_query(struct pkg_repo *repo, const char *cond, const char *patte
 		return (NULL);
 
 	comp = pkgdb_get_pattern_query(pattern, match);
+	if (comp == NULL)
+		comp = "";
 	if (cond == NULL)
-		xasprintf(&sql, basesql, repo->name, comp ? comp : "", "", "", "");
+		xasprintf(&sql, basesql, repo->name, comp, "", "", "");
 	else
-		xasprintf(&sql, basesql, repo->name, comp ? comp : "",
-		    comp[0] ? "AND (" : "WHERE (", cond + 7, ")");
+		xasprintf(&sql, basesql, repo->name, comp,
+		    comp[0] != '\0' ? "AND (" : "WHERE (", cond + 7, ")");
 
 	pkg_debug(4, "Pkgdb: running '%s' query for %s", sql,
 	     pattern == NULL ? "all": pattern);

--- a/src/lock.c
+++ b/src/lock.c
@@ -154,7 +154,7 @@ list_locked(struct pkgdb *db, bool has_locked)
 	struct pkg	*pkg = NULL;
 	bool		 gotone = false;
 
-	if ((it = pkgdb_query(db, " where locked=1", MATCH_CONDITION)) == NULL) {
+	if ((it = pkgdb_query_cond(db, " WHERE locked=1", NULL, MATCH_ALL)) == NULL) {
 		pkgdb_close(db);
 		return (EXIT_FAILURE);
 	}

--- a/src/query.c
+++ b/src/query.c
@@ -127,7 +127,7 @@ format_str(struct pkg *pkg, xstring *dest, const char *qstr, const void *data)
 				break;
 			case 's':
 				qstr++;
-				if (qstr[0] == 'h') 
+				if (qstr[0] == 'h')
 					pkg_fprintf(dest->fp, "%#sB", pkg);
 			        else if (qstr[0] == 'b')
 					pkg_fprintf(dest->fp, "%s", pkg);
@@ -869,7 +869,9 @@ exec_query(int argc, char **argv)
 	int			 retcode = EXIT_SUCCESS;
 	int			 i;
 	char			 multiline = 0;
+	int			 nprinted = 0;
 	char			*condition = NULL;
+	const char 		*condition_sql = NULL;
 	xstring			*sqlcond = NULL;
 	const unsigned int	 q_flags_len = NELEM(accepted_query_flags);
 
@@ -893,7 +895,6 @@ exec_query(int argc, char **argv)
 			pkgdb_set_case_sensitivity(true);
 			break;
 		case 'e':
-			match = MATCH_CONDITION;
 			condition = optarg;
 			break;
 		case 'F':
@@ -923,7 +924,7 @@ exec_query(int argc, char **argv)
 	}
 
 	/* Default to all packages if no pkg provided */
-	if (argc == 1 && pkgname == NULL && condition == NULL && match == MATCH_EXACT) {
+	if (argc == 1 && pkgname == NULL && match == MATCH_EXACT) {
 		match = MATCH_ALL;
 	} else if (((argc == 1) ^ (match == MATCH_ALL)) && pkgname == NULL
 			&& condition == NULL) {
@@ -995,49 +996,38 @@ exec_query(int argc, char **argv)
 		return (EXIT_FAILURE);
 	}
 
-	if (match == MATCH_ALL || match == MATCH_CONDITION) {
-		const char *condition_sql = NULL;
-		if (match == MATCH_CONDITION && sqlcond) {
-			fflush(sqlcond->fp);
-			condition_sql = sqlcond->buf;
-		}
-		if ((it = pkgdb_query(db, condition_sql, match)) == NULL)
-			return (EXIT_FAILURE);
+	if (sqlcond) {
+		fflush(sqlcond->fp);
+		condition_sql = sqlcond->buf;
+	}
+        i = 1;
+        do {
+		pkgname = i < argc ? argv[i] : NULL;
 
-		while ((ret = pkgdb_it_next(it, &pkg, query_flags)) == EPKG_OK)
-			print_query(pkg, argv[0],  multiline);
-
-		if (ret != EPKG_END)
+		if ((it = pkgdb_query_cond(db, condition_sql, pkgname, match)) == NULL) {
+			warnx("DEBUG: %s/%s\n", condition_sql ? condition_sql : "-", pkgname ? pkgname : "-");
 			retcode = EXIT_FAILURE;
+			goto cleanup;
+		}
+
+		while ((ret = pkgdb_it_next(it, &pkg, query_flags)) == EPKG_OK) {
+			nprinted++;
+			print_query(pkg, argv[0], multiline);
+		}
+
+		if (ret != EPKG_END) {
+			retcode = EXIT_FAILURE;
+			break;
+		}
 
 		pkgdb_it_free(it);
-	} else {
-		int nprinted = 0;
-		for (i = 1; i < argc; i++) {
-			pkgname = argv[i];
+		i++;
+	} while (i < argc);
 
-			if ((it = pkgdb_query(db, pkgname, match)) == NULL) {
-				retcode = EXIT_FAILURE;
-				goto cleanup;
-			}
-
-			while ((ret = pkgdb_it_next(it, &pkg, query_flags)) == EPKG_OK) {
-				nprinted++;
-				print_query(pkg, argv[0], multiline);
-			}
-
-			if (ret != EPKG_END) {
-				retcode = EXIT_FAILURE;
-				break;
-			}
-
-			pkgdb_it_free(it);
-		}
-		if (nprinted == 0 && retcode == EXIT_SUCCESS) {
-			/* ensure to return a non-zero status when no package
-			 were found. */
-			retcode = EXIT_FAILURE;
-		}
+	if (nprinted == 0 && condition_sql == NULL && retcode == EXIT_SUCCESS) {
+		/* ensure to return a non-zero status when no package
+		 were found. */
+		retcode = EXIT_FAILURE;
 	}
 
 cleanup:

--- a/src/rquery.c
+++ b/src/rquery.c
@@ -114,6 +114,7 @@ exec_rquery(int argc, char **argv)
 	int			 i;
 	char			 multiline = 0;
 	char			*condition = NULL;
+	const char		*condition_sql = NULL;
 	const char		*portsdir;
 	xstring			*sqlcond = NULL;
 	const unsigned int	 q_flags_len = NELEM(accepted_rquery_flags);
@@ -233,7 +234,6 @@ exec_rquery(int argc, char **argv)
 	if (index_output)
 		query_flags = PKG_LOAD_BASIC|PKG_LOAD_CATEGORIES|PKG_LOAD_DEPS;
 
-	const char *condition_sql = NULL;
 	if (sqlcond) {
 		fflush(sqlcond->fp);
 		condition_sql = sqlcond->buf;

--- a/src/rquery.c
+++ b/src/rquery.c
@@ -146,7 +146,6 @@ exec_rquery(int argc, char **argv)
 			pkgdb_set_case_sensitivity(true);
 			break;
 		case 'e':
-			match = MATCH_CONDITION;
 			condition = optarg;
 			break;
 		case 'g':
@@ -183,7 +182,7 @@ exec_rquery(int argc, char **argv)
 
 	/* Default to all packages if no pkg provided */
 	if (!index_output) {
-		if (argc == 1 && condition == NULL && match == MATCH_EXACT) {
+		if (argc == 1 && match == MATCH_EXACT) {
 			match = MATCH_ALL;
 		} else if (((argc == 1) ^ (match == MATCH_ALL )) && condition == NULL) {
 			usage_rquery();
@@ -234,13 +233,13 @@ exec_rquery(int argc, char **argv)
 	if (index_output)
 		query_flags = PKG_LOAD_BASIC|PKG_LOAD_CATEGORIES|PKG_LOAD_DEPS;
 
-	if (match == MATCH_ALL || match == MATCH_CONDITION) {
-		const char *condition_sql = NULL;
-		if (match == MATCH_CONDITION && sqlcond) {
-			fflush(sqlcond->fp);
-			condition_sql = sqlcond->buf;
-		}
-		if ((it = pkgdb_repo_query(db, condition_sql, match, reponame)) == NULL) {
+	const char *condition_sql = NULL;
+	if (sqlcond) {
+		fflush(sqlcond->fp);
+		condition_sql = sqlcond->buf;
+	}
+	if (match == MATCH_ALL) {
+		if ((it = pkgdb_repo_query_cond(db, condition_sql, NULL, match, reponame)) == NULL) {
 			xstring_free(sqlcond);
 			return (EXIT_FAILURE);
 		}
@@ -260,7 +259,7 @@ exec_rquery(int argc, char **argv)
 		for (i = (index_output ? 0 : 1); i < argc; i++) {
 			pkgname = argv[i];
 
-			if ((it = pkgdb_repo_query(db, pkgname, match, reponame)) == NULL) {
+			if ((it = pkgdb_repo_query_cond(db, condition_sql, pkgname, match, reponame)) == NULL) {
 				xstring_free(sqlcond);
 				return (EXIT_FAILURE);
 			}

--- a/tests/frontend/query.sh
+++ b/tests/frontend/query.sh
@@ -73,10 +73,46 @@ EOF
 		pkg query -e "%#r>0" "%n: %rn %rv %ro"
 
 	atf_check \
+		-o inline:"test: plop 1 plop\n" \
+		-e empty \
+		-s exit:0 \
+		pkg query -e "%#r>0" "%n: %rn %rv %ro" test
+
+	atf_check \
+		-o empty \
+		-e empty \
+		-s exit:0 \
+		pkg query -e "%#r>0" "%n: %rn %rv %ro" plop
+
+	atf_check \
+		-o inline:"test: plop 1 plop\n" \
+		-e empty \
+		-s exit:0 \
+		pkg query -e "%#r>0" "%n: %rn %rv %ro" plop test
+
+	atf_check \
+		-o inline:"test: plop 1 plop\n" \
+		-e empty \
+		-s exit:0 \
+		pkg query -ge "%#r>0" "%n: %rn %rv %ro" "p*p" "t*t"
+
+	atf_check \
+		-o inline:"test: plop 1 plop\n" \
+		-e empty \
+		-s exit:0 \
+		pkg query -xe "%#r>0" "%n: %rn %rv %ro" "p.*p" "t.*t"
+
+	atf_check \
 		-o inline:"plop: test 1 test\n" \
 		-e empty \
 		-s exit:0 \
 		pkg query -e "%#d>0" "%n: %dn %dv %do"
+
+	atf_check \
+		-o inline:"plop: test 1 test\n" \
+		-e empty \
+		-s exit:0 \
+		pkg query -e "%#d>0" "%n: %dn %dv %do" plop test
 
 	atf_check \
 		-o empty \

--- a/tests/frontend/repo.sh
+++ b/tests/frontend/repo.sh
@@ -201,7 +201,21 @@ EOF
 	atf_check -o ignore \
 		pkg -C ./pkg.conf update
 	atf_check -o inline:"test\n" \
+		pkg -C ./pkg.conf rquery "%n"
+	atf_check -o inline:"test\n" \
 		pkg -C ./pkg.conf rquery -a "%n"
+	atf_check -o inline:"test\n" \
+		pkg -C ./pkg.conf rquery -e "%n == test" "%n"
+	atf_check -o empty \
+		pkg -C ./pkg.conf rquery -e "%n != test" "%n"
+	atf_check -o inline:"test\n" \
+		pkg -C ./pkg.conf rquery -e "%n == test" "%n" test
+	atf_check -o empty \
+		  -s exit:1 \
+		pkg -C ./pkg.conf rquery -e "%n != test" "%n" test
+	atf_check -o empty \
+		  -s exit:1 \
+		pkg -C ./pkg.conf rquery -e "%n == test" "%n" nottest
 
 	rm -rf repo
 	mkdir repo


### PR DESCRIPTION
The -e option of `pkg query` has only been supported as an alternative to e.g. -g but could not be used in a combined query expression.
This patch set makes -e orthogonal to other package selectors in the query.

E.g.: `pkg query -e "%a==1" -g %n-%v "py*"` will select Python ports but drop those that do not have the automatic flag set from the result list.
The combination of -e with other selectors allows to simplify bsd.port.mk, e.g. with regard to the CONFLICTS checks.

This patch set includes neither the required man-page changes nor additional test cases - I'm willing to provide both if the patch is accepted.