### PR TITLE
Fix pkgsign overflow

### DIFF
--- a/external/libder/libder/libder_write.c
+++ b/external/libder/libder/libder_write.c
@@ -201,7 +201,7 @@ libder_write(struct libder_ctx *ctx, struct libder_object *root, uint8_t *buf,
 	/* Allocate if we weren't passed a buffer. */
 	if (*bufsz == 0) {
 		*bufsz = needed;
-		buf = malloc(needed + 1);
+		buf = malloc(needed);
 		if (buf == NULL)
 			return (NULL);
 	} else if (needed > *bufsz) {

--- a/libpkg/pkg_repo.c
+++ b/libpkg/pkg_repo.c
@@ -755,12 +755,8 @@ pkg_repo_archive_extract_check_archive(int fd, const char *file,
 		 * over the repo rather than raw.  This required some kludges
 		 * to work with, but future pkgsign_verify implementations
 		 * should not follow in its path.
-		 *
-		 * We reduce siglen by one to chop off the NULL terminator that
-		 * is packed in with it over in pkg_repo_finish().
 		 */
-		ret = pkgsign_verify(sctx, rkey, s->sig, s->siglen - 1,
-		    dest_fd);
+		ret = pkgsign_verify(sctx, rkey, s->sig, s->siglen, dest_fd);
 		if (ret != EPKG_OK) {
 			pkg_emit_error("Invalid signature, "
 					"removing repository.");

--- a/libpkg/pkg_repo_create.c
+++ b/libpkg/pkg_repo_create.c
@@ -1018,7 +1018,7 @@ pack_sign(struct packing *pack, struct pkgsign_ctx *sctx, const char *path,
 	}
 
 	iov[offset].iov_base = sigret;
-	iov[offset++].iov_len = siglen + 1;
+	iov[offset++].iov_len = siglen;
 
 	if (packing_append_iovec(pack, name, iov, offset) != EPKG_OK) {
 		free(sigret);


### PR DESCRIPTION
We shouldn't be reading past the declared size a signer returns, so push the current +/-1 hack that writes/reads a nul terminator into the ossl signer to avoid an overflow in other signers.