### PR TITLE
Use $(AR) instead of hardcoding ar tool

### DIFF
--- a/libpkg/Makefile.autosetup
+++ b/libpkg/Makefile.autosetup
@@ -188,7 +188,7 @@ lib$(LIB)_flat.a: $(STATIC_LIBS)
 	libtool -static -o lib$(LIB)_flat.a $(STATIC_LIBS)
 @else
 lib$(LIB)_flat.a: ${STATIC_LIBS} mergelib_script
-	ar -M < mergelib_script
+	$(AR) -M < mergelib_script
 @endif
 
 mergelib_script: $(STATIC_LIBS)


### PR DESCRIPTION
Single change needed to successfully cross-compile on macOS to FreeBSD.