### PR TITLE
curl: fix openssl double free during pkg_shutdown

### DIFF
--- a/external/curl/lib/vtls/openssl.c
+++ b/external/curl/lib/vtls/openssl.c
@@ -1705,6 +1705,9 @@ static int ossl_init(void)
 #else
     OPENSSL_INIT_LOAD_CONFIG |
 #endif
+#ifdef OPENSSL_INIT_NO_ATEXIT
+    OPENSSL_INIT_NO_ATEXIT |
+#endif
     0;
   OPENSSL_init_ssl(flags, NULL);
 #else


### PR DESCRIPTION
Fixes: https://github.com/freebsd/pkg/issues/2191

https://github.com/curl/curl/pull/12153

We should keep this until upstream curl takes this patch.