### PR TITLE
Add support for using external 3-way merge tool when handling @config items

### DIFF
--- a/libpkg/pkg_config.c
+++ b/libpkg/pkg_config.c
@@ -367,6 +367,12 @@ static struct config_entry c[] = {
 	},
 	{
 		PKG_STRING,
+		"MERGETOOL",
+		NULL,
+		"Path to a program to be used for solving conflicts during the 3-way merging"
+	},
+	{
+		PKG_STRING,
 		"VERSION_SOURCE",
 		NULL,
 		"Version source for pkg-version (I, P, R), default is auto detect"


### PR DESCRIPTION
The introduced MERGETOOL config option expects a value in form "/path/to/program %b %l %r %o" where
* "%b" is the file containing the original config shipped by the previous version of the package
* "%l" is the file containing the current config (%b that is possibly altered by the user)
* "%r" is the new config that is going to be installed by the new package
* "%o" is the file that should be created by the too and contain the merge result
* "%n" is the name of file as listed in the pkg-plist with leading '/' stripped

If the merge tool return a non-zero code, pkg will attempt to the merging using a builtin algorithm.