### PR TITLE
external: libder: fix after explicit_bzero() usage

### DIFF
--- a/external/libder/libder/libder_private.h
+++ b/external/libder/libder/libder_private.h
@@ -12,11 +12,11 @@
 #include <signal.h>
 #include <stdbool.h>
 #ifdef __APPLE__
-#define	__STDC_WANT_LIB_EXT1__	1
-#include <string.h>	/* memset_s */
-#else
-#include <strings.h>	/* explicit_bzero */
+#define	__STDC_WANT_LIB_EXT1__	1	/* memset_s */
 #endif
+/* explicit_bzero is in one of these... */
+#include <string.h>
+#include <strings.h>
 #include "libder.h"
 
 /* FreeBSD's sys/cdefs.h */


### PR DESCRIPTION
explicit_bzero() is in <strings.h> on FreeBSD, but <string.h> on Linux -- just include both.