### PR TITLE
Add support for storing a list of expired packages in the meta

### DIFF
--- a/libpkg/pkg.h.in
+++ b/libpkg/pkg.h.in
@@ -6,8 +6,8 @@
  * Copyright (c) 2011-2012 Marin Atanasov Nikolov <dnaeon@gmail.com>
  * Copyright (c) 2013-2014 Matthew Seaman <matthew@FreeBSD.org>
  * Copyright (c) 2014-2016 Vsevolod Stakhov <vsevolod@FreeBSD.org>
- * Copyright (c) 2023 Serenity Cyber Security, LLC <license@futurecrew.ru>
- *                    Author: Gleb Popov <arrowd@FreeBSD.org>
+ * Copyright (c) 2023-2024 Serenity Cyber Security, LLC <license@futurecrew.ru>
+ *                         Author: Gleb Popov <arrowd@FreeBSD.org>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -843,6 +843,7 @@ void pkg_repo_create_set_output_dir(struct pkg_repo_create *prc, const char *);
 void pkg_repo_create_set_metafile(struct pkg_repo_create *prc, const char *);
 void pkg_repo_create_set_sign(struct pkg_repo_create *prc, char **argv, int argc, pkg_password_cb *cb);
 void pkg_repo_create_set_groups(struct pkg_repo_create *prc, const char *);
+void pkg_repo_create_set_expired_packages(struct pkg_repo_create *prc, const char *);
 int pkg_repo_create(struct pkg_repo_create *, char *path);
 
 /**

--- a/libpkg/private/pkg.h
+++ b/libpkg/private/pkg.h
@@ -311,6 +311,7 @@ struct pkg_repo_create {
 	const char *metafile;
 	struct pkg_repo_meta *meta;
 	ucl_object_t *groups;
+	ucl_object_t *expired_packages;
 	struct {
 		char **argv;
 		int argc;

--- a/libpkg/repo/binary/update.c
+++ b/libpkg/repo/binary/update.c
@@ -640,6 +640,9 @@ pkg_repo_binary_update_proceed(const char *name, struct pkg_repo *repo,
 		pkg_emit_progress_tick(cnt, nbel);
 		save_ucl(repo,
 		    ucl_object_ref(ucl_object_find_key(data, "groups")), "groups.ucl");
+		save_ucl(repo,
+		    ucl_object_ref(ucl_object_find_key(data, "expired_packages")),
+		    "expired_packages.ucl");
 	}
 
 	if (rc == EPKG_OK)


### PR DESCRIPTION
This is a draft PR that I wanted to show off before proceeding further.

- I generalized `group_open_schema()` into `open_schema()`.
- `group_load()` and `expired_load()` may be generalized too.
- Add a config option that would remove expired packages during `pkg upgrade`? Or maybe `pkg autoremove`?
- What will actually pass `-e` to the `pkg repo` call? Changes are required on the Poudriere side?
- Bikeshedding? Should this be called "expired_packages" or somehow else?