### PR TITLE
Changes for the appstream plugin

### DIFF
--- a/libpkg/libpkg.ver
+++ b/libpkg/libpkg.ver
@@ -222,6 +222,11 @@ global:
 	pkgdb_transaction_rollback;
 	pkgdb_upgrade_lock;
 	ports_parse_plist;
+	pkg_repo_fetch_remote_tmp;
+	pkg_copy_file;
+	pkg_mkdirs;
+	pkg_emit_error;
+	pkg_emit_notice;
 # Symbols from libcsu
 	__progname;
 	environ;

--- a/libpkg/lua.c
+++ b/libpkg/lua.c
@@ -1,7 +1,9 @@
 /*-
  * Copyright (c) 2019-2022 Baptiste Daroussin <bapt@FreeBSD.org>
+ * Copyright (c) 2023 Serenity Cyber Security, LLC
+ *                    Author: Gleb Popov <arrowd@FreeBSD.org>
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
@@ -11,7 +13,7 @@
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
  * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
@@ -219,7 +221,7 @@ lua_pkg_copy(lua_State *L)
 		return (1);
 	}
 
-	if (!copy_file(fd1, fd2)) {
+	if (!pkg_copy_file(fd1, fd2)) {
 		lua_pushinteger(L, 2);
 		return (1);
 	}

--- a/libpkg/pkg.h.in
+++ b/libpkg/pkg.h.in
@@ -435,6 +435,7 @@ typedef enum _pkg_plugin_hook_t {
 	PKG_PLUGIN_HOOK_PRE_AUTOREMOVE,
 	PKG_PLUGIN_HOOK_POST_AUTOREMOVE,
 	PKG_PLUGIN_HOOK_PKGDB_CLOSE_RW,
+	PKG_PLUGIN_HOOK_REPO_UPDATE_SUCCESS,
 	PKG_PLUGIN_HOOK_LAST
 } pkg_plugin_hook_t;
 
@@ -1507,6 +1508,9 @@ mirror_t pkg_repo_mirror_type(struct pkg_repo *r);
 unsigned pkg_repo_priority(struct pkg_repo *r);
 unsigned pkg_repo_ip_version(struct pkg_repo *r);
 struct pkg_repo *pkg_repo_find(const char *name);
+int pkg_repo_fetch_remote_tmp(struct pkg_repo *repo,
+	const char *filename, const char *extension,
+	time_t *t, int *rc, bool silent);
 
 /**
  * pkg_printf() and friends.  These parallel the similarly named libc
@@ -1637,6 +1641,8 @@ bool pkg_is_locked(const struct pkg * restrict p);
 
 char *pkg_utils_tokenize(char **);
 int pkg_utils_count_spaces(const char *);
+int pkg_mkdirs(const char *path);
+bool pkg_copy_file(int from, int to);
 int pkg_add_port(struct pkgdb *db, struct pkg *pkg, const char *root, \
     const char *locationn, bool testing);
 char *pkg_absolutepath(const char *src, char *dest, size_t dest_len, bool fromroot);
@@ -1648,6 +1654,16 @@ int pkg_get_cachedirfd(void);
 int pkg_get_dbdirfd(void);
 
 int pkg_namecmp(struct pkg *, struct pkg *);
+
+#ifndef PKG_FORMAT_ATTRIBUTE
+#ifdef __GNUC__
+#define PKG_FORMAT_ATTRIBUTE(x, y) __attribute__ ((format (printf, (x), (y))));
+#else
+#define PKG_FORMAT_ATTRIBUTE(x, y)
+#endif
+#endif
+void pkg_emit_error(const char *fmt, ...) PKG_FORMAT_ATTRIBUTE(1, 2);
+void pkg_emit_notice(const char *fmt, ...) PKG_FORMAT_ATTRIBUTE(1, 2);
 
 struct pkg_create *pkg_create_new(void);
 void pkg_create_free(struct pkg_create *);

--- a/libpkg/pkg_create.c
+++ b/libpkg/pkg_create.c
@@ -3,6 +3,8 @@
  * Copyright (c) 2011-2012 Julien Laffaye <jlaffaye@FreeBSD.org>
  * Copyright (c) 2014-2015 Matthew Seaman <matthew@FreeBSD.org>
  * Copyright (c) 2014 Vsevolod Stakhov <vsevolod@FreeBSD.org>
+ * Copyright (c) 2023 Serenity Cyber Security, LLC
+ *                    Author: Gleb Popov <arrowd@FreeBSD.org>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -190,7 +192,7 @@ pkg_create_archive(struct pkg *pkg, struct pkg_create *pc, unsigned required_fla
 	if (pkg->type != PKG_OLD_FILE)
 		assert((pkg->flags & required_flags) == required_flags);
 
-	if (mkdirs(pc->outdir) != EPKG_OK)
+	if (pkg_mkdirs(pc->outdir) != EPKG_OK)
 		return NULL;
 
 	if (pkg_asprintf(&pkg_path, "%S/%n-%v", pc->outdir, pkg, pkg) == -1) {

--- a/libpkg/pkg_jobs.c
+++ b/libpkg/pkg_jobs.c
@@ -2338,7 +2338,7 @@ pkg_jobs_fetch(struct pkg_jobs *j)
 	struct statfs fs;
 	while (statfs(cachedir, &fs) == -1) {
 		if (errno == ENOENT) {
-			if (mkdirs(cachedir) != EPKG_OK)
+			if (pkg_mkdirs(cachedir) != EPKG_OK)
 				return (EPKG_FATAL);
 		} else {
 			pkg_emit_errno("statfs", cachedir);

--- a/libpkg/pkg_repo.c
+++ b/libpkg/pkg_repo.c
@@ -4,6 +4,8 @@
  * Copyright (c) 2011-2012 Marin Atanasov Nikolov <dnaeon@gmail.com>
  * Copyright (c) 2012-2015 Matthew Seaman <matthew@FreeBSD.org>
  * Copyright (c) 2014 Vsevolod Stakhov <vsevolod@FreeBSD.org>
+ * Copyright (c) 2023 Serenity Cyber Security, LLC
+ *                    Author: Gleb Popov <arrowd@FreeBSD.org>
  *
  * All rights reserved.
  *
@@ -64,7 +66,7 @@ struct sig_cert {
 	bool trusted;
 };
 
-static int
+int
 pkg_repo_fetch_remote_tmp(struct pkg_repo *repo,
   const char *filename, const char *extension, time_t *t, int *rc, bool silent)
 {
@@ -90,7 +92,7 @@ pkg_repo_fetch_remote_tmp(struct pkg_repo *repo,
 	tmpdir = getenv("TMPDIR");
 	if (tmpdir == NULL)
 		tmpdir = "/tmp";
-	mkdirs(tmpdir);
+	pkg_mkdirs(tmpdir);
 	snprintf(tmp, sizeof(tmp), "%s/%s.%s.XXXXXX", tmpdir, filename, extension);
 
 	fd = mkstemp(tmp);

--- a/libpkg/pkg_repo_create.c
+++ b/libpkg/pkg_repo_create.c
@@ -4,6 +4,8 @@
  * Copyright (c) 2011-2012 Marin Atanasov Nikolov <dnaeon@gmail.com>
  * Copyright (c) 2012-2013 Matthew Seaman <matthew@FreeBSD.org>
  * Copyright (c) 2014 Vsevolod Stakhov <vsevolod@FreeBSD.org>
+ * Copyright (c) 2023 Serenity Cyber Security, LLC
+ *                    Author: Gleb Popov <arrowd@FreeBSD.org>
  *
  * All rights reserved.
  *
@@ -137,7 +139,7 @@ hash_file(struct pkg_repo_meta *meta, struct pkg *pkg, char *path)
 	rel_dir = (char *)&tmp_name;
 	if (!is_dir(rel_dir)) {
 		pkg_debug(1, "Making directory: %s", rel_dir);
-		(void)mkdirs(rel_dir);
+		(void)pkg_mkdirs(rel_dir);
 	}
 
 	if (strcmp(path, hash_name) != 0) {

--- a/libpkg/pkg_repo_update.c
+++ b/libpkg/pkg_repo_update.c
@@ -2,6 +2,8 @@
  * Copyright (c) 2012-2014 Baptiste Daroussin <bapt@FreeBSD.org>
  * Copyright (c) 2012 Julien Laffaye <jlaffaye@FreeBSD.org>
  * Copyright (c) 2014 Vsevolod Stakhov <vsevolod@FreeBSD.org>
+ * Copyright (c) 2023 Serenity Cyber Security, LLC
+ *                    Author: Gleb Popov <arrowd@FreeBSD.org>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -49,5 +51,9 @@
 int
 pkg_update(struct pkg_repo *repo, bool force)
 {
-	return (repo->ops->update(repo, force));
+	int rc = repo->ops->update(repo, force);
+	if (rc == EPKG_OK) {
+		pkg_plugins_hook_run(PKG_PLUGIN_HOOK_REPO_UPDATE_SUCCESS, repo, NULL);
+	}
+	return rc;
 }

--- a/libpkg/pkgdb.c
+++ b/libpkg/pkgdb.c
@@ -697,7 +697,7 @@ pkgdb_check_access(unsigned mode, const char *dbname)
 		break;
 	case PKGDB_MODE_WRITE:
 		if (dbdirfd == -1) {
-			mkdirs(ctx.dbdir);
+			pkg_mkdirs(ctx.dbdir);
 			dbdirfd = pkg_get_dbdirfd();
 			if (dbdirfd == -1)
 				goto out;
@@ -706,7 +706,7 @@ pkgdb_check_access(unsigned mode, const char *dbname)
 		break;
 	case PKGDB_MODE_READ|PKGDB_MODE_WRITE:
 		if (dbdirfd == -1) {
-			mkdirs(ctx.dbdir);
+			pkg_mkdirs(ctx.dbdir);
 			dbdirfd = pkg_get_dbdirfd();
 			if (dbdirfd == -1)
 				goto out;
@@ -983,7 +983,7 @@ retry:
 		dbdirfd = pkg_get_dbdirfd();
 		if (dbdirfd == -1) {
 			if (errno == ENOENT) {
-				if (mkdirs(ctx.dbdir) != EPKG_OK) {
+				if (pkg_mkdirs(ctx.dbdir) != EPKG_OK) {
 					pkgdb_close(db);
 					return (EPKG_FATAL);
 				}

--- a/libpkg/private/event.h
+++ b/libpkg/private/event.h
@@ -3,6 +3,8 @@
  * Copyright (c) 2011-2012 Julien Laffaye <jlaffaye@FreeBSD.org>
  * Copyright (c) 2014 Vsevolod Stakhov <vsevolod@FreeBSD.org>
  * Copyright (c) 2015 Matthew Seaman <matthew@FreeBSD.org>
+ * Copyright (c) 2023 Serenity Cyber Security, LLC
+ *                    Author: Gleb Popov <arrowd@FreeBSD.org>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -30,13 +32,13 @@
 #ifndef _PKG_EVENT
 #define _PKG_EVENT
 
+#ifndef PKG_FORMAT_ATTRIBUTE
 #ifdef __GNUC__
 #define PKG_FORMAT_ATTRIBUTE(x, y) __attribute__ ((format (printf, (x), (y))));
 #else
 #define PKG_FORMAT_ATTRIBUTE(x, y)
 #endif
-void pkg_emit_error(const char *fmt, ...) PKG_FORMAT_ATTRIBUTE(1, 2);
-void pkg_emit_notice(const char *fmt, ...) PKG_FORMAT_ATTRIBUTE(1, 2);
+#endif
 void pkg_emit_errno(const char *func, const char *arg);
 
 #define pkg_errno(fmt, ...) \

--- a/libpkg/private/utils.h
+++ b/libpkg/private/utils.h
@@ -1,8 +1,10 @@
 /*-
  * Copyright (c) 2011-2022 Baptiste Daroussin <bapt@FreeBSD.org>
  * Copyright (c) 2011-2012 Julien Laffaye <jlaffaye@FreeBSD.org>
+ * Copyright (c) 2023 Serenity Cyber Security, LLC
+ *                    Author: Gleb Popov <arrowd@FreeBSD.org>
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
@@ -12,7 +14,7 @@
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
  * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
@@ -80,7 +82,6 @@ struct pkg_key;
 
 int32_t string_hash_func(const char *);
 
-int mkdirs(const char *path);
 int file_to_buffer(const char *, char **, off_t *);
 int file_to_bufferat(int, const char *, char **, off_t *);
 int format_exec_cmd(char **, const char *, const char *, const char *, const char *,
@@ -122,7 +123,6 @@ int checkflags(const char *mode, int *optr);
 bool match_ucl_lists(const char *buffer, const ucl_object_t *globs, const ucl_object_t *regexes);
 char *get_dirname(char *dir);
 char *rtrimspace(char *buf);
-bool copy_file(int from, int to);
 void hidden_tempfile(char *buf, int buflen, const char *path);
 void append_random_suffix(char *buf, int buflen, int suffixlen);
 char *json_escape(const char *str);

--- a/libpkg/repo/binary/fetch.c
+++ b/libpkg/repo/binary/fetch.c
@@ -4,6 +4,8 @@
  * Copyright (c) 2011-2012 Marin Atanasov Nikolov <dnaeon@gmail.com>
  * Copyright (c) 2012-2013 Matthew Seaman <matthew@FreeBSD.org>
  * Copyright (c) 2014 Vsevolod Stakhov <vsevolod@FreeBSD.org>
+ * Copyright (c) 2023 Serenity Cyber Security, LLC
+ *                    Author: Gleb Popov <arrowd@FreeBSD.org>
  *
  * All rights reserved.
  *
@@ -166,7 +168,7 @@ pkg_repo_binary_try_fetch(struct pkg_repo *repo, struct pkg *pkg,
 
 	/* Create the dirs in cachedir */
 	dir = get_dirname(xstrdup(dest));
-	if ((retcode = mkdirs(dir)) != EPKG_OK)
+	if ((retcode = pkg_mkdirs(dir)) != EPKG_OK)
 		goto cleanup;
 
 	/*

--- a/libpkg/utils.c
+++ b/libpkg/utils.c
@@ -2,8 +2,10 @@
  * Copyright (c) 2011-2020 Baptiste Daroussin <bapt@FreeBSD.org>
  * Copyright (c) 2011-2012 Julien Laffaye <jlaffaye@FreeBSD.org>
  * Copyright (c) 2013 Vsevolod Stakhov <vsevolod@FreeBSD.org>
+ * Copyright (c) 2023 Serenity Cyber Security, LLC
+ *                    Author: Gleb Popov <arrowd@FreeBSD.org>
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
@@ -13,7 +15,7 @@
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
  * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
@@ -93,7 +95,7 @@ match_ucl_lists(const char *buf, const ucl_object_t *globs, const ucl_object_t *
 }
 
 int
-mkdirs(const char *_path)
+pkg_mkdirs(const char *_path)
 {
 	char path[MAXPATHLEN];
 	char *p;
@@ -673,7 +675,7 @@ pkg_utils_tokenize(char **args)
 				else {
 					parse_state = ORDINARY_TEXT;
 					p_start = p;
-				}				
+				}
 			} else
 				p_start = p;
 			break;
@@ -890,7 +892,7 @@ _copy_file(int from, int to)
 }
 
 bool
-copy_file(int from, int to)
+pkg_copy_file(int from, int to)
 {
 #ifdef HAVE_COPY_FILE_RANGE
 	bool cfr = true;
@@ -962,7 +964,7 @@ hidden_tempfile(char *buf, int buflen, const char *path)
 	if (fname != NULL)
 		fname++;
 
-	/* 
+	/*
 	 * try to reduce the temporary name as much as possible to fit with very
 	 * long file names if possible. by default
 	 * .pkgtemp. fname . <suffix>
@@ -1009,7 +1011,7 @@ open_tempdir(int rootfd, const char *path)
 	char walk[MAXPATHLEN];
 	char *dir;
 	size_t cnt = 0;
-	
+
 	strlcpy(walk, path, sizeof(walk));
 	while ((dir = strrchr(walk, '/')) != NULL) {
 		struct tempdir *t;
@@ -1019,7 +1021,7 @@ open_tempdir(int rootfd, const char *path)
 		if (strlen(walk) == 0 && cnt == 1)
 			break;
 		if (strlen(walk) > 0) {
-			if (fstatat(rootfd, RELATIVE_PATH(walk), &st, 0) == -1) 
+			if (fstatat(rootfd, RELATIVE_PATH(walk), &st, 0) == -1)
 				continue;
 			if (S_ISDIR(st.st_mode) && cnt == 1)
 				break;


### PR DESCRIPTION
These are changes on the libpkg side that I need to implement a plugin for AppStream metadata fetching. This is a draft and isn't mean to be merged.

To sum it up:
1. I want to have `pkg_repo_fetch_remote_tmp` for a convenient fetching. Without it I have to re-do the logic of making up an url.
2. I need `pkg_emit_error`/`pkg_emit_notice` so that the plugin may report errors and informative messages.
3. It would be great to have access to `mkdirs` and `copy_file`. For now I just copied them into my plugin.

Exporting `pkg_repo_fetch_remote_tmp` isn't probably a right thing to do, so I'll be happy to do it right (rm) way.
