### PR TITLE
Use SQLite3 safely

### DIFF
--- a/libpkg/pkgdb.c
+++ b/libpkg/pkgdb.c
@@ -336,6 +336,8 @@ static int
 pkgdb_init(sqlite3 *sdb)
 {
 	const char	sql[] = ""
+	"PRAGMA journal_mode = TRUNCATE;"
+	"PRAGMA synchronous = FULL;"
 	"BEGIN;"
 	"CREATE TABLE packages ("
 		"id INTEGER PRIMARY KEY,"
@@ -2925,8 +2927,6 @@ int
 pkgdb_begin_solver(struct pkgdb *db)
 {
 	const char solver_sql[] = ""
-		"PRAGMA synchronous = OFF;"
-		"PRAGMA journal_mode = MEMORY;"
 		"BEGIN TRANSACTION;";
 	const char update_digests_sql[] = ""
 		"DROP INDEX IF EXISTS pkg_digest_id;"
@@ -2992,9 +2992,7 @@ int
 pkgdb_end_solver(struct pkgdb *db)
 {
 	const char solver_sql[] = ""
-		"END TRANSACTION;"
-		"PRAGMA synchronous = NORMAL;"
-		"PRAGMA journal_mode = DELETE;";
+		"END TRANSACTION;";
 
 	return (sql_exec(db->sqlite, solver_sql));
 }

--- a/libpkg/repo/binary/init.c
+++ b/libpkg/repo/binary/init.c
@@ -482,7 +482,12 @@ pkg_repo_binary_init(struct pkg_repo *repo)
 
 	sqlite3_create_function(sqlite, "file_exists", 2, SQLITE_ANY, NULL,
 		    sqlite_file_exists, NULL, NULL);
-	retcode = sql_exec(sqlite, "PRAGMA synchronous=default");
+
+	retcode = sql_exec(sqlite, "PRAGMA journal_mode=TRUNCATE;");
+	if (retcode != EPKG_OK)
+		return (retcode);
+
+	retcode = sql_exec(sqlite, "PRAGMA synchronous=FULL");
 	if (retcode != EPKG_OK)
 		return (retcode);
 

--- a/libpkg/repo/binary/update.c
+++ b/libpkg/repo/binary/update.c
@@ -519,7 +519,8 @@ pkg_repo_binary_update_proceed(const char *name, struct pkg_repo *repo,
 	sql_exec(sqlite, "PRAGMA mmap_size = 209715200;");
 	sql_exec(sqlite, "PRAGMA page_size = %d;", getpagesize());
 	sql_exec(sqlite, "PRAGMA foreign_keys = OFF;");
-	sql_exec(sqlite, "PRAGMA synchronous = OFF;");
+	sql_exec(sqlite, "PRAGMA journal_mode = TRUNCATE;");
+	sql_exec(sqlite, "PRAGMA synchronous = FULL;");
 
 	rc = pkgdb_transaction_begin_sqlite(sqlite, "REPO");
 	if (rc != EPKG_OK)


### PR DESCRIPTION
For basically forever, `pkg` has used SQLite3 with `PRAGMA synchronous = OFF; PRAGMA journal_mode = MEMORY;`, at least during solver execution (which is when the database gets rewritten on package installs).  If pkg or the system crashes then, the database basically _will_ be corrupted.  This changes it to always do `PRAGMA synchronous = FULL; PRAGMA journal_mode = TRUNCATE;`, which is a safe mode that should mostly eliminate corruption.

I put an experimental fix that uses SQLite3 in its optimal mode up as #2009 but we probably don't need to go that far.  #2072 has prompted me to say "let's just fix it already" and this is the result.  Only lightly tested so far; I intend to build `pkg` with this and test it in a system install though.  Performance seems fine in light usage, even on a VM on a USB HDD.
