### PR TITLE
libpkg: don't recurse on pkg_jobs_universe_process_deps for local pkgs

### DIFF
--- a/libpkg/pkg_jobs_universe.c
+++ b/libpkg/pkg_jobs_universe.c
@@ -251,7 +251,7 @@ pkg_jobs_universe_process_deps(struct pkg_jobs_universe *universe,
 		pkg_debug(4, "Processing rdeps for %s (%s)", pkg->uid, pkg->type == PKG_INSTALLED ? "installed" : "remote");
 		if (pkg->type != PKG_INSTALLED) {
 			lpkg = pkg_jobs_universe_get_local(universe, pkg->uid, 0);
-			if (lpkg != NULL)
+			if (lpkg != NULL && lpkg != pkg)
 				return (pkg_jobs_universe_process_deps(universe, lpkg, flags));
 		}
 		deps_func = pkg_rdeps;


### PR DESCRIPTION
This can be reproduced by simply trying to `pkg install` a .pkg out of
/var/cache/pkg.  libpkg ends up blowing up the stack here and crashing,
because it wants to fetch the local package but it's already been presented
with the local package.

Simply stop doing that. This now attempts to install the latest version of
the named packaged from the remote.