### PR TITLE
Two memory leaks from calls for printf arguments

### DIFF
--- a/libpkg/pkg_config.c
+++ b/libpkg/pkg_config.c
@@ -790,6 +790,7 @@ walk_repo_obj(const ucl_object_t *obj, const char *file, pkg_init_flags flags)
 	ucl_object_iter_t it = NULL;
 	struct pkg_repo *r;
 	const char *key;
+	const char *yaml;
 
 	while ((cur = ucl_iterate_object(obj, &it, true))) {
 		key = ucl_object_key(cur);
@@ -799,9 +800,12 @@ walk_repo_obj(const ucl_object_t *obj, const char *file, pkg_init_flags flags)
 			pkg_debug(1, "PkgConfig: overwriting repository %s", key);
 		if (cur->type == UCL_OBJECT)
 			add_repo(cur, r, key, flags);
-		else
+		else {
+			yaml = ucl_object_emit(cur, UCL_EMIT_YAML);
 			pkg_emit_error("Ignoring bad configuration entry in %s: %s",
-			    file, ucl_object_emit(cur, UCL_EMIT_YAML));
+			    file, yaml);
+			free(yaml);
+		}
 	}
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -294,13 +294,15 @@ show_plugin_info(void)
 {
 	const pkg_object	*conf;
 	struct pkg_plugin	*p = NULL;
+	const char		*dump;
 
 	while (pkg_plugins(&p) == EPKG_OK) {
 		conf = pkg_plugin_conf(p);
 		printf("Configuration for plugin: %s\n",
 		    pkg_plugin_get(p, PKG_PLUGIN_NAME));
-
-		printf("%s\n", pkg_object_dump(conf));
+		dump = pkg_object_dump(conf);
+		printf("%s\n", dump);
+		free(dump);
 	}
 }
 


### PR DESCRIPTION
I just found these sitting in my repo.  They fix two unimportant memory leaks.  I forget how I identified them exactly, but it was with a compile time or run time memory checker of some sort.
