### PR TITLE
Introduce suppression option to UndefinedBehaviorSanitizer

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,8 +33,7 @@ jobs:
                 - ubsan
                 - tsan
                 exclude:
-                - build-os: macos-latest
-                  sanitize: ubsan # No space left on device
+                # don't run the sanitizers on Ubuntu 22.04
                 - build-os: ubuntu-latest
                   sanitize: [ "asan", "lsan" ]
                 - build-os: ubuntu-latest
@@ -137,6 +136,7 @@ jobs:
             echo "CPP=${{ matrix.llvm-bindir }}/clang-cpp" >> "${GITHUB_ENV}"
             # this is miraculously not picked up by automake as the default
             echo "CC_FOR_BUILD=${{ matrix.llvm-bindir }}/clang" >> "${GITHUB_ENV}"
+            echo "SRC_PKG=${GITHUB_WORKSPACE}/src.pkg" >> "${GITHUB_ENV}"
             echo "BUILD_PKG=${GITHUB_WORKSPACE}/build.pkg" >> "${GITHUB_ENV}"
             echo "INST_PKG=${GITHUB_WORKSPACE}/inst.pkg" >> "${GITHUB_ENV}"
             echo "NPROC=`getconf _NPROCESSORS_ONLN 2>/dev/null || getconf NPROCESSORS_ONLN 2>/dev/null || echo 1`" >> "${GITHUB_ENV}"
@@ -155,11 +155,13 @@ jobs:
             echo CC="${CC}"
             echo CPP="${CPP}"
             echo PKG_CONFIG_PATH="${PKG_CONFIG_PATH}"
+            echo SRC_PKG="${SRC_PKG}"
             echo BUILD_PKG="${BUILD_PKG}"
             echo INST_PKG="${INST_PKG}"
+
             mkdir -p "${BUILD_PKG}"
             cd "${BUILD_PKG}"
-            ${GITHUB_WORKSPACE}/src.pkg/configure --prefix=${INST_PKG} --with-libarchive.pc --with-libcurl --with-openssl.pc ${CFG_OPTS}
+            ${SRC_PKG}/configure --prefix=${INST_PKG} --with-libarchive.pc --with-libcurl --with-openssl.pc ${CFG_OPTS}
             make -j${NPROC}
 
         - name: test&install pkg

--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -21,8 +21,11 @@ check: all
 @if TESTS
 all: Kyuafile
 
-check:
-	export UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1; \
+$(top_builddir)/UndefinedBehaviour.suppress: $(top_srcdir)/UndefinedBehaviour.suppress
+	install -m 644 $< $@
+
+check: $(top_builddir)/UndefinedBehaviour.suppress
+	export UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1:suppressions=$(top_builddir)/UndefinedBehaviour.suppress; \
 	export LLVM_PROFILE_FILE=/tmp/pkg.%p.profraw; \
 	if [ "$(HTML)" != "" ]; then \
 		args="-r $(top_builddir)/res.db" ; \

--- a/UndefinedBehaviour.suppress
+++ b/UndefinedBehaviour.suppress
@@ -1,0 +1,14 @@
+#
+# These are errors that need to be taken care of, but in the sprit of
+# "Put Your Own Oxygen Mask on First", we provide here a suppression list for
+# _external_ sources.
+#
+
+# external/sqlite/sqlite3.c:45168:9: runtime error: call to function _dbdir_getcwd through pointer to incorrect function type 'char *(*)(char *, unsigned long)'
+# +pkgdb.c:921: note: _dbdir_getcwd defined here
+# +SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior external/sqlite/sqlite3.c:45168:9 
+function:sqlite3.c
+
+# external/picosat/picosat.c:3432:33: runtime error: applying non-zero offset 8 to null pointer
+# +SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior external/picosat/picosat.c:3432:33 
+pointer-overflow:picosat.c


### PR DESCRIPTION
We maintain a list of suppressions to UndefinedBehaviorSanitizer in order to focus on the work inside pkg.
Structure enables digging into the external code and upstream any fixes.