### PR TITLE
Don't ignore failed pre-install/post-install scripts/lua files in pkg-register(8) (#2073)

### DIFF
--- a/libpkg/pkg_ports.c
+++ b/libpkg/pkg_ports.c
@@ -1332,8 +1332,10 @@ pkg_add_port(struct pkgdb *db, struct pkg *pkg, const char *input_path,
 
 	if (!testing) {
 		/* Execute pre-install scripts */
-		pkg_lua_script_run(pkg, PKG_LUA_PRE_INSTALL, false);
-		pkg_script_run(pkg, PKG_SCRIPT_PRE_INSTALL, false, false);
+		if ((rc = pkg_lua_script_run(pkg, PKG_LUA_PRE_INSTALL, false)) != EPKG_OK)
+			goto cleanup;
+		if ((rc = pkg_script_run(pkg, PKG_SCRIPT_PRE_INSTALL, false, false)) != EPKG_OK)
+			goto cleanup;
 
 		if (input_path != NULL) {
 			pkg_register_cleanup_callback(pkg_rollback_cb, pkg);
@@ -1347,8 +1349,10 @@ pkg_add_port(struct pkgdb *db, struct pkg *pkg, const char *input_path,
 		}
 
 		/* Execute post-install scripts */
-		pkg_lua_script_run(pkg, PKG_LUA_POST_INSTALL, false);
-		pkg_script_run(pkg, PKG_SCRIPT_POST_INSTALL, false, false);
+		if ((rc = pkg_lua_script_run(pkg, PKG_LUA_POST_INSTALL, false)) != EPKG_OK)
+			goto cleanup;
+		if ((rc = pkg_script_run(pkg, PKG_SCRIPT_POST_INSTALL, false, false)) != EPKG_OK)
+			goto cleanup;
 	}
 
 	if (rc == EPKG_OK) {

--- a/tests/frontend/install.sh
+++ b/tests/frontend/install.sh
@@ -6,7 +6,7 @@ tests_init \
 	metalog \
 	reinstall \
 	pre_script_fail \
-	post_script_ignored \
+	post_script_fail \
 	install_missing_dep
 
 test_setup()
@@ -150,7 +150,7 @@ EOF
 		pkg -o REPOS_DIR="/dev/null" install -y ${TMPDIR}/test-1.pkg
 }
 
-post_script_ignored_body()
+post_script_fail_body()
 {
 	atf_check -s exit:0 sh ${RESOURCEDIR}/test_subr.sh new_pkg test test 1
 	cat << EOF >> test.ucl
@@ -167,7 +167,7 @@ EOF
 
 	atf_check -o ignore \
 		-e inline:"${PROGNAME}: POST-INSTALL script failed\n" \
-		-s exit:0 \
+		-s exit:3 \
 		pkg -o REPOS_DIR="/dev/null" install -y ${TMPDIR}/test-1.pkg
 }
 

--- a/tests/frontend/lua.sh
+++ b/tests/frontend/lua.sh
@@ -221,7 +221,7 @@ pkg: lua script failed\n"
 	mkdir -p ${TMPDIR}/target
 	atf_check \
 		-e inline:"${ERR}" \
-		-s exit:0 \
+		-s exit:3 \
 		pkg -o REPOS_DIR=/dev/null -r ${TMPDIR}/target install -qfy ${TMPDIR}/test-1.pkg
 }
 


### PR DESCRIPTION
When a package is registered through pkg-register(8) the return codes of pre-install and post-install scripts and lua files  are ignored. Now they are respected as with pkg-add(8).

This fixes #2073