### PR TITLE
Introduce `--without-procctl` to explicitly disable procctl hardening

### DIFF
--- a/auto.def
+++ b/auto.def
@@ -18,6 +18,7 @@ options {
 	with-coverage => "build with llvm coverage support"
 	with-asan => "build with libasan support"
 	with-ubsan => "Build with libubsan support"
+	without-procctl => "build explicitly without procctl hardening"
 	default-format:txz => "Default compression format: tzst, txz (default), tbz, tar"
 }
 
@@ -217,7 +218,11 @@ if {![cc-check-functions __res_query]} {
 }
 
 cc-check-includes link.h machine/endian.h osreldate.h readpassphrase.h \
-	sys/procctl.h sys/statfs.h sys/statvfs.h libutil.h
+	sys/statfs.h sys/statvfs.h libutil.h
+
+if {![opt-bool without-procctl]} {
+	cc-check-includes sys/procctl.h
+}
 
 # for compat
 cc-check-includes dirent.h


### PR DESCRIPTION
This knob explicitly disables procctl hardening support on platforms that provide it (i.e. FreeBSD). This build option is necessary in order for child processes spawned by scripts to be reparented to the system default repear (init) instead of being explicitly killed. Under normal circumstances pkg should not be starting long-lived processes. This is a nice-to-have knob for projects that would like to use the pkg infrastructure and need a way to restart daemons, etc.

If this is accepted, we will also want to expose this knob in the FreeBSD port as well.