### PR TITLE
Introduce LeakSanitizer suppression

### DIFF
--- a/Leak.suppress.in
+++ b/Leak.suppress.in
@@ -1,0 +1,14 @@
+# Unfixable leak reports from system libraries on MacOS
+leak:fork
+leak:dyld4::Loader::*
+
+
+# Suspected unfixable leak from within libcrypto on Ubuntu
+# Direct leak of 32 byte(s) in 1 object(s) allocated from:
+#    #0 0x55558b4c7293 in malloc (/home/runner/work/pkg/pkg/build.pkg/src/pkg+0x1e7293) (BuildId: 0d38bdca4c756f735a194bf765528e76b46c416f)
+#    #1 0x7f2a7f2237c4 in CRYPTO_zalloc (/lib/x86_64-linux-gnu/libcrypto.so.3+0x2237c4) (BuildId: c503df82cf13681b2f81e1097e857e3fc50679b1)
+#    #2 0x7f2a7f11afa3 in BUF_MEM_new (/lib/x86_64-linux-gnu/libcrypto.so.3+0x11afa3) (BuildId: c503df82cf13681b2f81e1097e857e3fc50679b1)
+#    #3 0x7f2a7f11b004 in BUF_MEM_new_ex (/lib/x86_64-linux-gnu/libcrypto.so.3+0x11b004) (BuildId: c503df82cf13681b2f81e1097e857e3fc50679b1)
+#    #4 0x7f2a7f0f79dd  (/lib/x86_64-linux-gnu/libcrypto.so.3+0xf79dd) (BuildId: c503df82cf13681b2f81e1097e857e3fc50679b1)
+#    #5 0x7f2a7f0ed883 in BIO_new_ex (/lib/x86_64-linux-gnu/libcrypto.so.3+0xed883) (BuildId: c503df82cf13681b2f81e1097e857e3fc50679b1)
+leak:BIO_new_ex

--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -21,8 +21,9 @@ check: all
 @if TESTS
 all: Kyuafile
 
-check: UndefinedBehaviour.suppress
+check: UndefinedBehaviour.suppress Leak.suppress
 	export UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1:suppressions=$(top_builddir)/UndefinedBehaviour.suppress; \
+	export LSAN_OPTIONS=print_suppressions=0:suppressions=$(top_builddir)/Leak.suppress; \
 	export ASAN_OPTIONS=detect_leaks=1; \
 	export LLVM_PROFILE_FILE=/tmp/pkg.%p.profraw; \
 	if [ "$(HTML)" != "" ]; then \


### PR DESCRIPTION
LeakSanitizer produces unfixable (from a programmer perspective) leak reports from allocations deep inside system libraries on MacOS. 
Similarly unfixable (from a pkg programmer perspective) leaks are reported against e.g. libcrypto on Ubuntu.

Enable suppression feature for these leaks to focus on actual pkg issues.
This patch makes LeakSanitizer output comparable across MacOS / Linux.