### PR TITLE
Fix roff escape sequence for accented char

### DIFF
--- a/docs/pkg.8
+++ b/docs/pkg.8
@@ -432,7 +432,7 @@ command first appeared in
 .An Matthew Seaman Aq matthew@FreeBSD.org ,
 .An Bryan Drewery Aq bryan@shatow.net ,
 .An Eitan Adler Aq eadler@FreeBSD.org ,
-.An Romain Tarti\`ere Aq romain@FreeBSD.org ,
+.An Romain Tarti\[`e]re Aq romain@FreeBSD.org ,
 .An Vsevolod Stakhov Aq vsevolod@FreeBSD.org ,
 .An Alexandre Perrin Aq alex@kaworu.ch
 .\" ---------------------------------------------------------------------------


### PR DESCRIPTION
Graham Perrin reported this typo on bugzilla:
https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=274291

Fix the syntax for accented char.
