### PR TITLE
Small fixes to improve code, fix crash condition

### DIFF
--- a/libpkg/pkg_add.c
+++ b/libpkg/pkg_add.c
@@ -1139,7 +1139,7 @@ pkg_add_check_pkg_archive(struct pkgdb *db, struct pkg *pkg,
 	const char	*arch;
 	int	ret, retcode;
 	struct pkg_dep	*dep = NULL;
-	char	bd[MAXPATHLEN], *basedir = NULL;
+	char	bd[MAXPATHLEN];
 	char	dpath[MAXPATHLEN], *ppath;
 	const char	*ext = NULL;
 	struct pkg	*pkg_inst = NULL;
@@ -1187,8 +1187,14 @@ pkg_add_check_pkg_archive(struct pkgdb *db, struct pkg *pkg,
 	fromstdin = STREQ(path, "-");
 	strlcpy(bd, path, sizeof(bd));
 	if (!fromstdin) {
-		basedir = get_dirname(bd);
-		strlcpy(bd, basedir, sizeof(bd));
+		/* In-place truncate bd to the directory components. */
+		char *basedir = strrchr(bd, '/');
+		if (NULL == basedir) {
+			bd[0]='.';
+			bd[1]='\0';
+		} else {
+			*basedir = '\0';
+		}
 		if ((ext = strrchr(path, '.')) == NULL) {
 			pkg_emit_error("%s has no extension", path);
 			return (EPKG_FATAL);

--- a/libpkg/repo/binary/update.c
+++ b/libpkg/repo/binary/update.c
@@ -89,7 +89,7 @@ pkg_repo_binary_delete_conflicting(const char *origin, const char *version,
     bool forced)
 {
 	int ret = EPKG_FATAL;
-	const char *oversion;
+	const unsigned char *oversion;
 
 	if (pkg_repo_binary_run_prstatement(REPO_VERSION, origin) != SQLITE_ROW) {
 		ret = EPKG_FATAL;

--- a/libpkg/utils.c
+++ b/libpkg/utils.c
@@ -804,6 +804,13 @@ get_socketpair(int *pipe)
 	return (r);
 }
 
+/*
+ * Modify the passed C-String by stripping off the last component delimited by '/'.
+ * Return the string. Return a constant "." when passed NULL or the empty string.
+ * FIXME: This routine corrupts memory when passed the empty string.
+ * FIXME: This routine should propagate NULL.
+ * TODO: Refactor at call sites.
+ */
 char *
 get_dirname(char *d)
 {


### PR DESCRIPTION
Small fixes to improve the codebase.
Major improvement in pkg_add behaviour on MacOS/amd64|arm64. The process crashed due to improper use of strlcpy, with this improvement, 9 kyua tests related to pkg_add pass.