### PR TITLE
Install the flat version of the static library, to fix consumers

### DIFF
--- a/libpkg/Makefile.autosetup
+++ b/libpkg/Makefile.autosetup
@@ -181,7 +181,7 @@ install: all pkg.h lib$(LIB)$(LIBSOEXT) lib$(LIB)_flat.a
 	install -d -m 755 $(DESTDIR)$(pkgconfigdir)
 	install -m 644 lib$(LIB)$(LIBSOEXT) $(DESTDIR)$(libdir)/
 	ln -sf lib$(LIB)$(LIBSOEXT) $(DESTDIR)$(libdir)/lib$(LIB)$(SH_SOEXT)
-	install -m 644 lib$(LIB).a $(DESTDIR)$(libdir)/lib$(LIB).a
+	install -m 644 lib$(LIB)_flat.a $(DESTDIR)$(libdir)/lib$(LIB).a
 	install -m 644 pkg.h $(DESTDIR)$(includedir)/
 	install -m 644 $(top_srcdir)/libpkg/pkg/audit.h $(DESTDIR)$(includedir)/pkg
 	install -m 644 pkg.pc $(DESTDIR)$(pkgconfigdir)/


### PR DESCRIPTION
I found an issue on DragonFly BSD, where pkg builds with the internal libelf, but the installed and packaged libpkg.a doesn't contain the elf_* symbols.

I think it is a fix to 2c1678a commit, maybe just forgot to change the static lib to the flat version.
