### PR TITLE
pkg: fix build on Linux

### DIFF
--- a/compat/bsd_compat.h
+++ b/compat/bsd_compat.h
@@ -80,6 +80,10 @@
 #include <bsd/libutil.h>
 #endif
 
+#ifdef HAVE_BSD_SYS_TIME_H
+#include <bsd/sys/time.h>
+#endif
+
 #include <sys/stat.h>
 #include "endian_util.h"
 


### PR DESCRIPTION
\* Commit 6238273fe6d7f571390e0c078e57dd120ab830a8 requires BSD specific time functions, which are unavailable on Linux. Using sys/time.h header from libbsd (already being used) does however solve this problem.

This commit doesn't enable this though. Apparently, I don't know how to enable this macro for a specific platform. I tried to add this in auto.def and it worked, but I don't think that was right as it didn't check for platform. 