### PR TITLE
Change signature of sqlite getcwd callback function.

### DIFF
--- a/UndefinedBehaviour.suppress
+++ b/UndefinedBehaviour.suppress
@@ -4,11 +4,6 @@
 # _external_ sources.
 #
 
-# external/sqlite/sqlite3.c:45168:9: runtime error: call to function _dbdir_getcwd through pointer to incorrect function type 'char *(*)(char *, unsigned long)'
-# +pkgdb.c:921: note: _dbdir_getcwd defined here
-# +SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior external/sqlite/sqlite3.c:45168:9 
-function:sqlite3.c
-
 # external/picosat/picosat.c:3432:33: runtime error: applying non-zero offset 8 to null pointer
 # +SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior external/picosat/picosat.c:3432:33 
 pointer-overflow:picosat.c

--- a/libpkg/pkgdb.c
+++ b/libpkg/pkgdb.c
@@ -916,10 +916,19 @@ _dbdir_mkdir(const char *path, mode_t mode)
 	return (mkdirat(dfd, _dbdir_trim_path(path), mode));
 }
 
-static int
+static char *
 _dbdir_getcwd(char *path, size_t sz)
 {
-	return (snprintf(path, sz, "/"));
+	if (0 == sz) {
+		errno = EINVAL;
+	} else 	if (sz >= 2) {
+		path[0] = '/';
+		path[1] = '\0';
+		return path;
+	} else {
+		errno = ERANGE;
+	}
+	return 0;
 }
 
 void


### PR DESCRIPTION
Sleeping bug detected by UndefinedBehaviourSanitizer. 
While here, simplify the implementation.