### PR TITLE
jobs: drop pkg_jobs_universe_change_uid()

### DIFF
--- a/libpkg/private/pkg_jobs.h
+++ b/libpkg/private/pkg_jobs.h
@@ -39,6 +39,11 @@
 struct pkg_jobs;
 struct job_pattern;
 
+/*
+ * Each item in pkg_jobs_universe->items is the head of a doubly linked list
+ * and has inhash set to true. Other items with the same uid are added to
+ * this doubly linked list and have inhash set to false.
+ */
 struct pkg_job_universe_item {
 	struct pkg *pkg;
 	int priority;

--- a/libpkg/private/pkg_jobs.h
+++ b/libpkg/private/pkg_jobs.h
@@ -75,17 +75,10 @@ struct pkg_job_provide {
 	struct pkg_job_provide *next, *prev;
 };
 
-struct pkg_job_replace {
-	char *new_uid;
-	char *old_uid;
-	struct pkg_job_replace *next;
-};
-
 struct pkg_jobs_universe {
 	pkghash *items;		/* package uid, pkg_job_universe_item */
 	pkghash *seen;		/* package digest, pkg_job_universe_item */
 	pkghash *provides;	/* shlibs, pkg_job_provide */
-	struct pkg_job_replace *uid_replaces;
 	struct pkg_jobs *j;
 	size_t nitems;
 };
@@ -183,13 +176,6 @@ struct pkg_job_universe_item* pkg_jobs_universe_find(struct pkg_jobs_universe
  */
 int pkg_jobs_universe_add_pkg(struct pkg_jobs_universe *universe,
 	struct pkg *pkg, bool force, struct pkg_job_universe_item **found);
-
-/*
- * Change uid for universe item
- */
-void pkg_jobs_universe_change_uid(struct pkg_jobs_universe *universe,
-	struct pkg_job_universe_item *unit,
-	const char *new_uid, bool update_rdeps);
 
 /*
  * Find local package in db or universe


### PR DESCRIPTION
This function is unused since 1921a4fca.

~~Getting rid of it also allows us to get rid of the inhash field of pkg_job_universe_item as all universe items are now always in universe->items (as one might expect).~~
