### PR TITLE
Fix link of libpkg.so with lld >= 17

### DIFF
--- a/libpkg/Makefile.autosetup
+++ b/libpkg/Makefile.autosetup
@@ -125,7 +125,7 @@ LOCAL_LDFLAGS+=	-L$(top_builddir)/external/libmachista -lmachista_pic \
 SRCS+=		pkg_macho.c
 @else
 SRCS+=		pkg_elf.c
-LOCAL_LDFLAGS+=	-Wl,--version-script=$(top_srcdir)/libpkg/libpkg.ver \
+LOCAL_LDFLAGS+=	-Wl,--version-script=$(top_srcdir)/libpkg/libpkg.ver,--undefined-version \
 @endif
 
 @if libelf-internal


### PR DESCRIPTION
As of lld 17, it has become more strict about undefined symbols in version scripts, leading to errors while linking libpkg.so:

```
ld: error: version script assignment of 'LIBPKG_1.4' to symbol '__progname' failed: symbol not defined
ld: error: version script assignment of 'LIBPKG_1.4' to symbol 'environ' failed: symbol not defined
```

Note that in commit 841c436e these two symbols were explicitly added to libpkg.ver, under the description "Fix issue with recent lld by adding symbols from libcsu", but it is unclear to me which issue that is.

In any case, if these symbols are needed for *some* FreeBSD versions, but not for others, I would like to suggest using the linker option ``--undefined-version``, which stops it from producing errors on undefined versioned symbols, similar to what I did in freebsd/freebsd-src@2ba84b4bcdd6 2ba84b4bcdd6.