### PR TITLE
libpkg: fix regression in config parsing

### DIFF
--- a/libpkg/pkg_config.c
+++ b/libpkg/pkg_config.c
@@ -361,6 +361,7 @@ static struct config_entry c[] = {
 	{
 		PKG_ARRAY,
 		"VALID_URL_SCHEME",
+		"pkg+http,pkg+https,https,http,file,ssh,tcp",
 	},
 	{
 		PKG_BOOL,


### PR DESCRIPTION
Commit 9df5da58d which aimed to only removed dead code accidentally deleted the default value for VALID_URL_SCHEME.

My text editor magic failed me as this option lacked a description even before 9df5da58d.

This commit fixes the regression.

Sponsored by:	The FreeBSD Foundation