### PR TITLE
Actually detect leaks also on non-Linux

### DIFF
--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -23,6 +23,7 @@ all: Kyuafile
 
 check: UndefinedBehaviour.suppress
 	export UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1:suppressions=$(top_builddir)/UndefinedBehaviour.suppress; \
+	export ASAN_OPTIONS=detect_leaks=1; \
 	export LLVM_PROFILE_FILE=/tmp/pkg.%p.profraw; \
 	if [ "$(HTML)" != "" ]; then \
 		args="-r $(top_builddir)/res.db" ; \


### PR DESCRIPTION
Clang Address+Leak Sanitizer behave slightly different on Linux. To actually detect leaks on non-Darwin, ASAN_OPTIONS needs to be set.

This "fixes" the strangely empty ASAN-LSAN runs on MacOS. The traces obtained from Ubuntu are still way more precise, so that platform remains the best to hunt for leaks.
