### PR TITLE
pkg-create(8): fix description of --all

### DIFF
--- a/docs/pkg-create.8
+++ b/docs/pkg-create.8
@@ -137,12 +137,12 @@ The following options are supported by
 .It Fl a , Cm --all
 Create package tarballs from all packages installed on your system.
 This option is incompatible with the
-.It Fl e , Cm --expand-manifest
-The manifest contained in pkg will be expanded to readable UCL format.
 .Fl g , x
 or
 .Fl m Ar metadatadir
 options.
+.It Fl e , Cm --expand-manifest
+The manifest contained in pkg will be expanded to readable UCL format.
 .It Fl g , Cm --glob
 Interpret
 .Ar pkg-name


### PR DESCRIPTION
The manual page for pkg-create(8) looked like this:

OPTIONS
     The following options are supported by pkg create:

     -a, --all         Create package tarballs from all packages installed on
                       your system.  This option is incompatible with the

     -e, --expand-manifest
                       The manifest contained in pkg will be expanded to
                       readable UCL format.  -g, -x or -m metadatadir options.

The "expand-manifest" entry was misplaced and just needs to be
moved a bit down.

Reported by: TommyC on EFnet #freebsd