### PR TITLE
pkg-add: provide fallback for version mismatch

### DIFF
--- a/libpkg/pkg_add.c
+++ b/libpkg/pkg_add.c
@@ -867,7 +867,7 @@ pkg_add_check_pkg_archive(struct pkgdb *db, struct pkg *pkg,
 	int	ret, retcode;
 	struct pkg_dep	*dep = NULL;
 	char	bd[MAXPATHLEN], *basedir = NULL;
-	char	dpath[MAXPATHLEN], *ppath;
+	char	dpath[MAXPATHLEN] = "", *ppath;
 	const char	*ext = NULL;
 	struct pkg	*pkg_inst = NULL;
 	bool	fromstdin;
@@ -939,7 +939,9 @@ pkg_add_check_pkg_archive(struct pkgdb *db, struct pkg *pkg,
 		if (dep->version != NULL && dep->version[0] != '\0') {
 			snprintf(dpath, sizeof(dpath), "%s/%s-%s%s", bd,
 				dep->name, dep->version, ext);
-		} else {
+		}
+
+		if (strlen(dpath) == 0 || access(dpath, F_OK) != 0) {
 			snprintf(dpath, sizeof(dpath), "%s/%s-*%s", bd,
 			    dep->name, ext);
 			ppath = pkg_globmatch(dpath, dep->name);

--- a/tests/frontend/add.sh
+++ b/tests/frontend/add.sh
@@ -11,7 +11,8 @@ tests_init	\
 		add_quiet \
 		add_stdin \
 		add_stdin_missing \
-		add_no_version
+		add_no_version \
+		add_wrong_version
 
 initialize_pkg() {
 	touch a
@@ -220,6 +221,27 @@ add_no_version_body() {
 deps {
 	test {
 		origin = "test";
+	}
+}
+EOF
+		fi
+		atf_check -o ignore -s exit:0 \
+			pkg create -M ${p}.ucl
+	done
+	atf_check -o ignore -s exit:0 \
+		pkg add final-1.pkg
+}
+
+add_wrong_version_body() {
+
+	for p in test test-lib final ; do
+		atf_check -s exit:0 sh ${RESOURCEDIR}/test_subr.sh new_pkg ${p} ${p} 1
+		if [ ${p} = "final" ]; then
+			cat << EOF >> final.ucl
+deps {
+	test {
+		origin = "test";
+		version = "2";
 	}
 }
 EOF


### PR DESCRIPTION
Currenty either we find the proper version or we go to the
nearest match, but not both, which leads to missing errors
when there is no need for it.