### PR TITLE
libpkg/pkg_jobs.c: use pkg_mkdirs() and not mkdirs()

### DIFF
--- a/libpkg/pkg_jobs.c
+++ b/libpkg/pkg_jobs.c
@@ -2379,7 +2379,7 @@ pkg_jobs_fetch(struct pkg_jobs *j)
 	struct statvfs fs;
 	while (statvfs(cachedir, &fs) == -1) {
 		if (errno == ENOENT) {
-			if (mkdirs(cachedir) != EPKG_OK)
+			if (pkg_mkdirs(cachedir) != EPKG_OK)
 				return (EPKG_FATAL);
 		} else {
 			pkg_emit_errno("statvfs", cachedir);


### PR DESCRIPTION
I couldn't able to find valid information regarding "mkdirs()" function. Grepping through the source, the only function that's defined called pkg_mkdirs() and not mkdirs(). As pkg_config.h already defines "HAVE_FSTATFS", the content inside the "elif" macro never passes the compiler and gets ignored entirely, otherwise the build would have been failed.