### PR TITLE
Second take on handling vital flag in the solver

### DIFF
--- a/libpkg/pkg_jobs.c
+++ b/libpkg/pkg_jobs.c
@@ -669,7 +669,7 @@ _is_orphaned(struct pkg_jobs *j, const char *uid)
 		return (false);
 	unit = pkg_jobs_universe_find(j->universe, uid);
 	if (unit != NULL) {
-		if (!unit->pkg->automatic)
+		if (!unit->pkg->automatic || unit->pkg->vital)
 			return (false);
 		npkg = unit->pkg;
 	} else {
@@ -678,7 +678,7 @@ _is_orphaned(struct pkg_jobs *j, const char *uid)
 		    PKG_LOAD_SHLIBS_REQUIRED|PKG_LOAD_REQUIRES);
 		if (npkg == NULL)
 			return (false);
-		if (!npkg->automatic) {
+		if (!npkg->automatic || npkg->vital) {
 			pkg_free(npkg);
 			return (false);
 		}
@@ -1500,7 +1500,7 @@ jobs_solve_deinstall(struct pkg_jobs *j)
 		while (pkgdb_it_next(it, &pkg, PKG_LOAD_BASIC|PKG_LOAD_RDEPS|
 		    PKG_LOAD_DEPS|PKG_LOAD_ANNOTATIONS|PKG_LOAD_PROVIDES|
 		    PKG_LOAD_SHLIBS_PROVIDED) == EPKG_OK) {
-			if(pkg->locked) {
+			if(pkg->locked || pkg->vital) {
 				if (tsearch(pkg, &j->lockedpkgs, comp) == NULL) {
 					pkgdb_it_free(it);
 					return (EPKG_FATAL);

--- a/libpkg/pkg_solve.c
+++ b/libpkg/pkg_solve.c
@@ -1,5 +1,7 @@
 /*-
  * Copyright (c) 2013-2017 Vsevolod Stakhov <vsevolod@FreeBSD.org>
+ * Copyright (c) 2024 Serenity Cyber Security, LLC <license@futurecrew.ru>
+ *                    Author: Gleb Popov <arrowd@FreeBSD.org>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -633,6 +635,7 @@ pkg_solve_process_universe_variable(struct pkg_solve_problem *problem,
 	struct pkg_jobs *j = problem->j;
 	struct pkg_job_request *jreq = NULL;
 	bool chain_added = false;
+	bool force = j->flags & PKG_FLAG_FORCE;
 
 	LL_FOREACH(var, cur_var) {
 		pkg = cur_var->unit->pkg;
@@ -1121,7 +1124,7 @@ reiterate:
 		for (i = 0; i < problem->nvars; i ++) {
 			struct pkg_solve_variable *var = &problem->variables[i];
 
-			if (var->flags & PKG_VAR_TOP) {
+			if (var->flags & PKG_VAR_TOP || var->unit->pkg->vital) {
 				if (var->flags & PKG_VAR_FAILED) {
 					var->flags ^= PKG_VAR_INSTALL | PKG_VAR_FAILED;
 				}

--- a/src/delete.c
+++ b/src/delete.c
@@ -191,7 +191,7 @@ exec_delete(int argc, char **argv)
 	}
 
 	if (pkg_jobs_has_lockedpkgs(jobs)) {
-		printf("The following package(s) are locked and may not ");
+		printf("The following package(s) are locked or vital and may not ");
 		printf("be removed:\n\n");
 		pkg_jobs_iter_lockedpkgs(jobs, print_pkg, &locked_pkgs);
 		putchar('\n');

--- a/tests/frontend/upgrade.sh
+++ b/tests/frontend/upgrade.sh
@@ -9,7 +9,8 @@ tests_init \
 	dual_conflict \
 	file_become_dir \
 	dir_become_file \
-	dir_is_symlink_to_a_dir
+	dir_is_symlink_to_a_dir \
+	vital
 
 issue1881_body() {
 	atf_check -s exit:0 sh ${RESOURCEDIR}/test_subr.sh new_pkg pkg1 pkg_a 1
@@ -283,4 +284,45 @@ dir_is_symlink_to_a_dir_body()
 	echo "${TMPDIR}/share/something/file" >> plist-2
 	atf_check pkg create -M pkg.ucl -p plist-2
 	atf_check -o ignore pkg -o REPOS_DIR="${TMPDIR}" -r ${TMPDIR}/target install -Uy ${TMPDIR}/pkg-2.pkg
+}
+
+vital_body() {
+	atf_check -s exit:0 sh ${RESOURCEDIR}/test_subr.sh new_pkg "meta" "mymeta" "1"
+	mkdir file-pkg-1
+	cat << EOF >> meta.ucl
+vital = true;
+EOF
+	echo entry > file-pkg-1/file
+	echo "${TMPDIR}/file-pkg-1/file" > plist-1
+	atf_check pkg create -M meta.ucl -p plist-1
+	mkdir target
+	atf_check -o ignore pkg -o REPOS_DIR="${TMPDIR}" -r ${TMPDIR}/target install -Uy ${TMPDIR}/mymeta-1.pkg
+	atf_check -s exit:0 sh ${RESOURCEDIR}/test_subr.sh new_pkg "plop" "myplop" "1"
+	atf_check pkg create -M plop.ucl
+	atf_check -o ignore pkg -o REPOS_DIR="${TMPDIR}" -r ${TMPDIR}/target install -Uy ${TMPDIR}/myplop-1.pkg
+	atf_check -s exit:0 sh ${RESOURCEDIR}/test_subr.sh new_pkg "plop" "myplop" "2"
+	echo "${TMPDIR}/file-pkg-1/file" > plist-2
+	atf_check pkg create -M plop.ucl -p plist-2
+	mkdir repoconf
+	cat << EOF > repoconf/repo.conf
+local: {
+	url: file:///$TMPDIR,
+	enabled: true
+}
+EOF
+
+	atf_check -o ignore pkg repo .
+	atf_check -o ignore pkg -o REPOS_DIR="$TMPDIR/repoconf" -r ${TMPDIR}/target -o PKG_CACHEDIR="$TMPDIR" update
+	OUTPUT="Updating local repository catalogue...
+local repository is up to date.
+All repositories are up to date.
+Checking for upgrades (2 candidates):  done
+Processing candidates (2 candidates):  done
+Checking integrity... done (1 conflicting)
+  - myplop-2 conflicts with mymeta-1 on ${TMPDIR}/file-pkg-1/file
+Cannot solve problem using SAT solver, trying another plan
+Checking integrity... done (0 conflicting)
+Your packages are up to date.
+"
+	atf_check -o inline:"${OUTPUT}" pkg -o REPOS_DIR="$TMPDIR/repoconf" -r ${TMPDIR}/target -o PKG_CACHEDIR="$TMPDIR" upgrade -y
 }

--- a/tests/frontend/vital.sh
+++ b/tests/frontend/vital.sh
@@ -40,8 +40,8 @@ EOF
 
 	atf_check \
 		-o empty \
-		-e inline:"${PROGNAME}: Cannot delete vital package: test!\n${PROGNAME}: If you are sure you want to remove test, \n${PROGNAME}: unset the 'vital' flag with: pkg set -v 0 test\n" \
-		-s exit:3 \
+		-e empty  \
+		-s exit:1 \
 		pkg -r ${TMPDIR}/target delete -qy test
 	atf_check \
 		-o empty \


### PR DESCRIPTION
The change is surprisingly simple, but seems to work. I tested it in following cases:

- Simple `pkg upgrade` of a vital package. It turned out that my previous change broke even this primitive case.
- My initial case with diamond dependency graph (common `libdep` package, `foo` and `bar` depending on `libdep`, and `meta` package marked vital depending on `foo` and `bar`. Trying `pkg upgrade` that previously resulted in `meta` removal now correctly discards this plan and says that there is nothing to upgrade.
- A case with vital package split. I suspect this case was broken by the first one, but now it also works.

While there, I also made `pkg autoremove` not propose removing `vital` but `automatic` package. And made `pkg delete` to refuse removing vital package on the frontend side.