### PR TITLE
First step towards handling config file merges in the face of conflicts

### DIFF
--- a/libpkg/pkgdb_iterator.c
+++ b/libpkg/pkgdb_iterator.c
@@ -1302,19 +1302,14 @@ pkgdb_ensure_loaded_sqlite(sqlite3 *sqlite, struct pkg *pkg, unsigned flags)
 int
 pkgdb_ensure_loaded(struct pkgdb *db, struct pkg *pkg, unsigned flags)
 {
-	int ret;
-
-	if (pkg->type == PKG_INSTALLED) {
+	if (pkg->type == PKG_INSTALLED)
 		return (pkgdb_ensure_loaded_sqlite(db->sqlite, pkg, flags));
-	}
-	else {
-		/* Call repo functions */
-		tll_foreach(db->repos, cur) {
-			if (cur->item == pkg->repo) {
-				if (cur->item->ops->ensure_loaded) {
-					ret = cur->item->ops->ensure_loaded(cur->item, pkg, flags);
-					return (ret);
-				}
+
+	tll_foreach(db->repos, cur) {
+		if (cur->item == pkg->repo) {
+			if (cur->item->ops->ensure_loaded) {
+				return (cur->item->ops->ensure_loaded(cur->item,
+				    pkg, flags));
 			}
 		}
 	}

--- a/libpkg/pkghash.c
+++ b/libpkg/pkghash.c
@@ -151,7 +151,7 @@ pkghash_add(pkghash *table, const char *key, void *value, void (*free_func)(void
 size_t
 pkghash_count(pkghash *table)
 {
-	if (table == 0)
+	if (table == NULL)
 		return (0);
 	return (table->count);
 }

--- a/libpkg/private/pkg.h
+++ b/libpkg/private/pkg.h
@@ -610,10 +610,12 @@ int pkg_get_myarch_legacy(char *pkgarch, size_t sz);
 /**
  * Remove and unregister the package.
  * @param pkg An installed package to delete
+ * @param rpkg A package which will replace pkg, or NULL
  * @param db An opened pkgdb
  * @return An error code.
  */
-int pkg_delete(struct pkg *pkg, struct pkgdb *db, unsigned flags, struct triggers *);
+int pkg_delete(struct pkg *pkg, struct pkg *rpkg, struct pkgdb *db, int flags,
+    struct triggers *);
 #define PKG_DELETE_UPGRADE	(1 << 1)	/* delete as a split upgrade */
 #define PKG_DELETE_NOSCRIPT	(1 << 2)	/* don't run delete scripts */
 
@@ -683,7 +685,8 @@ pkg_formats packing_format_from_string(const char *str);
 const char* packing_format_to_string(pkg_formats format);
 bool packing_is_valid_format(const char *str);
 
-int pkg_delete_files(struct pkg *pkg, struct triggers *t);
+int pkg_delete_files(struct pkg *pkg, struct pkg *rpkg, int flags,
+    struct triggers *t);
 int pkg_delete_dirs(struct pkgdb *db, struct pkg *pkg, struct pkg *p);
 
 /* pkgdb commands */

--- a/libpkg/private/pkg_jobs.h
+++ b/libpkg/private/pkg_jobs.h
@@ -63,6 +63,7 @@ struct pkg_job_request {
 
 struct pkg_solved {
 	struct pkg_job_universe_item *items[2]; /* to-add/to-delete */
+	struct pkg_solved *xlink;	/* link split jobs together */
 	pkg_solved_t type;
 };
 typedef tll(struct pkg_solved *) pkg_solved;

--- a/libpkg/repo/binary/query.c
+++ b/libpkg/repo/binary/query.c
@@ -471,13 +471,18 @@ pkg_repo_binary_ensure_loaded(struct pkg_repo *repo,
 
 	/* Now move required elements to the provided package */
 	pkg_list_free(pkg, PKG_FILES);
+	pkg_list_free(pkg, PKG_CONFIG_FILES);
 	pkg_list_free(pkg, PKG_DIRS);
 	pkg->files = cached->files;
 	pkg->filehash = cached->filehash;
+	pkg->config_files = cached->config_files;
+	pkg->config_files_hash = cached->config_files_hash;
 	pkg->dirs = cached->dirs;
 	pkg->dirhash = cached->dirhash;
 	cached->files = NULL;
 	cached->filehash = NULL;
+	cached->config_files = NULL;
+	cached->config_files_hash = NULL;
 	cached->dirs = NULL;
 	cached->dirhash = NULL;
 
@@ -486,7 +491,6 @@ pkg_repo_binary_ensure_loaded(struct pkg_repo *repo,
 
 	return EPKG_OK;
 }
-
 
 int64_t
 pkg_repo_binary_stat(struct pkg_repo *repo, pkg_stats_t type)


### PR DESCRIPTION
A few minor bug fixes, then a commit which partly addresses FreeBSD PR 263879. The commit itself explains the change.

I would not consider the issue fully solved yet, since we still do not handle the case where a config file participates in a conflict. But, it's enough to fix my pkgbase upgrade problem.