### PR TITLE
Fix max temp dir path length

### DIFF
--- a/libpkg/private/utils.h
+++ b/libpkg/private/utils.h
@@ -57,8 +57,8 @@ struct hardlink {
 };
 
 struct tempdir {
-	char name[MAXPATHLEN];
-	char temp[MAXPATHLEN];
+	char name[PATH_MAX];
+	char temp[PATH_MAX];
 	size_t len;
 	int fd;
 };

--- a/libpkg/private/utils.h
+++ b/libpkg/private/utils.h
@@ -57,8 +57,8 @@ struct hardlink {
 };
 
 struct tempdir {
-	char name[MAXHOSTNAMELEN];
-	char temp[MAXHOSTNAMELEN];
+	char name[MAXPATHLEN];
+	char temp[MAXPATHLEN];
 	size_t len;
 	int fd;
 };


### PR DESCRIPTION
tempdir name and temp length was erroneously set to MAXHOSTNAMELEN so paths with length greater than 64 were being truncated

This lead to packages failing to install (as shown in the following [issue](https://github.com/freebsd/pkg/issues/2104#issue-1528873214))