### PR TITLE
Introduce PKG_EVENT_PKG_ERRNO event to report pkg-specific error codes.

### DIFF
--- a/libpkg/fetch_libcurl.c
+++ b/libpkg/fetch_libcurl.c
@@ -1,6 +1,6 @@
 /*-
  * Copyright (c) 2023 Baptiste Daroussin <bapt@FreeBSD.org>
- * Copyright (c) 2023 Serenity Cyber Security, LLC
+ * Copyright (c) 2023 Serenity Cyber Security, LLC <license@futurecrew.ru>
  *                    Author: Gleb Popov <arrowd@FreeBSD.org>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -175,6 +175,10 @@ curl_do_fetch(struct curl_userdata *data, CURL *cl, struct curl_repodata *cr)
 		if (msg->msg == CURLMSG_DONE) {
 			if (msg->data.result == CURLE_ABORTED_BY_CALLBACK)
 				return (-1); // FIXME: more clear return code?
+			if (msg->data.result == CURLE_COULDNT_CONNECT
+				|| msg->data.result == CURLE_COULDNT_RESOLVE_HOST
+				|| msg->data.result == CURLE_COULDNT_RESOLVE_PROXY)
+				pkg_emit_pkg_errno(EPKG_NONETWORK, "curl_do_fetch", NULL);
 			CURL *eh = msg->easy_handle;
 			long rc = 0;
 			curl_easy_getinfo(eh, CURLINFO_RESPONSE_CODE, &rc);

--- a/libpkg/fetch_ssh.c
+++ b/libpkg/fetch_ssh.c
@@ -1,5 +1,7 @@
 /*-
  * Copyright (c) 2020 Baptiste Daroussin <bapt@FreeBSD.org>
+ * Copyright (c) 2023 Serenity Cyber Security, LLC <license@futurecrew.ru>
+ *                    Author: Gleb Popov <arrowd@FreeBSD.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -71,7 +73,9 @@ tcp_connect(struct pkg_repo *repo, struct yuarel *u)
 		hints.ai_family = PF_INET6;
 	hints.ai_socktype = SOCK_STREAM;
 	snprintf(srv, sizeof(srv), "%d", u->port);
-	if (getaddrinfo(u->host, srv, &hints, &ai) != 0) {
+	retcode = getaddrinfo(u->host, srv, &hints, &ai);
+	if (retcode != 0) {
+		pkg_emit_pkg_errno(EPKG_NONETWORK, "tcp_connect", gai_strerror(retcode));
 		pkg_emit_error("Unable to lookup for '%s'", u->host);
 		return (EPKG_FATAL);
 	}
@@ -88,6 +92,7 @@ tcp_connect(struct pkg_repo *repo, struct yuarel *u)
 	}
 	freeaddrinfo(ai);
 	if (sd == -1) {
+		pkg_emit_pkg_errno(EPKG_NONETWORK, "tcp_connect", NULL);
 		pkg_emit_error("Could not connect to tcp://%s:%d", u->host,
 		    u->port);
 		return (EPKG_FATAL);

--- a/libpkg/pkg.h.in
+++ b/libpkg/pkg.h.in
@@ -6,7 +6,7 @@
  * Copyright (c) 2011-2012 Marin Atanasov Nikolov <dnaeon@gmail.com>
  * Copyright (c) 2013-2014 Matthew Seaman <matthew@FreeBSD.org>
  * Copyright (c) 2014-2016 Vsevolod Stakhov <vsevolod@FreeBSD.org>
- * Copyright (c) 2023 Serenity Cyber Security, LLC
+ * Copyright (c) 2023 Serenity Cyber Security, LLC <license@futurecrew.ru>
  *                    Author: Gleb Popov <arrowd@FreeBSD.org>
  * All rights reserved.
  *
@@ -519,7 +519,11 @@ typedef enum {
 	/**
 	 * the operation was cancelled
 	 */
-	EPKG_CANCEL
+	EPKG_CANCEL,
+	/**
+	 * the operation has failed due to network down
+	 */
+	EPKG_NONETWORK
 } pkg_error_t;
 
 /**
@@ -1259,7 +1263,8 @@ typedef enum {
 	PKG_EVENT_CONFLICTS,
 	PKG_EVENT_TRIGGERS_BEGIN,
 	PKG_EVENT_TRIGGER,
-	PKG_EVENT_TRIGGERS_FINISHED
+	PKG_EVENT_TRIGGERS_FINISHED,
+	PKG_EVENT_PKG_ERRNO
 } pkg_event_t;
 
 struct pkg_event {

--- a/libpkg/pkg_event.c
+++ b/libpkg/pkg_event.c
@@ -2,6 +2,8 @@
  * Copyright (c) 2011-2013 Baptiste Daroussin <bapt@FreeBSD.org>
  * Copyright (c) 2011-2012 Julien Laffaye <jlaffaye@FreeBSD.org>
  * Copyright (c) 2015 Matthew Seaman <matthew@FreeBSD.org>
+ * Copyright (c) 2023 Serenity Cyber Security, LLC <license@futurecrew.ru>
+ *                    Author: Gleb Popov <arrowd@FreeBSD.org>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -464,6 +466,19 @@ pkg_emit_errno(const char *func, const char *arg)
 	ev.e_errno.func = func;
 	ev.e_errno.arg = arg;
 	ev.e_errno.no = errno;
+
+	pkg_emit_event(&ev);
+}
+
+void
+pkg_emit_pkg_errno(pkg_error_t err, const char *func, const char *arg)
+{
+	struct pkg_event ev;
+
+	ev.type = PKG_EVENT_PKG_ERRNO;
+	ev.e_errno.func = func;
+	ev.e_errno.arg = arg;
+	ev.e_errno.no = err;
 
 	pkg_emit_event(&ev);
 }

--- a/libpkg/private/event.h
+++ b/libpkg/private/event.h
@@ -40,6 +40,7 @@
 #endif
 #endif
 void pkg_emit_errno(const char *func, const char *arg);
+void pkg_emit_pkg_errno(pkg_error_t err, const char *func, const char *arg);
 
 #define pkg_errno(fmt, ...) \
 	pkg_emit_error(fmt":%s", __VA_ARGS__, strerror(errno))


### PR DESCRIPTION
Use this functionality to emit EPKG_NONETWORK when fetchers are unable to connect.

Sponsored by:	Serenity Cybersecurity, LLC