### PR TITLE
libpkg: Do not dereference NULL pointer

### DIFF
--- a/libpkg/pkg_jobs.c
+++ b/libpkg/pkg_jobs.c
@@ -779,11 +779,13 @@ pkg_jobs_process_remote_pkg(struct pkg_jobs *j, struct pkg *rp,
 				}
 			}
 			/* Also process all rdeps recursively */
-			while (pkg_rdeps(nrit->pkg, &rdep) == EPKG_OK) {
-				lp = pkg_jobs_universe_get_local(j->universe, rdep->uid, 0);
+			if (nrit != NULL) {
+				while (pkg_rdeps(nrit->pkg, &rdep) == EPKG_OK) {
+					lp = pkg_jobs_universe_get_local(j->universe, rdep->uid, 0);
 
-				if (lp) {
-					(void)pkg_jobs_process_remote_pkg(j, lp, NULL, 0);
+					if (lp) {
+						(void)pkg_jobs_process_remote_pkg(j, lp, NULL, 0);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
	# pkg upgrade -v
	Updating ser repository catalogue...
	ser repository is up to date.
	All repositories are up to date.
	vulnxml file up-to-date
	Checking for upgrades (2 candidates): 100%
	Child process pid=99754 terminated abnormally: Segmentation fault

Prevent this segmentation fault by checking that the pointer is not null before
dereferencing.