### PR TITLE
external/blake2: use C99's inline keyword for inlining

### DIFF
--- a/external/blake2/blake2-impl.h
+++ b/external/blake2/blake2-impl.h
@@ -18,19 +18,7 @@
 #include <stdint.h>
 #include <string.h>
 
-#if !defined(__cplusplus) && (!defined(__STDC_VERSION__) || __STDC_VERSION__ < 199901L)
-  #if   defined(_MSC_VER)
-    #define BLAKE2_INLINE __inline
-  #elif defined(__GNUC__)
-    #define BLAKE2_INLINE __inline__
-  #else
-    #define BLAKE2_INLINE
-  #endif
-#else
-  #define BLAKE2_INLINE inline
-#endif
-
-static BLAKE2_INLINE uint32_t load32( const void *src )
+static inline uint32_t load32( const void *src )
 {
 #if defined(NATIVE_LITTLE_ENDIAN)
   uint32_t w;
@@ -45,7 +33,7 @@ static BLAKE2_INLINE uint32_t load32( const void *src )
 #endif
 }
 
-static BLAKE2_INLINE uint64_t load64( const void *src )
+static inline uint64_t load64( const void *src )
 {
 #if defined(NATIVE_LITTLE_ENDIAN)
   uint64_t w;
@@ -64,7 +52,7 @@ static BLAKE2_INLINE uint64_t load64( const void *src )
 #endif
 }
 
-static BLAKE2_INLINE uint16_t load16( const void *src )
+static inline uint16_t load16( const void *src )
 {
 #if defined(NATIVE_LITTLE_ENDIAN)
   uint16_t w;
@@ -77,7 +65,7 @@ static BLAKE2_INLINE uint16_t load16( const void *src )
 #endif
 }
 
-static BLAKE2_INLINE void store16( void *dst, uint16_t w )
+static inline void store16( void *dst, uint16_t w )
 {
 #if defined(NATIVE_LITTLE_ENDIAN)
   memcpy(dst, &w, sizeof w);
@@ -88,7 +76,7 @@ static BLAKE2_INLINE void store16( void *dst, uint16_t w )
 #endif
 }
 
-static BLAKE2_INLINE void store32( void *dst, uint32_t w )
+static inline void store32( void *dst, uint32_t w )
 {
 #if defined(NATIVE_LITTLE_ENDIAN)
   memcpy(dst, &w, sizeof w);
@@ -101,7 +89,7 @@ static BLAKE2_INLINE void store32( void *dst, uint32_t w )
 #endif
 }
 
-static BLAKE2_INLINE void store64( void *dst, uint64_t w )
+static inline void store64( void *dst, uint64_t w )
 {
 #if defined(NATIVE_LITTLE_ENDIAN)
   memcpy(dst, &w, sizeof w);
@@ -118,7 +106,7 @@ static BLAKE2_INLINE void store64( void *dst, uint64_t w )
 #endif
 }
 
-static BLAKE2_INLINE uint64_t load48( const void *src )
+static inline uint64_t load48( const void *src )
 {
   const uint8_t *p = ( const uint8_t * )src;
   return (( uint64_t )( p[0] ) <<  0) |
@@ -129,7 +117,7 @@ static BLAKE2_INLINE uint64_t load48( const void *src )
          (( uint64_t )( p[5] ) << 40) ;
 }
 
-static BLAKE2_INLINE void store48( void *dst, uint64_t w )
+static inline void store48( void *dst, uint64_t w )
 {
   uint8_t *p = ( uint8_t * )dst;
   p[0] = (uint8_t)(w >>  0);
@@ -140,18 +128,18 @@ static BLAKE2_INLINE void store48( void *dst, uint64_t w )
   p[5] = (uint8_t)(w >> 40);
 }
 
-static BLAKE2_INLINE uint32_t rotr32( const uint32_t w, const unsigned c )
+static inline uint32_t rotr32( const uint32_t w, const unsigned c )
 {
   return ( w >> c ) | ( w << ( 32 - c ) );
 }
 
-static BLAKE2_INLINE uint64_t rotr64( const uint64_t w, const unsigned c )
+static inline uint64_t rotr64( const uint64_t w, const unsigned c )
 {
   return ( w >> c ) | ( w << ( 64 - c ) );
 }
 
 /* prevents compiler optimizing out memset() */
-static BLAKE2_INLINE void secure_zero_memory(void *v, size_t n)
+static inline void secure_zero_memory(void *v, size_t n)
 {
   static void *(*const volatile memset_v)(void *, int, size_t) = &memset;
   memset_v(v, 0, n);


### PR DESCRIPTION
I'm aware that blake2 comes from an external repository, but the official implementation that pkg uses, hasn't seen an update for over 6 years (8 years for pkg repository) and no overall activity for over a year. There's, however, another repository, that implements the same blake2, with additional cleanups, but it also removes some functions (e.g. *16, load16, store16, etc.). Since the current implementation is quite right already, I personally don't think it need to be replaced.

Commit:
https://github.com/freebsd/pkg/commit/475f1e2123bf1dcb1f6a191b964b0cbc82c0b4e5