### PR TITLE
Fix failing test after 93928c61477b24d6bbd06b5cff6962cafe1db575 

### DIFF
--- a/tests/frontend/pkg.sh
+++ b/tests/frontend/pkg.sh
@@ -32,7 +32,7 @@ pkg_config_defaults_body()
 	    -o match:'^ *SYSLOG = true;$' \
 	    -o match:'^ *ALTABI = "[a-zA-Z0-9]+:[a-z\.A-Z0-9]+:[a-zA-Z0-9]+:[a-zA-Z0-9:]+";$' \
 	    -o match:'^ *DEVELOPER_MODE = false;$' \
-	    -o match:'^ *VULNXML_SITE = "http://vuxml.freebsd.org/freebsd/vuln.xml.xz";$' \
+	    -o match:'^ *VULNXML_SITE = "https://vuxml.freebsd.org/freebsd/vuln.xml.xz";$' \
 	    -o match:'^ *FETCH_RETRY = 3;$' \
 	    -o match:'^ *PKG_PLUGINS_DIR = ".*lib/pkg/";$' \
 	    -o match:'^ *PKG_ENABLE_PLUGINS = true;$' \


### PR DESCRIPTION
93928c61477b24d6bbd06b5cff6962cafe1db575 libpkg: switch DEFAULT_VULNXML_URL to HTTPS
changed the default, change the expected value in the testcase to reflect this.