### PR TITLE
pkg(8): Add example on how to restore database.

### DIFF
--- a/docs/pkg.8
+++ b/docs/pkg.8
@@ -367,6 +367,10 @@ Check for missing dependencies:
 .Pp
 Show the pkg-message of a package:
 .Dl # pkg info -D perl-5.14
+.Pp
+Restore a backup database:
+.Dl % rm /var/db/pkg/local.sqlite
+.Dl % xzcat /var/backups/pkg.sql.xz | pkg shell
 .\" ---------------------------------------------------------------------------
 .Sh SEE ALSO
 .Xr pkg_create 3 ,


### PR DESCRIPTION
As discussed recently in https://www.mail-archive.com/ports@freebsd.org/msg02505.html
add this useful example.

Using `%` as the root's prompt though not sure if this is correct. There are
three different prompts in pkg(8) manual page: `$`, `%` and `#`. In other FreeBSD
documentation `#` seems to be used for root and `%` for user's prompt, while here `%`
seems to be for root and `%` for normal users.