### PR TITLE
Improve description of packagesite.txz and filesite.txz file formats.

### DIFF
--- a/docs/pkg-repository.5
+++ b/docs/pkg-repository.5
@@ -121,11 +121,21 @@ link, used for bootstrapping
 .Nm pkg
 itself on a new system.
 .It Pa $REPOSITORY_ROOT/packagesite.txz
-Contains one
-.Cm JSON
-document, which is the concatenation of the
+Contains a single file, usually named
+.Pa packagesite.yaml ,
+a concatenation of the
 .Pa +MANIFEST
-files from each of the packages in the repository.
+files from the packages in the repository.
+Each manifest is represented as a single-line
+.Cm JSON
+text (no carriage returns or line feeds are used as
+whitespace within the
+.Cm JSON
+text),
+and the manifests are separated by newlines.
+The complete file is not a valid
+.Cm JSON
+text.
 This is used by
 .Nm pkg-1.1
 or later.
@@ -137,14 +147,26 @@ This is supplied for backwards compatibility with
 .Nm pkg-1.0 .
 .It Pa $REPOSITORY_ROOT/filesite.txz
 (Optional).
-Contains a YAML document listing all of the files contained in all
-of the packages within the repository.
+Contains a single file, usually named
+.Pa filesite.yaml ,
+a concatenation of the file lists
+from the packages in the repository.
+Each file list is represented as a single-line
+.Cm JSON
+text (no carriage returns or line feeds are used as
+whitespace within the
+.Cm JSON
+text),
+and the file lists are separated by newlines.
+The complete file is not a valid
+.Cm JSON
+text.
+.El
 .Pp
 The repository may optionally contain sub-directories corresponding to
 the package origins within the
 .Os
 ports tree.
-.El
 .Pp
 Each of the packages listed in the repository catalogue must have a
 unique


### PR DESCRIPTION
The pkg-repository manpage claims these are JSON, which isn't accurate.  Describe them better.
