### PR TITLE
pkg-lock: add a message if there are no locked packages and fix man page typo

### DIFF
--- a/docs/pkg-lock.8
+++ b/docs/pkg-lock.8
@@ -14,7 +14,7 @@
 .\"
 .\"     @(#)pkg.8
 .\"
-.Dd January 14, 2021
+.Dd March 19, 2024
 .Dt PKG-LOCK 8
 .Os
 .Sh NAME
@@ -73,14 +73,14 @@ This includes:
 .Pp
 .Bl -bullet -compact
 .It
-Attempts to reinstall, up- or downgrade or delete the locked package
+Attempts to reinstall, upgrade, downgrade, or delete the locked package
 itself.
 .It
-Installation, up- or downgrade of a package where the resultant
+Installation, upgrade, or downgrade of a package where the resultant
 package would have a dependency on a different version of the locked
 package.
 .It
-Deletion, up- or downgrade of any package the locked package depends
+Deletion, upgrade, or downgrade of any package the locked package depends
 upon, either directly or as a consequence of installing or upgrading
 some third package.
 .El
@@ -88,7 +88,7 @@ some third package.
 The following options are supported by
 .Nm :
 .Bl -tag -width all
-.It Fl a , Fl --all
+.It Fl a , Fl -all
 Lock or unlock all installed packages.
 .It Fl C , Fl -case-sensitive
 Make the standard or the regular expression

--- a/src/lock.c
+++ b/src/lock.c
@@ -186,7 +186,7 @@ list_locked(struct pkgdb *db, bool has_locked)
 	}
 
 	if (!gotone && !quiet && !has_locked)
-		warnx("No locked packages were found.");
+		printf("No locked packages were found\n");
 
 	pkg_free(pkg);
 	pkgdb_it_free(it);

--- a/src/lock.c
+++ b/src/lock.c
@@ -171,23 +171,27 @@ list_locked(struct pkgdb *db, bool has_locked)
 		return (EXIT_FAILURE);
 	}
 
-	if (!quiet && !has_locked)
-		printf("Currently locked packages:\n");
-
-	while (pkgdb_it_next(it, &pkg, PKG_LOAD_BASIC) == EPKG_OK) {
-		gotone = true;
-		if (has_locked)
-			break;
+        while (pkgdb_it_next(it, &pkg, PKG_LOAD_BASIC) == EPKG_OK) {
+		if (!gotone) {
+			gotone = true;
+			if (has_locked) {
+				break;
+			} else {
+				if (!quiet) {
+					printf("Currently locked packages:\n");
+				}
+			}
+		}
 		pkg_printf("%n-%v\n", pkg, pkg);
 	}
+
+	if (!gotone && !quiet && !has_locked)
+		warnx("No locked packages were found.");
 
 	pkg_free(pkg);
 	pkgdb_it_free(it);
 
-	if (has_locked)
-		return (gotone ? EXIT_SUCCESS : EXIT_FAILURE);
-
-	return (EXIT_SUCCESS);
+	return (gotone ? EXIT_SUCCESS : EXIT_FAILURE);
 }
 
 static int

--- a/tests/frontend/lock.sh
+++ b/tests/frontend/lock.sh
@@ -52,9 +52,9 @@ lock_body() {
 	    pkg unlock -y sqlite3
 
 	atf_check \
-	    -o inline:"Currently locked packages:\n" \
+	    -o inline:"No locked packages were found\n" \
 	    -e empty \
-	    -s exit:0 \
+	    -s exit:1 \
 	    pkg lock -l
 
 	atf_check \
@@ -83,9 +83,9 @@ lock_body() {
 	    pkg unlock -y -a
 
 	atf_check \
-	    -o inline:"Currently locked packages:\n" \
+	    -o inline:"No locked packages were found\n" \
 	    -e empty \
-	    -s exit:0 \
+	    -s exit:1 \
 	    pkg lock -l
 }
 


### PR DESCRIPTION
Changes on
1. src/lock.c: https://github.com/freebsd/pkg/commit/3428300796864e77b13632277afd40d91f0f1157
2. tests/lock.sh: https://github.com/freebsd/pkg/commit/36316b8c1032f7e1e9a618f7d13319981a3a5ff7
3. docs/pkg-lock.8: https://github.com/freebsd/pkg/commit/353e7e219327a76477726888d5f0ee4557ef027f