### PR TITLE
pkg.c: change error message from dup2 to dup

### DIFF
--- a/libpkg/pkg.c
+++ b/libpkg/pkg.c
@@ -1451,7 +1451,7 @@ pkg_open_root_fd(struct pkg *pkg)
 	path = pkg_kv_get(&pkg->annotations, "relocated");
 	if (path == NULL) {
 		if ((pkg->rootfd = dup(ctx.rootfd)) == -1) {
-			pkg_emit_errno("dup2", "rootfd");
+			pkg_emit_errno("dup", "rootfd");
 			return (EPKG_FATAL);
 		}
 		return (EPKG_OK);


### PR DESCRIPTION
In pkg_open_root_fd() dup() is used to duplicate a file descriptor. However, the on error it prints dup2() (where the error occurred), instead of dup(). This patch changes the function (error message) according to its previous call.