### PR TITLE
Add runtime library version information to verbose pkg -vv

### DIFF
--- a/libpkg/pkg.h.in
+++ b/libpkg/pkg.h.in
@@ -1484,6 +1484,7 @@ void pkg_event_register(pkg_event_cb cb, void *data);
 bool pkg_compiled_for_same_os_major(void);
 int pkg_ini(const char *, const char *, pkg_init_flags);
 int pkg_init(const char *, const char *);
+const char *pkg_libversion(void);
 int pkg_initialized(void);
 void pkg_shutdown(void);
 

--- a/libpkg/pkg_config.c
+++ b/libpkg/pkg_config.c
@@ -593,6 +593,12 @@ connect_evpipe(const char *evpipe) {
 
 }
 
+const char *
+pkg_libversion(void)
+{
+	return PKGVERSION;
+}
+
 int
 pkg_initialized(void)
 {

--- a/src/main.c
+++ b/src/main.c
@@ -58,6 +58,11 @@
 #include <pkg.h>
 #include <tllist.h>
 #include <xmalloc.h>
+#include <curl/curl.h>
+
+#include <archive.h>
+#include <sqlite3.h>
+#include <openssl/crypto.h>
 
 #include "pkgcli.h"
 
@@ -373,6 +378,12 @@ show_version_info(int version)
 
 	if (version == 1)
 		exit(EXIT_SUCCESS);
+
+	printf("%-24s: %s\n", "libpkg", pkg_libversion());
+	printf("%-24s: %s\n", "libcurl", curl_version());
+	printf("%-24s: %s\n", "libarchive", archive_version_string());
+	printf("%-24s: %s\n", "sqlite", sqlite3_libversion());
+	printf("%-24s: %s\n", "openssl", OpenSSL_version(OPENSSL_VERSION));
 
 	config = pkg_config_dump();
 	printf("%s\n", config);


### PR DESCRIPTION
With pkg using external library dependencies, exact runtime information of these libraries is needed for efficient support.

Add pkg_libversion to libpkg to report its own version. 
Report libpkg, libcurl, libarchive, sqlite and openssl runtime versions in verbose show_version_info() i.e. ```pkg -vv```