### PR TITLE
Fix using search -q -o options together

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -385,7 +385,12 @@ exec_search(int argc, char **argv)
 	case FIELD_NONE:
 		break;		/* should never happen */
 	case FIELD_ORIGIN:
-		opt |= INFO_TAG_ORIGIN|INFO_COMMENT;
+		if (quiet) {
+			opt = INFO_TAG_ORIGIN;
+			quiet = false;
+		} else {
+			opt |= INFO_TAG_ORIGIN|INFO_COMMENT;
+		}
 		break;
 	case FIELD_NAME:
 		opt |= INFO_TAG_NAME|INFO_COMMENT;

--- a/tests/frontend/search.sh
+++ b/tests/frontend/search.sh
@@ -3,9 +3,69 @@
 . $(atf_get_srcdir)/test_environment.sh
 
 tests_init \
-	search
+	search \
+	search_options
 
 search_body() {
 	export REPOS_DIR=/nonexistent
 	atf_check -e inline:"No active remote repositories configured.\n" -o empty -s exit:3 pkg -C '' -R '' search -e -Q comment -S name pkg
+}
+
+search_options_body() {
+	touch pkgA.file
+	cat << EOF > pkgA.ucl
+name: pkgA
+origin: misc/pkgA
+version: "1.0"
+maintainer: test
+categories: [test]
+comment: a test
+www: http://test
+prefix: /usr/local
+desc: <<EOD
+Yet another test
+EOD
+deps: {
+		pkgB: {
+			origin: "misc/pkgB",
+			version: "1.0"
+		}
+	}
+	files: {
+		${TMPDIR}/pkgA.file: "",
+	}
+EOF
+
+	mkdir reposconf
+	cat << EOF > reposconf/repos.conf
+repoA: {
+	url: file://${TMPDIR}/repoA,
+	enabled: true
+}
+EOF
+
+	pkg create -o ${TMPDIR}/repoA -M ./pkgA.ucl
+	pkg repo -o ${TMPDIR}/repoA ${TMPDIR}/repoA
+
+	OUTPUT_ORIGIN="misc/pkgA                      a test\n"
+	OUTPUT_ORIGIN_QUIET="misc/pkgA\n"
+	OUTPUT_QUIET_ONLY="pkgA-1.0\n"
+
+	atf_check \
+		-o inline:"${OUTPUT_ORIGIN}" \
+		-e ignore \
+		-s exit:0 \
+	pkg -o REPOS_DIR="${TMPDIR}/reposconf" search -o pkgA
+
+	atf_check \
+		-o inline:"${OUTPUT_ORIGIN_QUIET}" \
+		-e ignore \
+		-s exit:0 \
+	pkg -o REPOS_DIR="${TMPDIR}/reposconf" search -o -q pkgA
+
+	atf_check \
+		-o inline:"${OUTPUT_QUIET_ONLY}" \
+		-e ignore \
+		-s exit:0 \
+	pkg -o REPOS_DIR="${TMPDIR}/reposconf" search -q pkgA
 }


### PR DESCRIPTION
Signed-off-by: Afshin Paydar <afshinpaydar@gmail.com>

https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=259696

Using both -q and -o should print only origins without description on the right side, but it prints package names instead:

```
% pkg search -q -o salt

p5-Crypt-Salt-0.01_1
p5-Crypt-SaltedHash-0.09
py38-salt-3004_1
py38-saltyrtc.server-5.0.1_1
rubygem-hammer_cli_foreman_salt-0.0.5
rubygem-smart_proxy_salt-4.0.0
```