### PR TITLE
rcscripts: Only pass the basename of file to service(8)

### DIFF
--- a/libpkg/rcscripts.c
+++ b/libpkg/rcscripts.c
@@ -67,10 +67,10 @@ pkg_start_stop_rc_scripts(struct pkg *pkg, pkg_rc_attr attr)
 			rc++;
 			switch (attr) {
 			case PKG_RC_START:
-				ret += rc_start(rcfile);
+				ret += rc_start(rc);
 				break;
 			case PKG_RC_STOP:
-				ret += rc_stop(rcfile);
+				ret += rc_stop(rc);
 				break;
 			}
 		}


### PR DESCRIPTION
s/rcfile/rc/
Signed-off-by: Collin Funk <collin.funk1@gmail.com>