### PR TITLE
pkg: open dev/null before doing the chroot

### DIFF
--- a/libpkg/pkg.h.in
+++ b/libpkg/pkg.h.in
@@ -763,6 +763,9 @@ int pkgdb_set2(struct pkgdb *db, struct pkg *pkg, ...);
 int64_t pkg_set_debug_level(int64_t debug_level);
 int pkg_set_rootdir(const char *rootdir);
 
+int pkg_open_devnull(void);
+void pkg_close_devnull(void);
+
 /**
  * Allocate a new struct pkg and add it to the deps of pkg.
  * @return An error code.

--- a/libpkg/pkg_config.c
+++ b/libpkg/pkg_config.c
@@ -72,6 +72,7 @@ struct pkg_ctx ctx = {
 	.rootfd = -1,
 	.cachedirfd = -1,
 	.pkg_dbdirfd = -1,
+	.devnullfd = -1,
 	.osversion = 0,
 	.backup_libraries = false,
 	.triggers = true,
@@ -1682,4 +1683,25 @@ pkg_get_dbdirfd(void)
 	}
 
 	return (ctx.pkg_dbdirfd);
+}
+
+int
+pkg_open_devnull(void) {
+	pkg_close_devnull();
+
+	if ((ctx.devnullfd = open("/dev/null", O_RDWR)) < 0) {
+		pkg_emit_error("Cannot open /dev/null");
+		return (EPKG_FATAL);
+	}
+
+	return (EPKG_OK);
+}
+
+void
+pkg_close_devnull(void) {
+	if (ctx.devnullfd != 1) {
+		close(ctx.devnullfd);
+	}
+
+	return;
 }

--- a/libpkg/private/pkg.h
+++ b/libpkg/private/pkg.h
@@ -158,6 +158,7 @@ struct pkg_ctx {
 	int compression_level;
 	int rootfd;
 	int cachedirfd;
+	int devnullfd;
 	int dbdirfd;
 	int pkg_dbdirfd;
 	int osversion;

--- a/src/main.c
+++ b/src/main.c
@@ -698,6 +698,8 @@ main(int argc, char **argv)
 	argv += optind;
 
 	pkg_set_debug_level(debug);
+	if (pkg_open_devnull() != EPKG_OK)
+		errx(EXIT_FAILURE, "Cannot open dev/null");
 
 	if (version == 1)
 		show_version_info(version);
@@ -889,6 +891,8 @@ main(int argc, char **argv)
 
 	if (save_argv != argv)
 		free(argv);
+
+	pkg_close_devnull();
 
 	if (ret == EXIT_SUCCESS && newpkgversion)
 		return (EX_NEEDRESTART);


### PR DESCRIPTION
This patch proposes fixing our issue when pkg runs where `/dev/null` is not mounted. @bapt don't hesitate to tell me if the proposed solution is not ok!

close #1763