### PR TITLE
libpkg: path can be NULL in first cleanup goto

### DIFF
--- a/libpkg/repo/binary/update.c
+++ b/libpkg/repo/binary/update.c
@@ -562,12 +562,12 @@ cleanup:
 		if (pkgdb_transaction_commit_sqlite(sqlite, "REPO") != EPKG_OK)
 			rc = EPKG_FATAL;
 	}
-	/* restore the previous db in case of failures */
-	if (rc != EPKG_OK && rc != EPKG_UPTODATE) {
-		unlink(name);
-		rename(path, name);
-	}
 	if (path != NULL) {
+		/* restore the previous db in case of failures */
+		if (rc != EPKG_OK && rc != EPKG_UPTODATE) {
+			unlink(name);
+			rename(path, name);
+		}
 		unlink(path);
 		free(path);
 	}


### PR DESCRIPTION
Noticed this while working on #2200.  Move the restore into the sanity check to avoid passing a NULL pointer and trying to restore a database that wasn't moved.