### PR TITLE
bsd_compat.h: fix __builtin_unreachable() detection with GCC

### DIFF
--- a/compat/bsd_compat.h
+++ b/compat/bsd_compat.h
@@ -176,14 +176,10 @@ char * strnstr(const char *s, const char *find, size_t slen);
 #endif
 
 #ifndef __unreachable
-# if defined(__GNUC__) && ((__GNUC__ >= 4) && (__GNUC_MINOR__ >= 6))
-#  define __unreachable() __builtin_unreachable()
-# elif defined(__clang__)
-#  if __has_builtin(__builtin_unreachable)
-#   define __unreachable() __builtin_unreachable()
-#  endif
+# if defined (__GNUC__) || defined (__clang__)
+#  define __unreachable()    __builtin_unreachable()
 # else
-#  define __unreachable() ((void)0)
+#  define __unreachable()    ((void)0)
 # endif
 #endif
 


### PR DESCRIPTION
GCC has _\_GNUC_MINOR\_\_ set to 2 (from godbolt). As it was detecting a specific version of it, __builtin_unreachable() was never being used with GCC (as _\_GNUC_MINOR\_\_ < 6). From godbolt, it looks like __builtin_unreachable() was introducued somewhere between 4.4.7 to 4.5.3. These versions were released back in 2011, so I think it's safe to assume that most systems have at least 4.5 or higher.

For Clang, __builtin_unreachable() (from godbolt test), available since at least 3.0, which was released in 2011 as well.