### PR TITLE
Non-trivial fixes for compiler warnings

### DIFF
--- a/external/libfetch/common.c
+++ b/external/libfetch/common.c
@@ -468,7 +468,7 @@ fetch_socks5_init(conn_t *conn, const char *host, int port, int verbose)
 		goto fail;
 	}
 	*ptr++ = strlen(host);
-	strncpy(ptr, host, strlen(host));
+	memcpy(ptr, host, strlen(host));
 	ptr = ptr + strlen(host);
 
 	port = htons(port);

--- a/libpkg/fetch.c
+++ b/libpkg/fetch.c
@@ -308,8 +308,8 @@ pkg_fetch_file_to_fd(struct pkg_repo *repo, const char *url, int dest,
 	}
 	pkg_emit_fetch_finished(url);
 
-	if (strcmp(u->scheme, "ssh") != 0 & strcmp(u->scheme, "tcp") != 0
-	    && ferror(remote)) {
+	if (strcmp(u->scheme, "ssh") != 0 && strcmp(u->scheme, "tcp") != 0 &&
+	    ferror(remote)) {
 		pkg_emit_error("%s: %s", url, fetchLastErrString);
 		retcode = EPKG_FATAL;
 		goto cleanup;

--- a/libpkg/lua.c
+++ b/libpkg/lua.c
@@ -52,7 +52,7 @@
 
 extern char **environ;
 
-lua_CFunction
+int
 stack_dump(lua_State *L)
 {
 	int i;

--- a/libpkg/lua_scripts.c
+++ b/libpkg/lua_scripts.c
@@ -93,7 +93,7 @@ pkg_lua_script_run(struct pkg * const pkg, pkg_lua_script type, bool upgrade)
 			close(cur_pipe[0]);
 			lua_State *L = luaL_newstate();
 			luaL_openlibs( L );
-			lua_atpanic(L, (lua_CFunction)stack_dump );
+			lua_atpanic(L, stack_dump);
 			lua_pushinteger(L, cur_pipe[1]);
 			lua_setglobal(L, "msgfd");
 			lua_pushlightuserdata(L, pkg);

--- a/libpkg/pkg.h.in
+++ b/libpkg/pkg.h.in
@@ -1704,7 +1704,7 @@ struct pkg_kvlist_iterator *pkg_kvlist_iterator(struct pkg_kvlist *l);
 struct pkg_kv *pkg_kvlist_next(struct pkg_kvlist_iterator *it);
 struct pkg_stringlist_iterator *pkg_stringlist_iterator(struct pkg_stringlist *l);
 const char *pkg_stringlist_next(struct pkg_stringlist_iterator *it);
-struct pkg_el *pkg_get_element(struct pkg *p, pkg_attr a);
+struct pkg_el *pkg_get_element(struct pkg *p, int a);
 
 #ifdef __cplusplus
 }

--- a/libpkg/pkg_attributes.c
+++ b/libpkg/pkg_attributes.c
@@ -214,7 +214,7 @@ pkg_stringlist_next(struct pkg_stringlist_iterator *it)
 }
 
 struct pkg_el *
-pkg_get_element(struct pkg *p, pkg_attr a)
+pkg_get_element(struct pkg *p, int a)
 {
 	struct pkg_el *e = xcalloc(1, sizeof(*e));
 

--- a/libpkg/pkg_audit.c
+++ b/libpkg/pkg_audit.c
@@ -533,11 +533,14 @@ pkg_audit_parse_vulnxml(struct pkg_audit *audit)
 	while (walk < end) {
 		r = yxml_parse(&x, *walk++);
 		switch (r) {
-		case YXML_EREF:
+		case YXML_EEOF:
 			pkg_emit_error("Unexpected EOF while parsing vulnxml");
 			goto out;
+		case YXML_EREF:
+			pkg_emit_error("Invalid entity encountered while parsing vulnxml");
+			goto out;
 		case YXML_ESTACK:
-			pkg_emit_error("Unexpected EOF while parsing vulnxml");
+			pkg_emit_error("Stack overflow while parsing vulnxml");
 			goto out;
 		case YXML_ESYN:
 			pkg_emit_error("Syntax error while parsing vulnxml");
@@ -547,7 +550,7 @@ pkg_audit_parse_vulnxml(struct pkg_audit *audit)
 			goto out;
 		case YXML_ELEMSTART:
 			vulnxml_start_element(&ud, &x);
-				break;
+			break;
 		case YXML_ELEMEND:
 			vulnxml_end_element(&ud, &x);
 			break;
@@ -560,9 +563,13 @@ pkg_audit_parse_vulnxml(struct pkg_audit *audit)
 		case YXML_ATTRSTART:
 			vulnxml_start_attribute(&ud, &x);
 			break;
-			/* ignore */
 		case YXML_ATTREND:
 			vulnxml_end_attribute(&ud, &x);
+			break;
+		case YXML_OK:
+		case YXML_PISTART:
+		case YXML_PICONTENT:
+		case YXML_PIEND:
 			/* ignore */
 			break;
 		}

--- a/libpkg/pkg_checksum.c
+++ b/libpkg/pkg_checksum.c
@@ -249,8 +249,10 @@ pkg_checksum_generate(struct pkg *pkg, char *dest, size_t destlen,
 		}
 	}
 
-	while (pkg_files(pkg, &f) == EPKG_OK) {
-		tll_push_back(entries, pkg_kv_new(f->path, f->sum));
+	if (inc_files) {
+		while (pkg_files(pkg, &f) == EPKG_OK) {
+			tll_push_back(entries, pkg_kv_new(f->path, f->sum));
+		}
 	}
 
 	/* Sort before hashing */

--- a/libpkg/pkg_event.c
+++ b/libpkg/pkg_event.c
@@ -1099,5 +1099,5 @@ pkg_emit_trigger(const char *name, bool cleanup)
 	ev.type = PKG_EVENT_TRIGGER;
 	ev.e_trigger.name = name;
 	ev.e_trigger.cleanup = cleanup;
-
+	pkg_emit_event(&ev);
 }

--- a/libpkg/pkg_jobs.c
+++ b/libpkg/pkg_jobs.c
@@ -1563,15 +1563,15 @@ pkg_jobs_find_install_candidates(struct pkg_jobs *j)
 {
 	struct pkg *pkg = NULL;
 	struct pkgdb_it *it;
-	candidates_t *candidates = xcalloc(1, sizeof(*candidates));
+	candidates_t *candidates;
 
 	if ((it = pkgdb_query(j->db, NULL, MATCH_ALL)) == NULL)
 		return (NULL);
 
+	candidates = xcalloc(1, sizeof(*candidates));
 	while (pkgdb_it_next(it, &pkg, PKG_LOAD_BASIC) == EPKG_OK) {
-
 		if ((j->flags & PKG_FLAG_FORCE) ||
-						pkg_jobs_check_remote_candidate(j, pkg)) {
+		    pkg_jobs_check_remote_candidate(j, pkg)) {
 			tll_push_front(*candidates, pkg->id);
 		}
 		pkg_free(pkg);

--- a/libpkg/private/lua.h
+++ b/libpkg/private/lua.h
@@ -27,7 +27,7 @@
 #include <lauxlib.h>
 #include <lualib.h>
 
-lua_CFunction stack_dump(lua_State *L);
+int stack_dump(lua_State *L);
 int lua_print_msg(lua_State *L);
 int lua_pkg_copy(lua_State *L);
 int lua_pkg_filecmp(lua_State *L);

--- a/tests/frontend/triggers.sh
+++ b/tests/frontend/triggers.sh
@@ -196,6 +196,7 @@ OUTPUT="Installing meh-1...
 \`-- Installing test-1...
 \`-- Extracting test-1:  done
 Extracting meh-1:  done
+==> Running trigger: trigger.ucl
 plop
 "
 	atf_check -o inline:"${OUTPUT}" pkg -o PKG_TRIGGERS_DIR="${TMPDIR}/trigger_dir" add meh-1.pkg


### PR DESCRIPTION
I spent a bit of time cleaning up all of the compiler errors from clang and gcc so that I can enable -Werror, since the lack of that flag bit me. Most of the reports are not interesting. This PR contains bug fixes that are at least somewhat interesting. In particular, I am not certain that the change to pkg_checksum.c is correct.