### PR TITLE
solver: Fix backwards debug about remote/local ABI

### DIFF
--- a/libpkg/pkg_solve.c
+++ b/libpkg/pkg_solve.c
@@ -299,7 +299,7 @@ pkg_solve_handle_provide (struct pkg_solve_problem *problem,
 			if (libfound && strcmp(pkg->arch, orig->arch) != 0) {
 				pkg_debug(2, "solver: require %s: package %s-%s(%c) provides wrong ABI %s, "
 					"wanted %s", pr->provide, pkg->name, pkg->version,
-					pkg->type == PKG_INSTALLED ? 'l' : 'r', orig->arch, pkg->arch);
+					pkg->type == PKG_INSTALLED ? 'l' : 'r', pkg->arch, orig->arch);
 				continue;
 			}
 		}


### PR DESCRIPTION
Local system is FreeBSD 12.3. Remote is FreeBSD 13.1.
Ran across this in debug which was confusing:
```
63042:DBG(2)[37457]> solver: require libpkg.so.4: package pkg-1.17.5_1(r) provides wrong ABI freebsd:12:x86:64, wanted freebsd:13:x86:64
...
63045:DBG(2)[37457]> solver: require libpkg.so.4: package pkg-1.17.5_1(r) provides wrong ABI freebsd:12:x86:64, wanted freebsd:13:x86:64
```

Now it makes sense:
```
63042:DBG(2)[7430]> solver: require libpkg.so.4: package pkg-1.17.5_1(r) provides wrong ABI freebsd:13:x86:64, wanted freebsd:12:x86:64
...
63067:DBG(2)[7430]> solver: require libpkg.so.4: package pkg-1.17.5_1(l) provides wrong ABI freebsd:12:x86:64, wanted freebsd:13:x86:64
```
