### PR TITLE
external: import libder changes to zero out payloads

### DIFF
--- a/external/libder/README.md
+++ b/external/libder/README.md
@@ -8,6 +8,11 @@ re-encode the resulting tree would apply any normalization expected by a DER
 decoder.  The author's use is primarily to decode/encode ECC keys for
 interoperability with OpenSSL.
 
+The authoritative source for this software is located at
+https://git.kevans.dev/kevans/libder, but it's additionally mirrored to
+[GitHub](https://github.com/kevans91/libder) for user-facing interactions.
+Pull requests and issues are open on GitHub.
+
 ## What is libder not?
 
 libder is not intended to be a general-purpose library for working with DER/BER

--- a/external/libder/libder/libder_private.h
+++ b/external/libder/libder/libder_private.h
@@ -11,7 +11,12 @@
 #include <assert.h>
 #include <signal.h>
 #include <stdbool.h>
-
+#ifdef __APPLE__
+#define	__STDC_WANT_LIB_EXT1__	1
+#include <string.h>	/* memset_s */
+#else
+#include <strings.h>	/* explicit_bzero */
+#endif
 #include "libder.h"
 
 /* FreeBSD's sys/cdefs.h */
@@ -137,6 +142,17 @@ libder_type_simple(const struct libder_tag *type)
 
 	encoded |= type->tag_short;
 	return (encoded);
+}
+
+static inline void
+libder_bzero(uint8_t *buf, size_t bufsz)
+{
+
+#ifdef __APPLE__
+	memset_s(buf, bufsz, 0, bufsz);
+#else
+	explicit_bzero(buf, bufsz);
+#endif
 }
 
 size_t	 libder_get_buffer_size(struct libder_ctx *);

--- a/external/libder/libder/libder_write.c
+++ b/external/libder/libder/libder_write.c
@@ -213,6 +213,7 @@ libder_write(struct libder_ctx *ctx, struct libder_object *root, uint8_t *buf,
 	mwrite.buf = buf;
 	mwrite.bufsz = *bufsz;
 	if (!libder_write_object(ctx, root, &memory_write, &mwrite)) {
+		libder_bzero(mwrite.buf, mwrite.offset);
 		free(buf);
 		return (NULL);	/* XXX Error */
 	}


### PR DESCRIPTION
libder doesn't know whether it's dealing with sensitive material or not, so it now zeroes out every buffer it uses for DER data transport to be overly cautious.