### PR TITLE
audit: Fix confusing single-line if/else statement

### DIFF
--- a/src/audit.c
+++ b/src/audit.c
@@ -398,8 +398,8 @@ exec_audit(int argc, char **argv)
 					if (quiet) {
 						if (version != NULL)
 							pkg_printf("%n-%v\n", pkg, pkg);
-							else
-						pkg_printf("%s\n", pkg);
+						else
+							pkg_printf("%s\n", pkg);
 						continue;
 					}
 


### PR DESCRIPTION
The unbracketed statement following the "else" is not indented and appears to be a part of the surrounding code. Fix the whitespace so it is clear that it is part of the conditional.