### PR TITLE
clean_cache.c, backup.c: remove unnecessary return, use goto jumps

### DIFF
--- a/libpkg/clean_cache.c
+++ b/libpkg/clean_cache.c
@@ -88,6 +88,5 @@ pkg_cache_full_clean(void)
 		return;
 
 	pkg_debug(1, "Cleaning up cachedir");
-
-	return (rm_rf(-1, NULL));
+	rm_rf(-1, NULL);
 }


### PR DESCRIPTION
draft (will edit it in a moment).