### PR TITLE
Consistently name x86_64 on Darwin

### DIFF
--- a/libpkg/pkg_abi.c
+++ b/libpkg/pkg_abi.c
@@ -109,8 +109,8 @@ pkg_os_uses_amd64_name(enum pkg_os os)
 {
 	switch (os) {
 	case PKG_OS_FREEBSD:
-	case PKG_OS_DARWIN:
 		return (true);
+	case PKG_OS_DARWIN:
 	case PKG_OS_NETBSD:
 	case PKG_OS_LINUX:
 		return (false);

--- a/tests/frontend/abi.sh
+++ b/tests/frontend/abi.sh
@@ -20,8 +20,8 @@ native_body() {
 			;;
 		Darwin)
 			# without a hint, the first arch is selected, which happens to be consistently x86_64
-			thisarch="amd64"
-			thisabi="x86:64"
+			thisarch="x86_64"
+			thisabi="x86_64"
 			version=$(uname -r | cut -d. -f1)
 			;;
 		FreeBSD)
@@ -84,8 +84,9 @@ machoparse_body() {
 	# Macho-O parsing now works across platforms
 
 	for bin in \
-		macos.bin macos106.bin macos150.bin macosfat.bin \
-		"macosfat.bin#amd64" "macosfat.bin#aarch64"
+		macos.bin macos106.bin macos150.bin \
+		macosfat.bin "macosfat.bin#x86_64" "macosfat.bin#aarch64" \
+		macosfatlib.bin "macosfatlib.bin#x86_64" "macosfatlib.bin#aarch64"
 	do
 		bin_meta ${bin}
 
@@ -155,13 +156,13 @@ machoparse_body() {
 		pkg -d -o IGNORE_OSMAJOR=1 -o ABI_FILE=$(atf_get_srcdir)/macos.bin#i386 config altabi
 
 	# if the binary is universal, selecting the first entry is to be commented
-	_expected="Darwin:17:amd64\n"
+	_expected="Darwin:17:x86_64\n"
 	atf_check \
 		-o inline:"${_expected}" \
 		-e match:"picking first" \
 		pkg -d -o IGNORE_OSMAJOR=1 -o ABI_FILE=$(atf_get_srcdir)/macosfat.bin config abi
 
-	_expected="darwin:17:x86:64\n"
+	_expected="darwin:17:x86_64\n"
 	atf_check \
 		-o inline:"${_expected}" \
 		-e match:"picking first" \

--- a/tests/frontend/create-parsebin.sh
+++ b/tests/frontend/create-parsebin.sh
@@ -128,8 +128,8 @@ create_from_bin_body() {
 		freebsd-i386.bin freebsd-powerpc.bin freebsd-powerpc64.bin freebsd-powerpc64le.bin \
 		freebsd-riscv64.bin dfly.bin linux.bin \
         macos.bin macos106.bin macos150.bin \
-        macosfat.bin "macosfat.bin#amd64" "macosfat.bin#aarch64" \
-        macosfatlib.bin "macosfatlib.bin#amd64" "macosfatlib.bin#aarch64"
+        macosfat.bin "macosfat.bin#x86_64" "macosfat.bin#aarch64" \
+        macosfatlib.bin "macosfatlib.bin#x86_64" "macosfatlib.bin#aarch64"
     do
         do_check no testbin $bin
     done
@@ -138,8 +138,8 @@ create_from_bin_body() {
 create_from_machobinbase_body() {
     for bin in \
         macos.bin macos106.bin macos150.bin \
-        macosfat.bin "macosfat.bin#amd64" "macosfat.bin#aarch64" \
-        macosfatlib.bin "macosfatlib.bin#amd64" "macosfatlib.bin#aarch64" 
+        macosfat.bin "macosfat.bin#x86_64" "macosfat.bin#aarch64" \
+        macosfatlib.bin "macosfatlib.bin#x86_64" "macosfatlib.bin#aarch64" 
     do
         do_check yes machobinbase $bin
     done

--- a/tests/frontend/test_environment.sh.in
+++ b/tests/frontend/test_environment.sh.in
@@ -131,20 +131,20 @@ bin_meta() {
 			Xshlibs_required_base="libSystem.B.dylib-1351.0"
 			;;
 		*macos106.bin)
-			XABI=Darwin:10:amd64
-			XALTABI=darwin:10:x86:64
+			XABI=Darwin:10:x86_64
+			XALTABI=darwin:10:x86_64
 			Xshlibs_required_base="libSystem.B.dylib-125.2.11"
 			;;
 		*macos150.bin)
-			XABI=Darwin:24:amd64
-			XALTABI=darwin:24:x86:64
+			XABI=Darwin:24:x86_64
+			XALTABI=darwin:24:x86_64
 			Xshlibs_required_base="libSystem.B.dylib-1351.0"
 			;;
 
-		# macosfat.bin has amd64 as its first entry
-		*macosfat.bin|*macosfat.bin#amd64)
-			XABI=Darwin:17:amd64
-			XALTABI=darwin:17:x86:64
+		# macosfat.bin has x86_64 as its first entry
+		*macosfat.bin|*macosfat.bin#x86_64)
+			XABI=Darwin:17:x86_64
+			XALTABI=darwin:17:x86_64
 			Xshlibs_required="libAnswer.A.dylib-1.2"
 			Xshlibs_required_base="libAnswer.A.dylib-1.2 libSystem.B.dylib-1319.0"
 			;;
@@ -157,10 +157,10 @@ bin_meta() {
 			Xshlibs_required_base="libAnswer.A.dylib-1.1 libSystem.B.dylib-1319.0"
 			;;
 
-		# macosfatlib.bin has aarch64 as its first entry
-		*macosfatlib.bin|*macosfatlib.bin#amd64)
-			XABI=Darwin:17:amd64
-			XALTABI=darwin:17:x86:64
+		# macosfatlib.bin has x86_64 as its first entry
+		*macosfatlib.bin|*macosfatlib.bin#x86_64)
+			XABI=Darwin:17:x86_64
+			XALTABI=darwin:17:x86_64
 			Xshlibs_provided="libAnswer.A.dylib-1.2"
 			Xshlibs_required_base="libSystem.B.dylib-1319.0"
 			;;


### PR DESCRIPTION
The new improved ABI code is specific about amd64 vs. x86_64 naming.
Darwin in fact uses x86_64 (uname -m produces x86_64).
Adjust the code as well as the test cases to use this value instead of the previously chosen amd64.