### PR TITLE
Improve --debug output when libcurl is used

### DIFF
--- a/libpkg/fetch_libcurl.c
+++ b/libpkg/fetch_libcurl.c
@@ -445,8 +445,10 @@ do_retry:
 	if (ctx.debug_flags & PKG_DBG_FETCH && ctx.debug_level >= 1) {
 		const char *lurl = NULL;
 		curl_easy_getinfo(cl, CURLINFO_EFFECTIVE_URL, &lurl);
-		pkg_dbg(PKG_DBG_FETCH, 2, "CURL> attempting to fetch from %s, left retry %ld\n",
-				lurl, retry);
+		if (lurl) {
+			pkg_dbg(PKG_DBG_FETCH, 2, "CURL> attempting to fetch from %s\n", lurl);
+		}
+		pkg_dbg(PKG_DBG_FETCH, 2, "CURL> retries left: %ld\n", retry);
 	}
 	curl_easy_setopt(cl, CURLOPT_HTTPAUTH, (long)CURLAUTH_ANY);
 	if (userpasswd != NULL) {


### PR DESCRIPTION
Original issue: https://github.com/freebsd/pkg/issues/2302

Note: I cannot test this code, as I am unable to get pkg to use libcurl instead of fetch.  `sudo src/pkg -d -C /usr/local/etc/pkg.conf upgrade` (after building) should suffice, but only seems to leverage libfetch and I don't see a `--flag` for forcing this anywhere.  I clearly see a bunch of stuff in external/libucrl/configure.ac relating to this, and it seems to pick libfetch first due to fetch.h existing -- which makes me wonder why the official FreeBSD pkg binary is using libcurl and not libfetch.  That gets into ports management which I do not want to discuss, period.