### PR TITLE
Alpine build support

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -70,3 +70,13 @@ fedora_task:
                 - ./configure --with-libarchive.pc --with-asan --with-ubsan
                 - make -j4 || make V=1
         check_script: make check || { kyua report --verbose ; exit 1 ; }
+
+alpine_task:
+        container:
+                image: alpine:latest
+        install_script:
+                - apk add musl-dev gcc g++ make kyua pkgconf gcompat tcl fts-dev libbsd-dev libarchive-dev openssl-dev bzip2-dev xz-dev zlib-dev m4
+        script:
+                - ./configure
+                - make -j4 || make V=1
+        check_script: make check || { kyua report --verbose ; exit 1 ; }

--- a/auto.def
+++ b/auto.def
@@ -272,7 +272,7 @@ cc-with { -libs { -ljail} } {
 # libbsd
 cc-check-includes bsd/err.h bsd/libutil.h bsd/readpassphrase.h \
 	bsd/stdio.h bsd/stdlib.h bsd/strlib.h bsd/string.h \
-	bsd/sys/cdefs.h bsd/unistd.h
+	bsd/sys/cdefs.h bsd/sys/queue.h bsd/unistd.h
  
 if {[opt-bool with-asan]} {
 	define-append ASAN_CFLAGS -O0 -ggdb -fsanitize=address

--- a/compat/bsd_compat.h
+++ b/compat/bsd_compat.h
@@ -37,7 +37,11 @@
  #endif
 #endif
 
-#ifdef HAVE_BSD_SYS_CDEFS_H
+#ifndef HAVE_BSD_SYS_CDEFS_H
+
+#include <sys/cdefs.h>
+
+#else
 
 /* Deal with broken __DECONST */
 #ifndef __uintptr_t

--- a/compat/strnstr.c
+++ b/compat/strnstr.c
@@ -31,7 +31,6 @@
  * SUCH DAMAGE.
  */
 
-#include <sys/cdefs.h>
 #include <string.h>
 
 #if !HAVE_STRNSTR

--- a/external/libfetch/common.c
+++ b/external/libfetch/common.c
@@ -29,7 +29,6 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <sys/cdefs.h>
 #include "bsd_compat.h"
 __FBSDID("$FreeBSD: head/lib/libfetch/common.c 347050 2019-05-03 06:06:39Z adrian $");
 

--- a/external/libfetch/fetch.c
+++ b/external/libfetch/fetch.c
@@ -28,7 +28,6 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <sys/cdefs.h>
 #include "bsd_compat.h"
 __FBSDID("$FreeBSD: head/lib/libfetch/fetch.c 357212 2020-01-28 18:37:18Z gordon $");
 

--- a/external/libfetch/fetch.h
+++ b/external/libfetch/fetch.h
@@ -90,7 +90,9 @@ struct url_ent {
 #define	FETCH_URL	18
 #define	FETCH_VERBOSE	19
 
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /* FILE-specific functions */
 FILE		*fetchXGetFile(struct url *, struct url_stat *, const char *);
@@ -134,7 +136,9 @@ struct url	*fetchParseURL(const char *);
 struct url	*fetchDupURL(struct url *);
 void		 fetchFreeURL(struct url *);
 
-__END_DECLS
+#ifdef __cplusplus
+}
+#endif
 
 /* Connection caching */
 void fetchConnectionCacheInit(int, int);

--- a/external/libfetch/file.c
+++ b/external/libfetch/file.c
@@ -28,7 +28,6 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <sys/cdefs.h>
 #include "bsd_compat.h"
 __FBSDID("$FreeBSD: head/lib/libfetch/file.c 326219 2017-11-26 02:00:33Z pfg $");
 

--- a/external/libfetch/ftp.c
+++ b/external/libfetch/ftp.c
@@ -28,7 +28,6 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <sys/cdefs.h>
 #include "bsd_compat.h"
 __FBSDID("$FreeBSD: head/lib/libfetch/ftp.c 341013 2018-11-27 10:45:14Z des $");
 

--- a/external/libfetch/ftp.c
+++ b/external/libfetch/ftp.c
@@ -628,14 +628,13 @@ ftp_transfer(conn_t *conn, const char *oper, const char *file,
 	const char *bindaddr;
 	const char *filename;
 	int filenamelen, type;
-	int low, pasv, verbose;
+	int pasv, verbose;
 	int e, sd = -1;
 	socklen_t l;
 	char *s;
 	FILE *df;
 
 	/* check flags */
-	low = CHECK_FLAG('l');
 	pasv = CHECK_FLAG('p') || !CHECK_FLAG('P');
 	verbose = CHECK_FLAG('v');
 
@@ -786,7 +785,11 @@ ftp_transfer(conn_t *conn, const char *oper, const char *file,
 	} else {
 		u_int32_t a;
 		u_short p;
-		int arg, d;
+#if defined(IPV6_PORTRANGE) || defined(IP_PORTRANGE)
+		int arg;
+		int low = CHECK_FLAG('l');
+#endif
+		int d;
 		char *ap;
 		char hname[INET6_ADDRSTRLEN];
 

--- a/external/libfetch/http.c
+++ b/external/libfetch/http.c
@@ -1507,12 +1507,12 @@ http_get_proxy(struct url * url, const char *flags)
 static void
 http_print_html(FILE *out, FILE *in)
 {
-	size_t len;
-	char *line, *p, *q;
+	size_t len = 0;
+	char *line = NULL, *p, *q;
 	int comment, tag;
 
 	comment = tag = 0;
-	while ((line = fgetln(in, &len)) != NULL) {
+	while (getline(&line, &len, in) >= 0) {
 		while (len && isspace((unsigned char)line[len - 1]))
 			--len;
 		for (p = q = line; q < line + len; ++q) {
@@ -1540,6 +1540,8 @@ http_print_html(FILE *out, FILE *in)
 			fwrite(p, q - p, 1, out);
 		fputc('\n', out);
 	}
+
+	free(line);
 }
 
 

--- a/external/libfetch/http.c
+++ b/external/libfetch/http.c
@@ -28,7 +28,6 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <sys/cdefs.h>
 #include "bsd_compat.h"
 __FBSDID("$FreeBSD: head/lib/libfetch/http.c 351573 2019-08-28 17:01:28Z markj $");
 

--- a/libpkg/flags.c
+++ b/libpkg/flags.c
@@ -35,7 +35,6 @@
 #if defined(LIBC_SCCS) && !defined(lint)
 static char sccsid[] = "@(#)flags.c	8.1 (Berkeley) 6/4/93";
 #endif /* LIBC_SCCS and not lint */
-#include <sys/cdefs.h>
 #include "bsd_compat.h"
 __FBSDID("$FreeBSD: head/lib/libc/stdio/flags.c 326025 2017-11-20 19:49:47Z pfg $");
 

--- a/libpkg/pkg.h.in
+++ b/libpkg/pkg.h.in
@@ -40,7 +40,6 @@ extern "C" {
 
 #include <sys/types.h>
 #include <sys/param.h>
-#include <sys/cdefs.h>
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdio.h>

--- a/src/audit.c
+++ b/src/audit.c
@@ -29,7 +29,6 @@
 #include "pkg_config.h"
 
 #include <sys/param.h>
-#include <sys/queue.h>
 #include <sys/stat.h>
 #include <sys/mman.h>
 

--- a/src/check.c
+++ b/src/check.c
@@ -28,7 +28,6 @@
  */
 
 #include <sys/param.h>
-#include <sys/queue.h>
 
 #include <err.h>
 #include <assert.h>

--- a/src/create.c
+++ b/src/create.c
@@ -32,7 +32,6 @@
 #endif
 
 #include <sys/param.h>
-#include <sys/queue.h>
 
 #ifdef PKG_COMPAT
 #include <sys/stat.h>

--- a/src/main.c
+++ b/src/main.c
@@ -36,7 +36,6 @@
 #include <sys/param.h>
 
 #include <sys/stat.h>
-#include <sys/queue.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 #ifdef __FreeBSD__

--- a/src/updating.c
+++ b/src/updating.c
@@ -33,7 +33,11 @@
 #include <sys/capsicum.h>
 #endif
 
+#ifdef HAVE_BSD_SYS_QUEUE_H
+#include <bsd/sys/queue.h>
+#else
 #include <sys/queue.h>
+#endif
 
 #include <err.h>
 #include <errno.h>


### PR DESCRIPTION
We require support for running pkg on alpine linux. I have picked out the remaining unmerged changes from [q66's](https://github.com/freebsd/pkg/pull/1960) PR, made the remaining requested change to the commits and supplied a cirrus task to test building under alpine so the build status of the code base against libc can be tracked.

Some additional work is still required to get pkg running on alpine as the elfheaders notes in alpine binaries don't contain NT_GNU_ABI_TAG and so we can't get the abi string on runtime.