### PR TITLE
Fix transaction leaks in pkg_add_common()

### DIFF
--- a/docs/pkg-repo.8
+++ b/docs/pkg-repo.8
@@ -171,7 +171,7 @@ set to a directory having a
 containing a fingerprint style representation of the public key:
 .Bd -literal -offset indent
 function: sha256
-fingerprint: sha256_representation_of_the_public_key
+fingerprint: \\"sha256_representation_of_the_public_key\\"
 .Ed
 .Pp
 See the
@@ -290,7 +290,7 @@ EOF
 # On package server:
 % pkg repo /usr/ports/packages signing_command: ssh signing-server sign.sh
 # Generate fingerprint for sharing with clients
-% sh -c '( echo "function: sha256"; echo "fingerprint: $(sha256 -q repo.pub)"; ) > fingerprint'
+% sh -c '( echo "function: sha256"; echo "fingerprint: \\"$(sha256 -q repo.pub)\\""; ) > fingerprint'
 # The 'fingerprint' file should be distributed to all clients.
 
 # On clients with FINGERPRINTS: /usr/local/etc/pkg/fingerprints/myrepo:

--- a/libpkg/backup_lib.c
+++ b/libpkg/backup_lib.c
@@ -43,6 +43,7 @@ register_backup(struct pkgdb *db, int fd, const char *path)
 	char *lpath;
 	struct stat st;
 	pkghash_entry *e;
+	int retcode;
 
 	sum = pkg_checksum_generate_fileat(fd, RELATIVE_PATH(path), PKG_HASH_TYPE_SHA256_HEX);
 
@@ -83,8 +84,10 @@ register_backup(struct pkgdb *db, int fd, const char *path)
 		if (fstatat(pkg->rootfd, RELATIVE_PATH(f->path), &st, AT_SYMLINK_NOFOLLOW) != -1)
 			pkg->flatsize += st.st_size;
 	}
-	pkgdb_register_finale(db, pkgdb_register_pkg(db, pkg, 0, "backuplib"), "backuplib");
-	return (EPKG_OK);
+	retcode = pkgdb_register_pkg(db, pkg, 0, "backuplib");
+	if (retcode == EPKG_OK)
+		pkgdb_register_finale(db, EPKG_OK, "backuplib");
+	return (retcode);
 }
 
 void

--- a/libpkg/pkg_ports.c
+++ b/libpkg/pkg_ports.c
@@ -1204,9 +1204,10 @@ pkg_add_port(struct pkgdb *db, struct pkg *pkg, const char *input_path,
 
 	if (db != NULL) {
 		rc = pkgdb_register_pkg(db, pkg, 0, NULL);
-
-		if (rc != EPKG_OK)
+		if (rc != EPKG_OK) {
+			db = NULL;
 			goto cleanup;
+		}
 	}
 
 	if (!testing) {


### PR DESCRIPTION
This addresses issue #2182 or at least one instance of it that I hit.

Also included an unrelated, old commit to update pkg-repo documentation.