### PR TITLE
Restore support of -e with other options

### DIFF
--- a/docs/pkg-query.8
+++ b/docs/pkg-query.8
@@ -30,9 +30,8 @@
 .Nm
 .Fl F Ao pkg-file Ac Ao query-format Ac
 .Nm
-.Fl e Ao evaluation-condition Ac Ao query-format Ac
-.Nm
 .Op Fl Cgix
+.Op Fl e Ao evaluation-condition Ac
 .Ao query-format Ac Ao pattern Ac Ao ... Ac
 .Pp
 .Nm
@@ -41,9 +40,8 @@
 .Nm
 .Cm --file Ao pkg-file Ac Ao query-format Ac
 .Nm
-.Cm --evaluate Ao evaluation-condition Ac Ao query-format Ac
-.Nm
 .Op Cm --{case-sensitive,glob,case-insensitive,regex}
+.Op Cm --evaluate Ao evaluation-condition Ac
 .Ao query-format Ac Ao pattern Ac Ao ... Ac
 .Sh DESCRIPTION
 .Nm
@@ -59,7 +57,7 @@ Make the standard or the regular expression
 .Fl ( x )
 matching against
 .Ar pkg-name
-case sensitive.
+in pattern case sensitive.
 .It Fl e , Cm --evaluate
 Match packages using the given
 .Ar evaluation-condition .
@@ -74,7 +72,7 @@ Make the standard or regular expression
 .Fl ( x )
 matching against
 .Ar pkg-name
-case insensitive.
+in pattern case insensitive.
 This is the default, unless modified by setting
 .Ev CASE_SENSITIVE_MATCH
 to true in

--- a/docs/pkg-rquery.8
+++ b/docs/pkg-rquery.8
@@ -30,12 +30,8 @@
 .Fl I Ns | Ns Ar query-format
 .Nm
 .Op Fl U
-.Fl e Ar evaluation-condition
-.Op Fl r Ar reponame
-.Fl I Ns | Ns Ar query-format
-.Nm
-.Op Fl U
 .Op Fl Cgix
+.Op Fl e Ar evaluation-condition
 .Op Fl r Ar reponame
 .Fl I Ns | Ns Ar query-format
 .Ar pattern ...
@@ -65,7 +61,7 @@ Make the standard or the regular expression
 .Pq Fl x
 matching against
 .Ar pkg-name
-case sensitive.
+in pattern case sensitive.
 .It Fl e Ar evaluation-condition , Fl -evaluate Ar evaluation-condition
 Match packages using the given
 .Ar evaluation-condition .
@@ -100,7 +96,7 @@ Make the standard or regular expression
 .Pq Fl x
 matching against
 .Ar pkg-name
-case insensitive.
+in pattern case insensitive.
 This is the default, unless modified by setting
 .Va CASE_SENSITIVE_MATCH
 to

--- a/src/query.c
+++ b/src/query.c
@@ -904,7 +904,6 @@ exec_query(int argc, char **argv)
 	const char 		*condition_sql = NULL;
 	xstring			*sqlcond = NULL;
 	const unsigned int	 q_flags_len = NELEM(accepted_query_flags);
-	size_t			optscount = 0;
 
 	struct option longopts[] = {
 		{ "all",		no_argument,		NULL,	'a' },
@@ -918,7 +917,6 @@ exec_query(int argc, char **argv)
 	};
 
 	while ((ch = getopt_long(argc, argv, "+aCe:F:gix", longopts, NULL)) != -1) {
-		optscount++;
 		switch (ch) {
 		case 'a':
 			match = MATCH_ALL;
@@ -950,13 +948,7 @@ exec_query(int argc, char **argv)
 	argc -= optind;
 	argv += optind;
 
-	if (optscount > 1 && condition != NULL) {
-		fprintf(stderr, "Usage: pkg query -e <evaluation> <query-format>\n"
-		    "'-e' flag do not accept any other argument\n");
-		return (EXIT_FAILURE);
-	}
-
-	if ((match == MATCH_ALL || condition != NULL || pkgname != NULL)
+	if ((match == MATCH_ALL || pkgname != NULL)
 	    && argc > 1) {
 		usage_query();
 		return (EXIT_FAILURE);

--- a/src/rquery.c
+++ b/src/rquery.c
@@ -122,7 +122,6 @@ exec_rquery(int argc, char **argv)
 	bool			 onematched = false;
 	bool			 old_quiet;
 	bool			 index_output = false;
-	size_t			 optscount = 0;
 
 	struct option longopts[] = {
 		{ "all",		no_argument,		NULL,	'a' },
@@ -140,7 +139,6 @@ exec_rquery(int argc, char **argv)
 	portsdir = pkg_object_string(pkg_config_get("PORTSDIR"));
 
 	while ((ch = getopt_long(argc, argv, "+aCgiIxe:r:U", longopts, NULL)) != -1) {
-		optscount++;
 		switch (ch) {
 		case 'a':
 			match = MATCH_ALL;
@@ -177,12 +175,6 @@ exec_rquery(int argc, char **argv)
 
 	argc -= optind;
 	argv += optind;
-
-	if (optscount > 1 && condition != NULL) {
-		fprintf(stderr, "Usage: pkg rquery -e <evaluation> [-r reponame] <query-format>\n"
-		    "'-e' flag do not accept any other argument\n");
-		exit(EXIT_FAILURE);
-	}
 
 	if (argc == 0 && !index_output) {
 		usage_rquery();

--- a/tests/frontend/query.sh
+++ b/tests/frontend/query.sh
@@ -73,33 +73,33 @@ EOF
 		pkg query -e "%#r>0" "%n: %rn %rv %ro"
 
 	atf_check \
-		-o empty \
-		-e match:"Usage:.*" \
-		-s exit:1 \
+		-o inline:"test: plop 1 plop\n" \
+		-e empty \
+		-s exit:0 \
 		pkg query -e "%#r>0" "%n: %rn %rv %ro" test
 
 	atf_check \
 		-o empty \
-		-e match:"Usage:.*" \
+		-e empty \
 		-s exit:1 \
 		pkg query -e "%#r>0" "%n: %rn %rv %ro" plop
 
 	atf_check \
-		-o empty \
-		-e match:"Usage:.*" \
-		-s exit:1 \
+		-o inline:"test: plop 1 plop\n" \
+		-e empty \
+		-s exit:0 \
 		pkg query -e "%#r>0" "%n: %rn %rv %ro" plop test
 
 	atf_check \
-		-o empty \
-		-e inline:"Usage: pkg query -e <evaluation> <query-format>\n'-e' flag do not accept any other argument\n" \
-		-s exit:1 \
+		-o inline:"test: plop 1 plop\n" \
+		-e empty \
+		-s exit:0 \
 		pkg query -ge "%#r>0" "%n: %rn %rv %ro" "p*p" "t*t"
 
 	atf_check \
-		-o empty \
-		-e inline:"Usage: pkg query -e <evaluation> <query-format>\n'-e' flag do not accept any other argument\n" \
-		-s exit:1 \
+		-o inline:"test: plop 1 plop\n" \
+		-e empty \
+		-s exit:0 \
 		pkg query -xe "%#r>0" "%n: %rn %rv %ro" "p.*p" "t.*t"
 
 	atf_check \
@@ -109,9 +109,9 @@ EOF
 		pkg query -e "%#d>0" "%n: %dn %dv %do"
 
 	atf_check \
-		-o empty \
-		-e match:"Usage:.*" \
-		-s exit:1 \
+		-o inline:"plop: test 1 test\n" \
+		-e empty \
+		-s exit:0 \
 		pkg query -e "%#d>0" "%n: %dn %dv %do" plop test
 
 	atf_check \


### PR DESCRIPTION
Issue #2078 was based on a mis-understanding of the semantics of the -i option. It does only apply to pkg-name pattern, not the values inside conditional expressions.

Support for string comparisons that ignore case have been added in a later commit, and thus there is now a way to express such filter conditions.

This commit effectively reverts commits cacd3d7298, c40314fea, and 1bf51ad3ab7 that added the restriction of -e not being allowed in combination with other options and which made the tests that should have warned about the regression match the new reality.

This update should be incorporated into a pkg release as soon as possible, since the current production version of pkg broke the conflicts checks in the ports system ("malke check-copnflicts").