### PR TITLE
Fix wrong definition of AT_FDCWD in bsd_compat.h on MacOS.

### DIFF
--- a/compat/bsd_compat.h
+++ b/compat/bsd_compat.h
@@ -84,6 +84,7 @@
 #include <bsd/sys/time.h>
 #endif
 
+#include <sys/fcntl.h>
 #include <sys/stat.h>
 #include "endian_util.h"
 

--- a/tests/lib/checksum.c
+++ b/tests/lib/checksum.c
@@ -26,6 +26,7 @@
 #include <atf-c.h>
 #include <err.h>
 #include <unistd.h>
+#include <errno.h>
 #include <pkg.h>
 #include <private/pkg.h>
 
@@ -131,7 +132,7 @@ ATF_TC_BODY(check_files, tc)
 	free(sum);
 
 	sum=pkg_checksum_generate_file("foo", PKG_HASH_TYPE_SHA256_HEX);
-	ATF_CHECK(pkg_checksum_validate_fileat(AT_FDCWD, "foo", "7d865e959b2466918c9863afca942d0fb89d7c9ac0c99bafc3749504ded97730") == 0);
+	ATF_CHECK_MSG(pkg_checksum_validate_fileat(AT_FDCWD, "foo", "7d865e959b2466918c9863afca942d0fb89d7c9ac0c99bafc3749504ded97730") == 0, "pkg_checksum_validate_fileat failed (%d,%s)", errno, strerror(errno));
 	free(sum);
 
 	ATF_REQUIRE_EQ(pkg_checksum_generate_fileat(AT_FDCWD, "nonexistent", PKG_HASH_TYPE_BLAKE2_BASE32), NULL);


### PR DESCRIPTION
On MacOS, AT_FDCWD is defined in sys/fcntl.h. This header was not included by bsd_compat.h an hence it took the liberty to define AT_FDCWD with an arbitrary (wrong) constant.

Error was triggered in tests/checksum:check_files. Improved the call-site to give a verbose error message.
This fixes tests/checksum for MacOS.