### PR TITLE
lua: Skip unused getenv call and silence unused variable

### DIFF
--- a/libpkg/lua.c
+++ b/libpkg/lua.c
@@ -200,7 +200,9 @@ lua_pkg_copy(lua_State *L)
 	int fd1, fd2;
 	struct timespec ts[2];
 
-	bool install_as_user = (getenv("INSTALL_AS_USER") != NULL);
+#ifdef HAVE_CHFLAGSAT
+        bool install_as_user = (getenv("INSTALL_AS_USER") != NULL);
+#endif
 
 	lua_getglobal(L, "rootfd");
 	int rootfd = lua_tointeger(L, -1);


### PR DESCRIPTION
On systems where HAVE_CHFLAGSAT is not defined (Linux) the install_as_user variable is not used. Silence the warning and don't bother calling getenv.