### PR TITLE
utils.c: return NULL when getenv(...) fails in get_http_auth() function

### DIFF
--- a/libpkg/utils.c
+++ b/libpkg/utils.c
@@ -1016,7 +1016,7 @@ get_http_auth(void)
 {
 	const char *str = getenv("HTTP_AUTH");
 	if (str == NULL)
-		return (false);
+		return (NULL);
 	if ((str = strchr(str, ':')) == NULL) {
 		pkg_emit_error("malformed HTTP_AUTH");
 		return (NULL);


### PR DESCRIPTION
See commit [message](https://github.com/freebsd/pkg/commit/c1d878bca90216eb10a75134177b61ca501411b9).