### PR TITLE
speed up plain "pkg which" calls

### DIFF
--- a/src/which.c
+++ b/src/which.c
@@ -211,7 +211,7 @@ exec_which(int argc, char **argv)
 			}
 
 			pkg = NULL;
-			while (pkgdb_it_next(it, &pkg, PKG_LOAD_FILES) == EPKG_OK) {
+			while (pkgdb_it_next(it, &pkg, (glob && show_match) ? PKG_LOAD_FILES : PKG_LOAD_BASIC) == EPKG_OK) {
 				retcode = EXIT_SUCCESS;
 				if (quiet && orig && !show_match)
 					pkg_printf("%o\n", pkg);


### PR DESCRIPTION
I was running "pkg which" on /usr/local to find unmanaged files and noticed that pkg was consuming a lot more CPU and memory than I expected.  I found that the main loop looks up the package for each file on the commandline, but then pulls the plist for that package.  This data is only needed when both -g and -m options are used.

After changing the code to use the PKG_LOAD_BASIC flag unless PKG_LOAD_FILES is needed, basic calls run much faster and use a fraction of the memory.

Before:
```
$ /usr/bin/time -l pkg which /usr/local/bin/* > /dev/null
       11.293 real         9.981 user         1.300 sys
   1473208  maximum resident set size
```

After:
```
$ /usr/bin/time -l pkg which /usr/local/bin/* > /dev/null
        0.213 real         0.162 user         0.055 sys
     62588  maximum resident set size
```
