### PR TITLE
pkg-lua-script.5: document 'type' as return value in pkg.stat

### DIFF
--- a/docs/pkg-lua-script.5
+++ b/docs/pkg-lua-script.5
@@ -121,6 +121,7 @@ if an error occured
 return an object table
 .Ft st
 with the following fields:
+.Va type ,
 .Va size ,
 .Va uid ,
 .Va gid


### PR DESCRIPTION
pkg.stat also contains a `type` in the returned `st`.