### PR TITLE
libpkg: track lib32 and Linuxulator shlibs 

### DIFF
--- a/libpkg/pkg.c
+++ b/libpkg/pkg.c
@@ -939,7 +939,7 @@ pkg_shlib_flags_from_abi(const struct pkg_abi *shlib_abi)
  * libfoo.so.1.0.0:Linux    - compat Linux
  * libfoo.so.1.0.0:Linux:32 - compat Linux 32
  */
-static char *
+char *
 pkg_shlib_name_with_flags(const char *name, enum pkg_shlib_flags flags)
 {
 	const char *compat_os = "";

--- a/libpkg/pkg.c
+++ b/libpkg/pkg.c
@@ -905,7 +905,8 @@ pkg_shlib_flags_from_abi(const struct pkg_abi *shlib_abi)
 	enum pkg_shlib_flags flags = PKG_SHLIB_FLAGS_NONE;
 
 	if (ctx.abi.os == PKG_OS_FREEBSD) {
-		if (shlib_abi->os == PKG_OS_LINUX) {
+		if (shlib_abi->os == PKG_OS_LINUX &&
+		    pkg_object_bool(pkg_config_get("TRACK_LINUX_COMPAT_SHLIBS"))) {
 			flags |= PKG_SHLIB_FLAGS_COMPAT_LINUX;
 		}
 

--- a/libpkg/pkg_abi_macho.c
+++ b/libpkg/pkg_abi_macho.c
@@ -381,9 +381,9 @@ analyse_macho(int fd, struct pkg *pkg)
 				xasprintf(&lib_with_version, "%s-%"PRIuFAST16".%"PRIuFAST16, basename, dylib->current_version.major, dylib->current_version.minor);
 			}
 			if (LC_ID_DYLIB == loadcmd) {
-				pkg_addshlib_provided(pkg, lib_with_version);
+				pkg_addshlib_provided(pkg, lib_with_version, PKG_SHLIB_FLAGS_NONE);
 			} else {
-				pkg_addshlib_required(pkg, lib_with_version);
+				pkg_addshlib_required(pkg, lib_with_version, PKG_SHLIB_FLAGS_NONE);
 			}
 			free(lib_with_version);
 			free(dylib);

--- a/libpkg/pkg_config.c
+++ b/libpkg/pkg_config.c
@@ -453,7 +453,12 @@ static struct config_entry c[] = {
 		PKG_BOOL,
 		"PKG_REINSTALL_ON_OPTIONS_CHANGE",
 		"TRUE",
-	}
+	},
+	{
+		PKG_BOOL,
+		"TRACK_LINUX_COMPAT_SHLIBS",
+		"FALSE",
+	},
 };
 
 static bool parsed = false;

--- a/libpkg/pkg_manifest.c
+++ b/libpkg/pkg_manifest.c
@@ -427,13 +427,13 @@ pkg_array(struct pkg *pkg, const ucl_object_t *obj, uint32_t attr)
 			if (cur->type != UCL_STRING)
 				pkg_emit_error("Skipping malformed required shared library");
 			else
-				pkg_addshlib_required(pkg, ucl_object_tostring(cur));
+				pkg_addshlib_required(pkg, ucl_object_tostring(cur), PKG_SHLIB_FLAGS_NONE);
 			break;
 		case MANIFEST_SHLIBS_PROVIDED:
 			if (cur->type != UCL_STRING)
 				pkg_emit_error("Skipping malformed provided shared library");
 			else
-				pkg_addshlib_provided(pkg, ucl_object_tostring(cur));
+				pkg_addshlib_provided(pkg, ucl_object_tostring(cur), PKG_SHLIB_FLAGS_NONE);
 			break;
 		case MANIFEST_CONFLICTS:
 			if (cur->type != UCL_STRING)

--- a/libpkg/pkgdb_iterator.c
+++ b/libpkg/pkgdb_iterator.c
@@ -586,6 +586,13 @@ pkgdb_load_group(sqlite3 *sqlite, struct pkg *pkg)
 }
 
 static int
+addshlib_required_raw(struct pkg *pkg, const char *name)
+{
+	tll_push_back(pkg->shlibs_required, xstrdup(name));
+	return (EPKG_OK);
+}
+
+static int
 pkgdb_load_shlib_required(sqlite3 *sqlite, struct pkg *pkg)
 {
 	const char	sql[] = ""
@@ -598,9 +605,15 @@ pkgdb_load_shlib_required(sqlite3 *sqlite, struct pkg *pkg)
 	assert(pkg != NULL);
 
 	return (load_val(sqlite, pkg, sql, PKG_LOAD_SHLIBS_REQUIRED,
-	    pkg_addshlib_required, PKG_ATTR_SHLIBS_REQUIRED));
+	    addshlib_required_raw, PKG_ATTR_SHLIBS_REQUIRED));
 }
 
+static int
+addshlib_provided_raw(struct pkg *pkg, const char *name)
+{
+	tll_push_back(pkg->shlibs_provided, xstrdup(name));
+	return (EPKG_OK);
+}
 
 static int
 pkgdb_load_shlib_provided(sqlite3 *sqlite, struct pkg *pkg)
@@ -615,7 +628,7 @@ pkgdb_load_shlib_provided(sqlite3 *sqlite, struct pkg *pkg)
 	assert(pkg != NULL);
 
 	return (load_val(sqlite, pkg, sql, PKG_LOAD_SHLIBS_PROVIDED,
-	    pkg_addshlib_provided, PKG_SHLIBS_PROVIDED));
+	    addshlib_provided_raw, PKG_SHLIBS_PROVIDED));
 }
 
 static int

--- a/libpkg/private/pkg.h
+++ b/libpkg/private/pkg.h
@@ -800,6 +800,11 @@ enum pkg_shlib_flags {
 };
 /* Determine shlib flags by comparing the shlib abi with ctx.abi */
 enum pkg_shlib_flags pkg_shlib_flags_from_abi(const struct pkg_abi *shlib_abi);
+/*
+ * Given an unadorned shlib name (e.g. libfoo.so.1.0.0) return a newly allocated
+ * string with the given flags appended (e.g. libfoo.so.1.0.0:Linux:32).
+ */
+char *pkg_shlib_name_with_flags(const char *name, enum pkg_shlib_flags flags);
 int pkg_addshlib_required(struct pkg *pkg, const char *name, enum pkg_shlib_flags);
 /* No checking for duplicates or filtering */
 int pkg_addshlib_required_raw(struct pkg *pkg, const char *name);

--- a/libpkg/private/pkg.h
+++ b/libpkg/private/pkg.h
@@ -792,8 +792,19 @@ int pkg_kv_add(kvlist_t *kv, const char *key, const char *value, const char *tit
 const char *pkg_kv_get(const kvlist_t *kv, const char *key);
 int pkg_adduser(struct pkg *pkg, const char *name);
 int pkg_addgroup(struct pkg *pkg, const char *group);
-int pkg_addshlib_required(struct pkg *pkg, const char *name);
-int pkg_addshlib_provided(struct pkg *pkg, const char *name);
+
+enum pkg_shlib_flags {
+	PKG_SHLIB_FLAGS_NONE = 0,
+	PKG_SHLIB_FLAGS_COMPAT_32 = 1 << 0,
+	PKG_SHLIB_FLAGS_COMPAT_LINUX = 1 << 1,
+};
+/* Determine shlib flags by comparing the shlib abi with ctx.abi */
+enum pkg_shlib_flags pkg_shlib_flags_from_abi(const struct pkg_abi *shlib_abi);
+int pkg_addshlib_required(struct pkg *pkg, const char *name, enum pkg_shlib_flags);
+/* No checking for duplicates or filtering */
+int pkg_addshlib_required_raw(struct pkg *pkg, const char *name);
+int pkg_addshlib_provided(struct pkg *pkg, const char *name, enum pkg_shlib_flags);
+
 int pkg_addconflict(struct pkg *pkg, const char *name);
 int pkg_addprovide(struct pkg *pkg, const char *name);
 int pkg_addrequire(struct pkg *pkg, const char *name);

--- a/tests/frontend/test_environment.sh.in
+++ b/tests/frontend/test_environment.sh.in
@@ -111,9 +111,7 @@ bin_meta() {
 			XABI=FreeBSD:14:riscv64
 			XALTABI=freebsd:14:riscv:64:hf
 			XFreeBSD_version=1401000
-# This riscv64 binary does not have the OS set to FreeBSD in its ELF header
-# TODO: handle this in pkg_elf.c
-#			Xshlibs_required="libc.so.7"
+			Xshlibs_required="libc.so.7"
 			;;
 		*dfly.bin)
 			XABI=dragonfly:5.10:x86:64

--- a/tests/lib/pkg_elf.c
+++ b/tests/lib/pkg_elf.c
@@ -49,6 +49,7 @@ ATF_TC_BODY(analyse_elf, tc)
 	struct pkg *p = NULL;
 	char *binpath = NULL;
 
+	ctx.abi.os = PKG_OS_FREEBSD;
 	ctx.abi.arch = PKG_ARCH_AMD64;
 
 	xasprintf(&binpath, "%s/frontend/libtestfbsd.so.1", atf_tc_get_config_var(tc, "srcdir"));


### PR DESCRIPTION
When scanning ELF files to generate the shlibs_provided/required lists, pkg now generates entries for lib32 and Linux compat shlibs rather than ignoring all non-native shlibs.

The following format is used for shlibs_provided/required entries:
```
libfoo.so.1.0.0          - native (no change to status quo)
libfoo.so.1.0.0:32       - compat 32
libfoo.so.1.0.0:Linux    - compat Linux
libfoo.so.1.0.0:Linux:32 - compat Linux 32
```
This is only done if targeting FreeBSD for now.

I've marked this as a draft because it depends on the unmerged #2386 and because I would like to add more tests before it is merged.

References: https://github.com/freebsd/pkg/issues/2331