### PR TITLE
pkg.conf(5): HTTPS for pkg.freebsd.org

### DIFF
--- a/docs/pkg.conf.5
+++ b/docs/pkg.conf.5
@@ -576,7 +576,7 @@ file.
 Repository configuration file:
 .Bd -literal -offset indent
 FreeBSD: {
-    url: "pkg+http://pkg.freebsd.org/${ABI}/latest",
+    url: "pkg+https://pkg.freebsd.org/${ABI}/latest",
     enabled: true,
     signature_type: "fingerprints",
     fingerprints: "/usr/share/keys/pkg",

--- a/docs/pkg.conf.5
+++ b/docs/pkg.conf.5
@@ -15,7 +15,7 @@
 .\"     @(#)pkg.1
 .\" $FreeBSD$
 .\"
-.Dd April 26, 2022
+.Dd November 24, 2023
 .Dt PKG.CONF 5
 .Os
 .Sh NAME


### PR DESCRIPTION
d557a86c879a8515d59e8380b083b2265e9a3547
for HTTPS by default was committed to FreeBSD src on 2023-09-11.