### PR TITLE
Fix host component handling in file:// URLs

### DIFF
--- a/tests/frontend/update.sh
+++ b/tests/frontend/update.sh
@@ -18,7 +18,7 @@ EOF
 
 	atf_check \
 		-o match:"Unable to update repository test" \
-		-e match:"pkg: file://empty//packagesite.pkg: No such file or directory" \
+		-e match:"Invalid url: 'file://empty//meta.conf'" \
 		-s exit:1 \
 		pkg -R repos update
 }
@@ -28,6 +28,10 @@ file_url_body() {
 	touch meta.conf
 	here=$(pwd)
 
+
+#
+# test file:/empty/, which is invalid
+#
 	cat > repos/test.conf << EOF
 test: {
   url: "file:/empty/",
@@ -40,6 +44,9 @@ EOF
 		-s exit:1 \
 		pkg -R repos update
 
+#
+# test file://here, which is invalid
+#
 	cat > repos/test.conf << EOF
 test: {
   url: "file://here",
@@ -47,11 +54,14 @@ test: {
 EOF
 	atf_check \
 		-o match:"Unable to update repository test" \
-		-e match:"meta.*No such file or directory" \
+		-e match:"Invalid url: 'file://here/meta.conf'" \
 		-s exit:1 \
 		pkg -R repos update
 
 
+#
+# test file://here//path, which is invalid
+#
 	cat > repos/test.conf << EOF
 test: {
   url: "file://here/${here}",
@@ -63,6 +73,9 @@ EOF
 		-s exit:1 \
 		pkg -R repos update
 
+#
+# test file:////path, which is valid
+#
 	cat > repos/test.conf << EOF
 test: {
   url: "file:///${here}",
@@ -75,6 +88,9 @@ EOF
 		-s exit:1 \
 		pkg -R repos update
 
+#
+# test file:///path, which is valid
+#
 	cat > repos/test.conf << EOF
 test: {
   url: "file://${here}",
@@ -87,6 +103,9 @@ EOF
 		-s exit:1 \
 		pkg -R repos update
 
+#
+# test file://path, which is invalid
+#
 	cat > repos/test.conf << EOF
 test: {
   url: "file:/${here}",
@@ -95,7 +114,24 @@ EOF
 
 	atf_check \
 		-o match:"Unable to update repository test" \
-		-e match:"meta.*No such file or directory" \
+		-e match:"Invalid url: 'file:/${here}/meta.conf'" \
 		-s exit:1 \
 		pkg -R repos update
+
+
+#
+# test file://localhost/path, which is a valid
+#
+	cat > repos/test.conf << EOF
+test: {
+  url: "file://localhost${here}",
+}
+EOF
+
+	atf_check \
+		-o match:"Unable to update repository test" \
+		-e not-match:"meta.*No such file or directory" \
+		-s exit:1 \
+		pkg -R repos update
+
 }


### PR DESCRIPTION
pkg handles file:// URLs in libpkg/fetch_file.c which translates the file URL into an access to the local filesystem. Ignoring the host component altogether in this process is semantically wrong. The host component, if given, directs the file to be fetched from that host, not from the local filesystem.

Extend the handling of the host component to accept the localhost host component - the null host component file:/// is anyway accepted already, but reject any other host component, as the code is not intended to go around looking for files on other hosts.
Update the test cases for the changed error message (invalid URL), as well as add a test case for accepting file://localhost/path URL.

closes #2339 