### PR TITLE
Add orphans alias to pkg.conf.sample

### DIFF
--- a/src/pkg.conf.sample
+++ b/src/pkg.conf.sample
@@ -72,6 +72,7 @@ ALIAS              : {
   noauto = "query -e '%a == 0' '%n-%v'",
   options: query -i "%n - %Ok: %Ov",
   origin: info -qo,
+  orphans: version -vRl\?,
   provided-depends: info -qb,
   rall-depends: rquery %dn-%dv,
   raw: info -R,


### PR DESCRIPTION
The orphans alias shows installed packages that are not/no longer
in the pkg repo. This find can help finding outdated installed
packages, that have been renamed, removed from the package list,
or were dropped from the repo for other reasons, or by accident.

In a second step this should probably be added to the pkg periodic
scripts.