### PR TITLE
pkg fetch: Don't count cached packages in the fetch count.

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -787,7 +787,6 @@ set_jobs_summary_pkg(struct pkg_jobs *jobs, struct pkg *new_pkg,
 	case PKG_SOLVED_FETCH:
 		*newsize += pkgsize;
 		it->display_type = PKG_DISPLAY_FETCH;
-		sum->fetch++;
 		if (destdir == NULL)
 			pkg_repo_cached_name(new_pkg, path, sizeof(path));
 		else
@@ -805,6 +804,7 @@ set_jobs_summary_pkg(struct pkg_jobs *jobs, struct pkg *new_pkg,
 		}
 		else
 			*dlsize += pkgsize;
+		sum->fetch++;
 
 		break;
 	}


### PR DESCRIPTION
```
# pkg fetch pkg
Updating FreeBSD repository catalogue...
Fetching packagesite.pkg: 100%    6 MiB   6.5MB/s    00:01
Processing entries: 100%
FreeBSD repository update completed. 30912 packages processed.
All repositories are up to date.
The following packages will be fetched:

New packages to be FETCHED:
        pkg: 1.17.1 (8 MiB: 100.00% of the 8 MiB to download)

Number of packages to be fetched: 1

The process will require 8 MiB more space.
8 MiB to be downloaded.

Proceed with fetching packages? [y/N]: y
Fetching pkg-1.17.1.pkg: 100%    8 MiB   8.7MB/s    00:01


# pkg fetch pkg
Updating FreeBSD repository catalogue...
FreeBSD repository is up to date.
All repositories are up to date.

Number of packages to be fetched: 1                                    <=========== (expect none)

No packages are required to be fetched.
Check the integrity of packages downloaded? [y/N]: n

# pkg fetch pkg poudriere
Updating FreeBSD repository catalogue...
FreeBSD repository is up to date.
All repositories are up to date.
The following packages will be fetched:

New packages to be FETCHED:
        poudriere: 3.3.7 (732 KiB: 100.00% of the 732 KiB to download)

Number of packages to be fetched: 2                                    <=========== (expect 1)

732 KiB to be downloaded.

Proceed with fetching packages? [y/N]: y
Fetching poudriere-3.3.7.pkg: 100%  732 KiB 749.2kB/s    00:01
```


With this change:
```
# src/pkg fetch pkg poudriere
Updating FreeBSD repository catalogue...
FreeBSD repository is up to date.
All repositories are up to date.

No packages are required to be fetched.
Check the integrity of packages downloaded? [y/N]: n

# src/pkg fetch pkg poudriere poudriere-devel
Updating FreeBSD repository catalogue...
FreeBSD repository is up to date.
All repositories are up to date.
The following packages will be fetched:

New packages to be FETCHED:
        poudriere-devel: 3.3.99.20210818 (750 KiB: 100.00% of the 750 KiB to download)

Number of packages to be fetched: 1

750 KiB to be downloaded.

Proceed with fetching packages? [y/N]: y
Fetching poudriere-devel-3.3.99.20210818.pkg: 100%  750 KiB 767.7kB/s    00:01

# src/pkg fetch pkg poudriere poudriere-devel
Updating FreeBSD repository catalogue...
FreeBSD repository is up to date.
All repositories are up to date.

No packages are required to be fetched.
Check the integrity of packages downloaded? [y/N]: n
```