### PR TITLE
fix auto.def:10: Error: wrong # args: should be "expr expression"

### DIFF
--- a/auto.def
+++ b/auto.def
@@ -7,7 +7,7 @@ set maj_ver 1
 set med_ver 20
 set min_ver 99
 set dev_ver 1
-define PKG_API [expr $maj_ver * 1000000 + $med_ver * 1000 + $min_ver]
+define PKG_API [expr {$maj_ver * 1000000 + $med_ver * 1000 + $min_ver}]
 define VERSION $maj_ver.$med_ver.$min_ver[expr {$dev_ver ? ".$dev_ver" : ""}]
 
 # Add any user options here


### PR DESCRIPTION
jimtcl allows only one argument to expr

PR: ports/272429