### PR TITLE
src/lock.c: return error if package is unavailable to lock/unlock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,8 @@ scripts/sbin/pkg2ng
 /external/linenoise/Makefile
 /external/libcurl/Makefile
 /external/libucl/Makefile
+/external/libucl/aclocal.m4
+/external/libucl/autom4te.cache
 /external/yxml/Makefile
 /external/liblua/Makefile
 /external/libmachista/Makefile


### PR DESCRIPTION
Commit (message): https://github.com/freebsd/pkg/commit/4d0b107a18ac308e39e62260e54b0ed3f4eebf8c
Closes: https://github.com/freebsd/pkg/issues/2211

Also, (I didn't mentioned in the commit message) added
```
/external/libucl/aclocal.m4
/external/libucl/autom4te.cache/
```
in the `.gitignore` file.
