### PR TITLE
Align handling of invalid files between analyse_macho and analyse_elf

### DIFF
--- a/libpkg/binfmt_macho.c
+++ b/libpkg/binfmt_macho.c
@@ -61,7 +61,13 @@ read_fully(const int fd, const size_t len, void *dest)
 	ssize_t x;
 	while (n > 0) {
 		if ((x = read(fd, p, n)) < 0) {
+			if ( EAGAIN == errno) {
+				continue;
+			}
 			return x;
+		}
+		if ( 0 == x) {
+			return -1;
 		}
 		n -= x;
 		p += x;

--- a/libpkg/pkg_abi_macho.c
+++ b/libpkg/pkg_abi_macho.c
@@ -455,12 +455,14 @@ pkg_analyse_macho(const bool developer_mode, struct pkg *pkg, const char *fpath)
 
 	int fd = open(fpath, O_RDONLY);
 	if (-1 == fd) {
-		pkg_emit_errno("open", fpath);
-		ret = EPKG_FATAL;
+		// pkg_emit_errno("open_pkg_analyse_macho", fpath);
+		// ret = EPKG_FATAL;
+		// Be consistent with analyse_elf and return no error if fpath cannot be opened
+		return ret;
 	} else {
 		ret = analyse_macho(fd, pkg, baselibs);
 		if (-1 == close(fd)) {
-			pkg_emit_errno("open", fpath);
+			pkg_emit_errno("close_pkg_analyse_macho", fpath);
 			ret = EPKG_FATAL;
 		}
 	}


### PR DESCRIPTION
Analyse_elf treats a file that cannot be opened (e.g. dangling symlink) not as an error, but simply as something that cannot be analysed. Make analyse_macho do the same.