### PR TITLE
Introduce PKG_ISCHROOTED script environment variable

### DIFF
--- a/libpkg/pkg.h.in
+++ b/libpkg/pkg.h.in
@@ -703,6 +703,7 @@ int pkgdb_set2(struct pkgdb *db, struct pkg *pkg, ...);
  */
 int64_t pkg_set_debug_level(int64_t debug_level);
 int pkg_set_rootdir(const char *rootdir);
+int pkg_set_ischrooted(bool ischrooted);
 
 int pkg_open_devnull(void);
 void pkg_close_devnull(void);

--- a/libpkg/pkg_config.c
+++ b/libpkg/pkg_config.c
@@ -1657,6 +1657,16 @@ pkg_set_rootdir(const char *rootdir) {
 	return (EPKG_OK);
 }
 
+int
+pkg_set_ischrooted(bool ischrooted) {
+	if (pkg_initialized())
+		return (EPKG_FATAL);
+
+	ctx.ischrooted = ischrooted;
+
+	return (EPKG_OK);
+}
+
 const char *
 pkg_get_cachedir(void)
 {

--- a/libpkg/private/pkg.h
+++ b/libpkg/private/pkg.h
@@ -179,6 +179,7 @@ struct pkg_ctx {
 	bool defer_triggers;
 	bool repo_accept_legacy_pkg;
 	ip_version_t ip;
+	bool ischrooted;
 };
 
 extern struct pkg_ctx ctx;

--- a/libpkg/scripts.c
+++ b/libpkg/scripts.c
@@ -114,6 +114,8 @@ pkg_script_run(struct pkg * const pkg, pkg_script type, bool upgrade)
 			if (ctx.pkg_rootdir == NULL)
 				ctx.pkg_rootdir = "/";
 			setenv("PKG_ROOTDIR", ctx.pkg_rootdir, 1);
+			if (ctx.ischrooted)
+				setenv("PKG_CHROOTED", "true", 1);
 			debug = pkg_object_bool(pkg_config_get("DEBUG_SCRIPTS"));
 			if (debug)
 				fprintf(script_cmd->fp, "set -x\n");

--- a/src/main.c
+++ b/src/main.c
@@ -704,10 +704,12 @@ main(int argc, char **argv)
 		    "-j, -c and/or -r cannot be used at the same time!\n");
 	}
 
+	pkg_set_ischrooted(false);
 	if (chroot_path != NULL) {
 		if (chroot(chroot_path) == -1) {
 			err(EXIT_FAILURE, "chroot failed");
 		}
+		pkg_set_ischrooted(true);
 	}
 
 #ifdef HAVE_LIBJAIL


### PR DESCRIPTION
Used for detecting if running with `pkg --chroot` 