### PR TITLE
Fix missing packages without license when %L is used

### DIFF
--- a/libpkg/pkgdb_iterator.c
+++ b/libpkg/pkgdb_iterator.c
@@ -515,7 +515,7 @@ static int
 pkgdb_load_license(sqlite3 *sqlite, struct pkg *pkg)
 {
 	const char	 sql[] = ""
-		"SELECT name "
+		"SELECT ifnull(group_concat(name, ', '), '') AS name"
 		"  FROM pkg_licenses, licenses AS l"
 		"  WHERE package_id = ?1"
 		"    AND license_id = l.id"


### PR DESCRIPTION
Reverted this change https://github.com/freebsd/pkg/commit/5edd062df23d708c0dc7c2b58a07de9b38b92a98 otherwise, pkg query won't report packages without licenses when `%L` is used.
See also https://github.com/freebsd/pkg/issues/1510