### PR TITLE
fix variable name in function pkg_plugin_conf_add for type = PKG_OBJECT

### DIFF
--- a/libpkg/plugins.c
+++ b/libpkg/plugins.c
@@ -217,7 +217,7 @@ pkg_plugin_conf_add(struct pkg_plugin *p, pkg_object_t type, const char *key,
 			buf++;
 			walk = buf;
 		}
-		key = walk;
+		k = walk;
 		value = walk;
 		while (*value != '\0') {
 			if (*value == '=')


### PR DESCRIPTION
Hi,

I think there is a little error on a variable name in function `pkg_plugin_conf_add` for `type` = `PKG_OBJECT`.

With: `pkg_plugin_conf_add(p, PKG_OBJECT, "KEY", "foo=bar");`

Actual result:

```
"foo=bar" {
}
```

Expected:

```
KEY {
  foo = "bar";
}
```

Because variable `key` is overwritten instead of, I guess, (re)using `k`.