### PR TITLE
bsd_compat.h: fix getprogname() to use program_invocation_* on glibc

### DIFF
--- a/compat/bsd_compat.h
+++ b/compat/bsd_compat.h
@@ -196,15 +196,15 @@ FILE * funopen(const void *cookie, int (*readfn)(void *, char *, int),
 #endif
 
 #if !HAVE_GETPROGNAME
-#if defined(__linux__)
-extern char *__progname;
-# define getprogname() __progname
-#elif defined(__GLIBC__)
+# if defined (__linux__) && defined (__GLIBC__)
 extern char *program_invocation_short_name;
-# define getprogname() program_invocation_short_name
-#else
-# error "Don't know how to replace getprogname()"
-#endif
+#  define getprogname()    program_invocation_short_name
+# elif defined (__linux__) && !defined (__GLIBC__)
+extern char *__progname;
+#  define getprogname()    __progname
+# else
+#  error "Don't know how to replace getprogname()"
+# endif
 #endif
 
 #endif


### PR DESCRIPTION
On glibc getprogname() isn't using the `program_invocation_short_name` instead it's using `__progname` global variable. It wasn't checking the existence of `__GLIBC__` macro, so it always falls back to `__progname`, and never went to the glibc part.