### PR TITLE
Simplify pkg_jobs_solve()/pkg_jobs_apply() control flow

### DIFF
--- a/libpkg/private/pkg_jobs.h
+++ b/libpkg/private/pkg_jobs.h
@@ -200,11 +200,6 @@ int pkg_conflicts_append_chain(struct pkg_job_universe_item *it,
 	struct pkg_jobs *j);
 
 /*
- * Perform integrity check for the jobs specified
- */
-int pkg_conflicts_integrity_check(struct pkg_jobs *j);
-
-/*
  * Check whether `rp` is an upgrade for `lp`
  */
 bool pkg_jobs_need_upgrade(struct pkg *rp, struct pkg *lp);

--- a/libpkg/private/pkg_jobs.h
+++ b/libpkg/private/pkg_jobs.h
@@ -102,7 +102,7 @@ struct pkg_jobs {
 	struct pkgdb	*db;
 	pkg_jobs_t	 type;
 	pkg_flags	 flags;
-	int		 solved;
+	bool solved;
 	int count;
 	int total;
 	int conflicts_registered;


### PR DESCRIPTION
This pull request simplifies the currently overly complex control flow in pkg_jobs_solve() and pkg_jobs_apply().

There should be no changes to observable behavior of pkg.

I've kept the individual commits small and independent which should hopefully make this patchset easier to review.