### PR TITLE
src/{event.c,updating.c}: fix error handling if strdup() fails and some cleanup

### DIFF
--- a/src/event.c
+++ b/src/event.c
@@ -183,16 +183,18 @@ job_status_begin(xstring *msg)
 void
 progressbar_start(const char *pmsg)
 {
-	free(progress_message);
-	progress_message = NULL;
+	if (progress_message) {
+		free(progress_message);
+		progress_message = NULL;
+	}
 
 	if (quiet)
 		return;
 	if (pmsg != NULL)
-		progress_message = strdup(pmsg);
+		progress_message = xstrdup(pmsg);
 	else {
 		fflush(msg_buf->fp);
-		progress_message = strdup(msg_buf->buf);
+		progress_message = xstrdup(msg_buf->buf);
 	}
 	last_progress_percent = -1;
 	last_tick = 0;

--- a/src/updating.c
+++ b/src/updating.c
@@ -194,18 +194,21 @@ matcher(const char *affects, const char *origin, bool ignorecase)
 			}
 		}
 		if (found == 0) {
-			ent = malloc(sizeof(struct regex_cache));
-			if (ent == NULL)
-				goto err;
+			if ((ent = malloc(sizeof(struct regex_cache))) == NULL) {
+				ret = 0;
+				goto out;
+			}
 			if ((ent->pattern = strdup(words[i])) == NULL) {
 				free(ent);
-				goto err;
+				ret = 0;
+				goto out;
 			}
 			re = convert_re(words[i]);
 			if (re == NULL) {
 				free(ent->pattern);
 				free(ent);
-				goto err;
+				ret = 0;
+				goto out;
 			}
 			regcomp(&ent->reg, re, (ignorecase) ? REG_ICASE|REG_EXTENDED : REG_EXTENDED);
 			free(re);
@@ -217,13 +220,10 @@ matcher(const char *affects, const char *origin, bool ignorecase)
 		}
 	}
 
+out:
 	free(words);
 	free(buf);
-	return ret;
- err:
-	free(words);
-	free(buf);
-	return 0;
+	return (ret);
 }
 
 int


### PR DESCRIPTION
Commit messages
1. [src/updating.c: set error code before jumping to out](https://github.com/freebsd/pkg/commit/79575708fb8eb0c4fc0455667c14e9852f2212a5)
2. [src/event.c: free() progress_message only when it's not empty](https://github.com/freebsd/pkg/commit/10b52a95cd550cecdff05b9d88063f6c64a44777)