### PR TITLE
curl: Add support for SSL_CA_CERT_PATH env var

### DIFF
--- a/libpkg/fetch_libcurl.c
+++ b/libpkg/fetch_libcurl.c
@@ -367,6 +367,7 @@ curl_fetch(struct pkg_repo *repo, int dest, struct fetch_item *fi)
 	const char *sslkey = getenv("SSL_CLIENT_KEY_FILE");
 	const char *sslcert = getenv("SSL_CLIENT_CERT_FILE");
 	const char *ssl_ca_cert_file = getenv("SSL_CA_CERT_FILE");
+	const char *ssl_ca_cert_path = getenv("SSL_CA_CERT_PATH");
 	const char *netrc_file = getenv("NETRC");
 
 	struct curl_repodata *cr = (struct curl_repodata *)repo->fetch_priv;
@@ -458,6 +459,8 @@ retry:
 		curl_easy_setopt(cl, CURLOPT_SSLCERT, sslcert);
 	if (ssl_ca_cert_file != NULL)
 		curl_easy_setopt(cl, CURLOPT_CAINFO, ssl_ca_cert_file);
+	if (ssl_ca_cert_path != NULL)
+		curl_easy_setopt(cl, CURLOPT_CAPATH, ssl_ca_cert_path);
 	if (netrc_file != NULL)
 		curl_easy_setopt(cl, CURLOPT_NETRC_FILE, netrc_file);
 	curl_easy_setopt(cl, CURLOPT_NETRC, 1L);


### PR DESCRIPTION
Allow user to specify SSL_CA_CERT_PATH in repository configuration environment.