### PR TITLE
pkg-create.8: The default default compression is tzst

### DIFF
--- a/docs/pkg-create.8
+++ b/docs/pkg-create.8
@@ -175,7 +175,7 @@ or
 .Ar tar
 which are currently the only supported formats.
 If an invalid or no format is specified
-.Ar txz
+.Ar tzst
 is assumed.
 .Po The
 .Pa .pkg


### PR DESCRIPTION
It can be overriden at configure time (and FreeBSD 13 does so), but here we should reflect the default default.

Sponsored by:	The FreeBSD Foundation