### PR TITLE
libpkg: don't complain about Last-Modified on failed fetches

### DIFF
--- a/libpkg/fetch_libcurl.c
+++ b/libpkg/fetch_libcurl.c
@@ -500,7 +500,8 @@ retry:
 
 	if (res == CURLE_OK && t >= 0) {
 		fi->mtime = t;
-	} else if (rc != 304) {
+	} else if (rc != 304 && retcode != EPKG_FATAL &&
+	    retcode != EPKG_CANCEL) {
 		pkg_emit_error("Impossible to get the value from Last-Modified"
 		    " HTTP header");
 		fi->mtime = 0;


### PR DESCRIPTION
We avoid complaining for HTTP 304, but let's also not complain if we've failed to fetch entirely (either out of retries or simply cancelled) to reduce the noise a little bit when packages simply haven't been built yet.  More importantly, it avoids leading one to believe that it's perhaps a misconfigured header setting rather than simply missing.