### PR TITLE
libpkg/sha256.c: remove non-standard memory.h header

### DIFF
--- a/libpkg/sha256.c
+++ b/libpkg/sha256.c
@@ -13,8 +13,7 @@
 *********************************************************************/
 
 /*************************** HEADER FILES ***************************/
-#include <stdlib.h>
-#include <memory.h>
+#include <string.h>
 #include "sha256.h"
 
 /****************************** MACROS ******************************/
@@ -40,7 +39,7 @@ static const WORD k[64] = {
 };
 
 /*********************** FUNCTION DEFINITIONS ***********************/
-void sha256_transform(SHA256_CTX *ctx, const BYTE data[])
+static void sha256_transform(SHA256_CTX *ctx, const BYTE data[])
 {
 	WORD a, b, c, d, e, f, g, h, i, j, t1, t2, m[64];
 
@@ -97,7 +96,7 @@ void sha256_init(SHA256_CTX *ctx)
 
 void sha256_update(SHA256_CTX *ctx, const BYTE data[], size_t len)
 {
-	WORD i;
+	size_t i;
 
 	for (i = 0; i < len; ++i) {
 		ctx->data[ctx->datalen] = data[i];


### PR DESCRIPTION
1. This implementation of SHA-256, doesn't seem like uses memory.h header anywhere except for prototyping memset() but according to POSIX standard, memset() prototype lives inside string.h header and doesn't explicitly say anything for memory.h.
I'm not even sure whether memory.h is in POSIX standard or not (I couldn't find any information regarding this), however, for portability purpose, string.h works better here.
Also, remove the stdlib.h header, it's not being used anywhere in the implementation.

2. Use size_t and not WORD (aka unsigned int). This is because if long is used to define WORD in 16-bit machines, it _may_ overflow as argument len is size_t which is always going to be unsigned.

3. Use static to mark the function sha256_transform(), that's not being used anywhere outside of that unit. (I forgot to add this message to the commit, but it's relatively tiny, so appending it here).