### PR TITLE
pkg_create.3, pkg_repo_create.3: fix typos

### DIFF
--- a/docs/pkg_create.3
+++ b/docs/pkg_create.3
@@ -43,7 +43,7 @@ which should be freed by the caller using
 .Fn pkg_create_free .
 .Pp
 .Fn pkg_create_set_format
-will define the compresion format to use.
+will define the compression format to use.
 By default
 .Qq txz
 except if specified otherwise in
@@ -77,8 +77,8 @@ a local file already exists.
 The default behaviour is to overwrite.
 .Pp
 .Fn pkg_create_set_rootdir
-tells the program where to find the root used for packaging (also called
-sometime staging area).
+Tells the program where to find the root directory used for packaging (it is
+also known as staging area).
 If none is provided pkg will consider
 .Sq Va / .
 .Pp

--- a/docs/pkg_repo_create.3
+++ b/docs/pkg_repo_create.3
@@ -64,7 +64,7 @@ Defaults to
 .Fn pkg_repo_create_set_hash_symlink
 If the
 .Va hash
-functionnality has been activated, then there will be a symlink for each
+functionality has been activated, then there will be a symlink for each
 packages in the
 .Qq Hashed
 directory will be created in the root of the repository.
@@ -78,7 +78,7 @@ to the metafile that will be used when creating the repository. If none is
 specified that it will fallback on the internal default.
 .Pp
 .Fn pkg_repo_create_set_sign
-Define the signing mecanism, which will be used to sign the metadata of the
+Define the signing mechanism, which will be used to sign the metadata of the
 repository. Defaults to none.
 .Pp
 .Fn pkg_repo_create


### PR DESCRIPTION
1. [pkg_create.3: fix typo and improve *_set_rootdir line](https://github.com/freebsd/pkg/commit/87e7c9c43a0e3f2859f852853f6996e55df1cdb3)
2. [pkg_repo_create.3: fix typos](https://github.com/freebsd/pkg/commit/5d86571b292cc2581779e40278168e23c4c78664)