### PR TITLE
fix `pkg install` error handling, add regression tests

### DIFF
--- a/libpkg/pkg_jobs.c
+++ b/libpkg/pkg_jobs.c
@@ -1680,7 +1680,9 @@ jobs_solve_partial_upgrade(struct pkg_jobs *j)
 	it = pkghash_iterator(j->request_add);
 	while (pkghash_next(&it)) {
 		req = it.value;
-		pkg_jobs_universe_process(j->universe, req->item->pkg);
+		retcode = pkg_jobs_universe_process(j->universe, req->item->pkg);
+		if (retcode != EPKG_OK)
+			return (retcode);
 	}
 	return (EPKG_OK);
 }
@@ -1758,6 +1760,7 @@ jobs_solve_fetch(struct pkg_jobs *j)
 	struct pkgdb_it *it;
 	struct pkg_job_request *req;
 	pkghash_it hit;
+	pkg_error_t rc;
 
 	if ((j->flags & PKG_FLAG_UPGRADES_FOR_INSTALLED) == PKG_FLAG_UPGRADES_FOR_INSTALLED) {
 		if ((it = pkgdb_query(j->db, NULL, MATCH_ALL)) == NULL)
@@ -1784,7 +1787,9 @@ jobs_solve_fetch(struct pkg_jobs *j)
 		hit = pkghash_iterator(j->request_add);
 		while (pkghash_next(&hit)) {
 			req = hit.value;
-			pkg_jobs_universe_process(j->universe, req->item->pkg);
+			rc = pkg_jobs_universe_process(j->universe, req->item->pkg);
+			if (rc != EPKG_OK)
+				return (rc);
 		}
 	}
 

--- a/tests/Makefile.autosetup
+++ b/tests/Makefile.autosetup
@@ -23,6 +23,7 @@ TESTS_SH= \
 	frontend/create.sh \
 	frontend/delete.sh \
 	frontend/extract.sh \
+	frontend/fetch.sh \
 	frontend/install.sh \
 	frontend/jpeg.sh \
 	frontend/lock.sh \

--- a/tests/frontend/add.sh
+++ b/tests/frontend/add.sh
@@ -195,22 +195,22 @@ EOF
 		-s exit:0 \
 		pkg create -M test.ucl
 
-	cat test-1.pkg | atf_check \
+	atf_check \
 		-o inline:"${JAILED}Installing test-1...\n\nFailed to install the following 1 package(s): -\n" \
 		-e inline:"${PROGNAME}: Missing dependency 'b'\n" \
 		-s exit:1 \
-		pkg add -
+		pkg add - < test-1.pkg
 
 OUTPUT="${JAILED}Installing test-1...
 pre-install
 ${JAILED}Extracting test-1:  done
 post-install
 "
-	cat test-1.pkg | atf_check \
+	atf_check \
 		-o inline:"${OUTPUT}" \
 		-e inline:"${PROGNAME}: Missing dependency 'b'\n" \
 		-s exit:0 \
-		pkg add -M -
+		pkg add -M - < test-1.pkg
 }
 
 add_no_version_body() {

--- a/tests/frontend/create.sh
+++ b/tests/frontend/create.sh
@@ -11,6 +11,7 @@ tests_init \
 	create_from_plist_mini \
 	create_from_plist_fflags create_from_plist_bad_fflags \
 	create_from_plist_with_keyword_arguments \
+	create_from_plist_missing_file \
 	create_from_manifest_and_plist \
 	create_from_manifest \
 	create_from_manifest_dir \
@@ -90,6 +91,18 @@ create_from_plist_body() {
 		-e ignore \
 		-s exit:0 \
 		bsdtar tvf test-1.pkg
+}
+
+create_from_plist_missing_file_body() {
+	# touch file1
+	genmanifest
+	genplist "file1"
+
+	atf_check \
+		-o empty \
+		-e match:"Unable to access file .*file1:" \
+		-s exit:1 \
+		pkg create -o ${TMPDIR} -m . -p test.plist -r .
 }
 
 create_from_plist_set_owner_body() {

--- a/tests/frontend/fetch.sh
+++ b/tests/frontend/fetch.sh
@@ -1,0 +1,74 @@
+#! /usr/bin/env atf-sh
+
+. $(atf_get_srcdir)/test_environment.sh
+
+tests_init \
+	fetch_missing \
+	fetch_missing_dep
+
+test_setup()
+{
+	# Do a local config to avoid permissions-on-system-db errors.
+        cat > ${TMPDIR}/pkg.conf << EOF
+PKG_CACHEDIR=${TMPDIR}/cache
+PKG_DBDIR=${TMPDIR}
+REPOS_DIR=[
+	${TMPDIR}/reposconf
+]
+repositories: {
+        local: { url : file://${TMPDIR} }
+}
+EOF
+	# Create one package so we at least have a repo.
+	atf_check -s exit:0 sh ${RESOURCEDIR}/test_subr.sh new_pkg ${TMPDIR}/test test 1 /usr/local
+	cat << EOF >> ${TMPDIR}/test.ucl
+deps: {
+	b: {
+		origin: "wedontcare",
+		version: "1"
+	}
+}
+EOF
+	atf_check \
+		-o ignore \
+		-e empty \
+		-s exit:0 \
+		pkg -C "${TMPDIR}/pkg.conf" create -o ${TMPDIR} -M ${TMPDIR}/test.ucl
+
+	atf_check \
+		-o ignore \
+		-e empty \
+		-s exit:0 \
+		pkg -C "${TMPDIR}/pkg.conf" repo ${TMPDIR}
+
+	mkdir -p ${TMPDIR}/reposconf
+	cat << EOF > ${TMPDIR}/reposconf/repo.conf
+local: {
+	url: file:///$TMPDIR,
+	enabled: true
+}
+EOF
+}
+
+fetch_missing_body()
+{
+	test_setup
+    
+	atf_check \
+		-o ignore \
+		-e not-empty \
+		-s not-exit:0 \
+		pkg -C "${TMPDIR}/pkg.conf" fetch -r local -y missing
+}
+
+fetch_missing_dep_body()
+{
+	test_setup
+
+	atf_check \
+		-o ignore \
+		-e match:"pkg: test has a missing dependency: b$" \
+		-s not-exit:0 \
+		pkg -C "${TMPDIR}/pkg.conf" fetch -r local -d -y test
+}
+

--- a/tests/frontend/install.sh
+++ b/tests/frontend/install.sh
@@ -6,7 +6,30 @@ tests_init \
 	metalog \
 	reinstall \
 	pre_script_fail \
-	post_script_ignored
+	post_script_ignored \
+	install_missing_dep
+
+test_setup()
+{
+	# Do a local config to avoid permissions-on-system-db errors.
+        cat > ${TMPDIR}/pkg.conf << EOF
+PKG_CACHEDIR=${TMPDIR}/cache
+PKG_DBDIR=${TMPDIR}
+REPOS_DIR=[
+	${TMPDIR}/reposconf
+]
+repositories: {
+        local: { url : file://${TMPDIR} }
+}
+EOF
+	mkdir -p ${TMPDIR}/reposconf
+	cat << EOF > ${TMPDIR}/reposconf/repo.conf
+local: {
+	url: file:///$TMPDIR,
+	enabled: true
+}
+EOF
+}
 
 metalog_body()
 {
@@ -146,4 +169,45 @@ EOF
 		-e inline:"${PROGNAME}: POST-INSTALL script failed\n" \
 		-s exit:0 \
 		pkg -o REPOS_DIR="/dev/null" install -y ${TMPDIR}/test-1.pkg
+}
+
+install_missing_dep_body()
+{
+	test_setup
+
+	# Create one package so we at least have a repo.
+	atf_check -s exit:0 sh ${RESOURCEDIR}/test_subr.sh new_pkg ${TMPDIR}/test test 1 /usr/local
+	cat << EOF >> ${TMPDIR}/test.ucl
+deps: {
+	b: {
+		origin: "wedontcare",
+		version: "1"
+	}
+}
+EOF
+	atf_check \
+		-o ignore \
+		-e empty \
+		-s exit:0 \
+		pkg -C "${TMPDIR}/pkg.conf" create -o ${TMPDIR} -M ${TMPDIR}/test.ucl
+
+	atf_check \
+		-o ignore \
+		-e empty \
+		-s exit:0 \
+		pkg  -C "${TMPDIR}/pkg.conf" repo ${TMPDIR}
+
+	mkdir -p ${TMPDIR}/reposconf
+	cat << EOF > ${TMPDIR}/reposconf/repo.conf
+local: {
+	url: file:///$TMPDIR,
+	enabled: true
+}
+EOF
+
+	atf_check \
+		-o ignore \
+		-e not-empty \
+		-s not-exit:0 \
+		pkg -C "${TMPDIR}/pkg.conf" install -y test
 }


### PR DESCRIPTION
Here's the regression test I promised for `pkg fetch` a couple of weeks ago, plus tests for error cases in `pkg create` and `pkg install`, and fixes for ignored errors in `pkg install` which that found.

`jobs_solve_partial_upgrade()` wasn't returning an error at the right point, so I made it do so.  But I do not claim to fully understand the solver and how jobs work, so someone who does should check my changes.  It does pass all regression tests, but we don't seem to have tests that make the solver work particularly hard.
