### PR TITLE
src/audit.c: print the default filename, when argument file (-F) isn't provided

### DIFF
--- a/src/audit.c
+++ b/src/audit.c
@@ -278,7 +278,7 @@ exec_audit(int argc, char **argv)
 		if (errno == ENOENT)
 			warnx("vulnxml file %s does not exist. "
 					"Try running 'pkg audit -F' first",
-					audit_file);
+			    audit_file == NULL ? "vuln.xml" : audit_file);
 		else
 			warn("unable to open vulnxml file %s",
 					audit_file);


### PR DESCRIPTION
Running "pkg audit", if the vuln.xml file wasn't fetched, pkg will print this error message,

"pkg: vulnxml file (null) does not exist.
 Try running 'pkg audit -F' first"

as audit_file was initialized as NULL, and as we're not providing a file via the -F argument, this error message gets printed. pkg_audit_load() can handle this, as it checked against the NULL argument.

To fix this, just print the default filename, by checking whether the audit_file is NULL or not.