### PR TITLE
pkg.conf.sample: pkgbase: prime-origins | sort -u

### DIFF
--- a/src/pkg.conf.sample
+++ b/src/pkg.conf.sample
@@ -66,7 +66,7 @@ ALIAS              : {
   iinfo: info -ix,
   isearch: search -ix,
   prime-list: "query -e '%a = 0' '%n'",
-  prime-origins: "query -e '%a = 0' '%o' | uniq | sort",
+  prime-origins: "query -e '%a = 0' '%o' | sort -u",
   leaf: "query -e '%#r == 0' '%n-%v'",
   list: info -ql,
   noauto = "query -e '%a == 0' '%n-%v'",

--- a/src/pkg.conf.sample
+++ b/src/pkg.conf.sample
@@ -66,7 +66,7 @@ ALIAS              : {
   iinfo: info -ix,
   isearch: search -ix,
   prime-list: "query -e '%a = 0' '%n'",
-  prime-origins: "query -e '%a = 0' '%o'",
+  prime-origins: "query -e '%a = 0' '%o' | uniq | sort",
   leaf: "query -e '%#r == 0' '%n-%v'",
   list: info -ql,
   noauto = "query -e '%a == 0' '%n-%v'",


### PR DESCRIPTION
Where pkgbase is used: without uniq(2), prime-origins will probably list hundreds of identical lines for base.

With one pipe in use, you may as well use a second: sort(1).