### PR TITLE
Two fixes (query -e extension and one mis-merge)

### DIFF
--- a/libpkg/pkgdb_query.c
+++ b/libpkg/pkgdb_query.c
@@ -166,7 +166,7 @@ pkgdb_query_cond(struct pkgdb *db, const char *cond, const char *pattern, match_
 		return (NULL);
 	}
 
-	if (match != MATCH_ALL || cond != NULL)
+	if (match != MATCH_ALL)
 		sqlite3_bind_text(stmt, 1, pattern, -1, SQLITE_TRANSIENT);
 
 	return (pkgdb_it_new_sqlite(db, stmt, PKG_INSTALLED, PKGDB_IT_FLAG_ONCE));

--- a/libpkg/repo/binary/binary_private.h
+++ b/libpkg/repo/binary/binary_private.h
@@ -377,8 +377,8 @@ static const struct repo_changes repo_upgrades[] = {
 	{2013,
 	 2014,
 	 "Drop 'pkg_search'",
-	 "DROP TABLE pkg_search;",
-	 NULL,
+
+	 "DROP TABLE pkg_search;"
 	},
 	/* Mark the end of the array */
 	{ -1, -1, NULL, NULL, }

--- a/libpkg/repo/binary/query.c
+++ b/libpkg/repo/binary/query.c
@@ -130,7 +130,7 @@ pkg_repo_binary_query(struct pkg_repo *repo, const char *cond, const char *patte
 	if (stmt == NULL)
 		return (NULL);
 
-	if (match != MATCH_ALL || cond != NULL)
+	if (match != MATCH_ALL)
 		sqlite3_bind_text(stmt, 1, pattern, -1, SQLITE_TRANSIENT);
 
 	return (pkg_repo_binary_it_new(repo, stmt, PKGDB_IT_FLAG_ONCE));


### PR DESCRIPTION
Both patches had been part of the previous pull request:

- The condition for passing a parameter for ?1 in an SQL query was wrong. It should be skipped for the MATCH_ALL case even if a condition is specified.
- The attempted fix of the incomplete initializer in libpkg/repo/binary/binary_private.h created a 5 element entry (obvious mis-merge)