### PR TITLE
libpkg: switch DEFAULT_VULNXML_URL to HTTPS

### DIFF
--- a/libpkg/pkg_config.c
+++ b/libpkg/pkg_config.c
@@ -58,7 +58,7 @@
 #define PORTSDIR "/usr/ports"
 #endif
 #ifndef DEFAULT_VULNXML_URL
-#define DEFAULT_VULNXML_URL "http://vuxml.freebsd.org/freebsd/vuln.xml.xz"
+#define DEFAULT_VULNXML_URL "https://vuxml.freebsd.org/freebsd/vuln.xml.xz"
 #endif
 
 #ifdef	OSMAJOR


### PR DESCRIPTION
For controversial consideration: switch the default location to HTTPS.

A signature check would also make sense. I wrote generic bindings for pkg signature support like used for `pkg.pkg.sig` bootstrap, see https://github.com/opnsense/update/tree/master/src/verify