### PR TITLE
elfhints.c: include endian.h, copy from pkg_elf.c

### DIFF
--- a/libpkg/elfhints.c
+++ b/libpkg/elfhints.c
@@ -30,6 +30,13 @@
 #include <bsd_compat.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
+#ifdef HAVE_SYS_ENDIAN_H
+#include <sys/endian.h>
+#elif HAVE_ENDIAN_H
+#include <endian.h>
+#elif HAVE_MACHINE_ENDIAN_H
+#include <machine/endian.h>
+#endif
 
 #include <assert.h>
 #include <ctype.h>


### PR DESCRIPTION
In a FreeBSD 12 environment, the following build errors occur.
elfhits.c needs to include endian.h
```
elfhints.c:457:10: error: implicit declaration of function 'be32toh' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
        is_be = be32toh(hdr->magic) == ELFHINTS_MAGIC;
                ^
elfhints.c:458:6: error: implicit declaration of function 'le32toh' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
        if (COND_SWAP(hdr->magic) != ELFHINTS_MAGIC)
            ^
elfhints.c:72:44: note: expanded from macro 'COND_SWAP'
#define COND_SWAP(n) (is_be ? be32toh(n) : le32toh(n))
                                           ^
elfhints.c:458:6: note: did you mean 'be32toh'?
elfhints.c:72:44: note: expanded from macro 'COND_SWAP'
#define COND_SWAP(n) (is_be ? be32toh(n) : le32toh(n))
                                           ^
elfhints.c:457:10: note: 'be32toh' declared here
        is_be = be32toh(hdr->magic) == ELFHINTS_MAGIC;
                ^
elfhints.c:481:11: error: implicit declaration of function 'be32toh' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
                is_be = be32toh(1) == 1;
                        ^
elfhints.c:512:14: error: implicit declaration of function 'be32toh' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
        hdr.magic = COND_SWAP(ELFHINTS_MAGIC);
                    ^
elfhints.c:72:31: note: expanded from macro 'COND_SWAP'
#define COND_SWAP(n) (is_be ? be32toh(n) : le32toh(n))
                              ^
elfhints.c:512:14: error: implicit declaration of function 'le32toh' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
elfhints.c:72:44: note: expanded from macro 'COND_SWAP'
#define COND_SWAP(n) (is_be ? be32toh(n) : le32toh(n))
```