### PR TITLE
pkg-check: add -n to usage

### DIFF
--- a/src/check.c
+++ b/src/check.c
@@ -246,9 +246,9 @@ void
 usage_check(void)
 {
 	fprintf(stderr,
-	    "Usage: pkg check -B|-d|-s|-r [-qvy] -a\n");
+	    "Usage: pkg check -B|-d[n]|-s|-r [-qvy] -a\n");
 	fprintf(stderr,
-	    "       pkg check -B|-d|-s|-r [-qvy] [-Cgix] <pattern>\n\n");
+	    "       pkg check -B|-d[n]|-s|-r [-qvy] [-Cgix] <pattern>\n\n");
 	fprintf(stderr, "For more information see 'pkg help check'.\n");
 }
 


### PR DESCRIPTION
Not sure if adding it this way (-d[n]) makes sense or if it should be moved to other optional ones.