### PR TITLE
filesite.yaml is simply concatenated, not newline-delimited

### DIFF
--- a/docs/pkg-repository.5
+++ b/docs/pkg-repository.5
@@ -157,7 +157,7 @@ text (no carriage returns or line feeds are used as
 whitespace within the
 .Cm JSON
 text),
-and the file lists are separated by newlines.
+and the file lists are concatenated with no delimiters.
 The complete file is not a valid
 .Cm JSON
 text.


### PR DESCRIPTION
I got the description wrong last time.  Fix.