### PR TITLE
Fix iterating in the pkgdb_all_search(PKGDB_MAYBE_REMOTE) case.

### DIFF
--- a/libpkg/pkgdb_iterator.c
+++ b/libpkg/pkgdb_iterator.c
@@ -1132,8 +1132,6 @@ pkgdb_it_next(struct pkgdb_it *it, struct pkg **pkg_p, unsigned flags)
 		int r = pkgdb_sqlite_it_next(it->local, pkg_p, flags);
 		if ( r != EPKG_END)
 			return (r);
-		if (tll_length(it->remote))
-			return (EPKG_END);
 	}
 
 	if (tll_length(it->remote) != 0) {


### PR DESCRIPTION
The recent 204423dced0f30ff6a57031c2086e2bc7a2a0df3 change completely broke `pkgdb_all_search()` use case in PackageKit.

This patch fixes it and also seem to perfectly make sense. I hope it doesn't break anything else.