### PR TITLE
pkg-static: change library link order to fix validation failures

### DIFF
--- a/src/Makefile.autosetup
+++ b/src/Makefile.autosetup
@@ -45,14 +45,14 @@ LOCAL_CFLAGS=	-I$(top_srcdir)/compat \
 		-DGITHASH=\"@GITHASH@\" \
 		-DHAVE_CONFIG_H
 LIBPKGFLAT=	-L$(top_builddir)/libpkg -lpkg_flat
-OTHER_LIBS=	@EXTRA_LIBS@
+OTHER_LIBS=	@EXTRA_LIBS@ -lssl -lcrypto
 
 @if HAVE_PKG_LIBARCHIVE
 OTHER_LIBS+=	@PKG_LIBARCHIVE_LDFLAGS@ @PKG_LIBARCHIVE_LIBS_STATIC@
 @else
 OTHER_LIBS+=	-larchive -lbz2 -lz -llzma @ZSTDLIB@
 @endif
-OTHER_LIBS+=	-lm -lssl -lcrypto -pthread
+OTHER_LIBS+=	-lm -pthread
 @if HAVE_LIBUTIL
 OTHER_LIBS+=	-lutil
 @endif


### PR DESCRIPTION
This issue is present on 13.0-RELEASE with latest pkg as well but doesn't
trigger for all TLS certificates.

    # pkg-static update -f
    Updating OPNsense repository catalogue...
    Certificate verification failed for /CN=pkg.opnsense.org
    34372419584:error:1416F086:SSL routines:tls_process_server_certificate:certificate verify failed:/usr/src/crypto/openssl/ssl/statem/statem_clnt.c:1916:
    Certificate verification failed for /CN=pkg.opnsense.org
    34372419584:error:1416F086:SSL routines:tls_process_server_certificate:certificate verify failed:/usr/src/crypto/openssl/ssl/statem/statem_clnt.c:1916:
    Certificate verification failed for /CN=pkg.opnsense.org
    34372419584:error:1416F086:SSL routines:tls_process_server_certificate:certificate verify failed:/usr/src/crypto/openssl/ssl/statem/statem_clnt.c:1916:
    Certificate verification failed for /CN=pkg.opnsense.org
    34372419584:error:1416F086:SSL routines:tls_process_server_certificate:certificate verify failed:/usr/src/crypto/openssl/ssl/statem/statem_clnt.c:1916:
    Certificate verification failed for /CN=pkg.opnsense.org
    34372419584:error:1416F086:SSL routines:tls_process_server_certificate:certificate verify failed:/usr/src/crypto/openssl/ssl/statem/statem_clnt.c:1916:
    Certificate verification failed for /CN=pkg.opnsense.org
    34372419584:error:1416F086:SSL routines:tls_process_server_certificate:certificate verify failed:/usr/src/crypto/openssl/ssl/statem/statem_clnt.c:1916:
    pkg-static: https://pkg.opnsense.org/FreeBSD:13:amd64/snapshots/libressl/meta.txz: Authentication error
    repository OPNsense has no meta file, using default settings
    Certificate verification failed for /CN=pkg.opnsense.org
    34372419584:error:1416F086:SSL routines:tls_process_server_certificate:certificate verify failed:/usr/src/crypto/openssl/ssl/statem/statem_clnt.c:1916:
    Certificate verification failed for /CN=pkg.opnsense.org
    34372419584:error:1416F086:SSL routines:tls_process_server_certificate:certificate verify failed:/usr/src/crypto/openssl/ssl/statem/statem_clnt.c:1916:
    Certificate verification failed for /CN=pkg.opnsense.org
    34372419584:error:1416F086:SSL routines:tls_process_server_certificate:certificate verify failed:/usr/src/crypto/openssl/ssl/statem/statem_clnt.c:1916:
    pkg-static: https://pkg.opnsense.org/FreeBSD:13:amd64/snapshots/libressl/packagesite.txz: Authentication error
    Unable to update repository OPNsense
    Error updating repositories!

While the same pkg binary is working:

    # pkg update -f
    Updating OPNsense repository catalogue...
    Fetching meta.conf: 100%    163 B   0.2kB/s    00:01
    Fetching packagesite.txz: 100%  214 KiB 219.0kB/s    00:01
    Processing entries: 100%
    OPNsense repository update completed. 779 packages processed.
    All repositories are up to date.