### PR TITLE
Properly initialize phtread mutexes in pkg repo.

### DIFF
--- a/libpkg/pkg_repo_create.c
+++ b/libpkg/pkg_repo_create.c
@@ -823,6 +823,12 @@ pkg_repo_create(struct pkg_repo_create *prc, char *path)
 
 	te.meta = prc->meta;
 
+	/* initialize mutexes & conditions */
+	pthread_mutex_init(&te.nlock, 0);
+	pthread_mutex_init(&te.llock, 0);
+	pthread_mutex_init(&te.flock, 0);
+	pthread_cond_init(&te.cond, 0);
+
 	repopath[0] = path;
 	repopath[1] = NULL;
 


### PR DESCRIPTION
MacOS pthread is very sensitive to have phthread mutexes properly initialized, but it should be done everywhere.

With this multi-threaded pkg repo works just fine also on MacOS.