### PR TITLE
libpkg: remove existing before renaming temp dir #2041

### DIFF
--- a/libpkg/pkg_add.c
+++ b/libpkg/pkg_add.c
@@ -875,6 +875,10 @@ pkg_extract_finalize(struct pkg *pkg, tempdirs_t *tempdirs)
 
 	if (tempdirs != NULL) {
 		tll_foreach(*tempdirs, t) {
+			if (fstatat(pkg->rootfd, RELATIVE_PATH(t->item->name),
+			    &st, AT_SYMLINK_NOFOLLOW) == 0)
+				unlinkat(pkg->rootfd,
+				    RELATIVE_PATH(t->item->name), 0);
 			if (renameat(pkg->rootfd, RELATIVE_PATH(t->item->temp),
 			    pkg->rootfd, RELATIVE_PATH(t->item->name)) != 0) {
 				pkg_fatal_errno("Fail to rename %s -> %s",


### PR DESCRIPTION
Possible fix (well at least POC) for failing to rename temporary directory because target location exists.