### PR TITLE
src/Makefile: create etcdir on install

### DIFF
--- a/src/Makefile.autosetup
+++ b/src/Makefile.autosetup
@@ -107,6 +107,7 @@ $(PROG): $(top_builddir)/libpkg/libpkg_flat.a
 install: $(PROG)
 	install -d -m 755 $(DESTDIR)$(sbindir)
 	install -m 755 pkg $(DESTDIR)$(sbindir)/pkg
+	install -d -m 755 $(DESTDIR)$(etcdir)
 	install -m 644 $(top_srcdir)/src/pkg.conf.sample $(DESTDIR)$(etcdir)/
 
 clean: clean-pkg-static


### PR DESCRIPTION
If etcdir does not exist, we get an error like the following on make install:

    install -m 644 /pkg/src/pkg.conf.sample /tmp/foo/etc/
    install: target '/tmp/foo/etc/' is not a directory: No such file or directory

I hit this when trying to install with a non-standard prefix.