### PR TITLE
Fill hashes to 50%, not 100%.

### DIFF
--- a/libpkg/pkghash.c
+++ b/libpkg/pkghash.c
@@ -141,7 +141,7 @@ pkghash_expand(pkghash *table)
 bool
 pkghash_add(pkghash *table, const char *key, void *value, void (*free_func)(void *))
 {
-	if (table->count >= table->capacity -1 && !pkghash_expand(table))
+	if (table->count * 2  >= table->capacity && !pkghash_expand(table))
 		return (NULL);
 
 	return (pkghash_set_entry(table->entries, table->capacity, key, value,


### PR DESCRIPTION
This fixes a performance regression introduced in 91a326bdf0fb41a3e6a89faec31e9c76b8c3ad5e.

Somebody decided to save a little memory, but when the hash table fills up, the insert code searches the entire table looking for a match or an empty slot.

Seen with `pkg query '%#F' texlive-texmf`, but it was no doubt causing performance regressions in many other places too.
