### PR TITLE
Review leak suppression

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -76,7 +76,7 @@ jobs:
           # on MacOS we build with
           #   * latest clang@19 from brew (system provided clang lacks sanitizers)
           #   * ld from system
-          #   * libarchive from brew (system provided libarchive has issues)
+          #   * libarchive from brew (system provided libarchive has no header files for development)
           #   * openssl from brew
           #   * libcurl from system
           #

--- a/Leak.suppress.in
+++ b/Leak.suppress.in
@@ -3,16 +3,21 @@
 # as a reference for this file format.
 
 
-# Unfixable leak reports from system libraries on MacOS
-leak:dyld4::Loader::*
-leak:dyld4::APIs::*
-leak:dyld3::MachOAnalyzer::*
-leak:fork
-leak:tlv_get_addr*
-leak:localtime*
-leak:vfprintf*
+### macOS specific
+# see https://github.com/llvm/llvm-project/pull/117478
+leak:*dyld4::RuntimeState::_instantiateTLVs*
+leak:*_fetchInitializingClassList*
 
-# Suspected unfixable leak from within libcrypto on Ubuntu
+# and more
+leak:*load_images*
+leak:*libSystem_atfork_child*
+leak:*__Balloc_D2A*
+leak:*tlv_get_addr*
+leak:*localtime*
+leak:*dyld4::APIs::runAllInitializersForMain*
+
+### Ubuntu specific
+# Leak from within libcrypto on Ubuntu
 # Direct leak of 32 byte(s) in 1 object(s) allocated from:
 #    #0 0x55558b4c7293 in malloc (/home/runner/work/pkg/pkg/build.pkg/src/pkg+0x1e7293) (BuildId: 0d38bdca4c756f735a194bf765528e76b46c416f)
 #    #1 0x7f2a7f2237c4 in CRYPTO_zalloc (/lib/x86_64-linux-gnu/libcrypto.so.3+0x2237c4) (BuildId: c503df82cf13681b2f81e1097e857e3fc50679b1)
@@ -27,13 +32,13 @@ leak:ucl_parser_add_fd
 
 # atf 0.22 introduced leaks in the test-code
 # https://github.com/freebsd/atf/issues/77
-leak:atf_map_init_charpp
 leak:atf_tp_get_tcs
+leak:atf_tc_init
 leak:atf_utils_wait
 # more from atf --HEAD
 leak:atf_tc_run
 
-## FIXME: Temporarily suppress inside pkg source
+## FIXME: _Temporarily_ suppress inside pkg source
 
 # this could be a dangling pointer false positive report, the whole function should be re-structured
 leak:pkgdb_open_all2
@@ -151,6 +156,23 @@ leak:pkg_ini
 leak:pkg_kvlist_iterator
 leak:pkg_get_element
 
+# strdup-ed memory not returned
+#Indirect leak of 72 byte(s) in 3 object(s) allocated from:
+#    #0 0x563b5ce75293 in malloc (/home/runner/work/pkg/pkg/build.pkg/src/pkg+0x1e5293) (BuildId: 54fa0df44c172ab44834adaab4fcc840a73e391a)
+#    #1 0x563b5d024beb in add_variable /home/runner/work/pkg/pkg/src.pkg/libpkg/pkg_ports.c:1220:2
+#    #2 0x563b5d01b4fa in parse_keywords /home/runner/work/pkg/pkg/src.pkg/libpkg/pkg_ports.c:911:10
+#    #3 0x563b5d01b082 in plist_parse_line /home/runner/work/pkg/pkg/src.pkg/libpkg/pkg_ports.c:996:11
+#    #4 0x563b5d01e167 in plist_parse /home/runner/work/pkg/pkg/src.pkg/libpkg/pkg_ports.c:1161:9
+#    #5 0x563b5d01db62 in ports_parse_plist /home/runner/work/pkg/pkg/src.pkg/libpkg/pkg_ports.c:1280:7
+#    #6 0x563b5d02f7b1 in load_metadata /home/runner/work/pkg/pkg/src.pkg/libpkg/pkg_create.c:525:23
+#    #7 0x563b5d02ee91 in pkg_create /home/runner/work/pkg/pkg/src.pkg/libpkg/pkg_create.c:408:6
+#   #8 0x563b5cec1b33 in exec_create /home/runner/work/pkg/pkg/src.pkg/src/create.c:345:8
+#    #9 0x563b5ced1be4 in main /home/runner/work/pkg/pkg/src.pkg/src/main.c:809:9
+#    #10 0x7f37b582a1c9  (/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9) (BuildId: 6d64b17fbac799e68da7ebd9985ddf9b5cb375e6)
+#    #11 0x7f37b582a28a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2a28a) (BuildId: 6d64b17fbac799e68da7ebd9985ddf9b5cb375e6)
+#    #12 0x563b5cdda444 in _start (/home/runner/work/pkg/pkg/build.pkg/src/pkg+0x14a444) (BuildId: 54fa0df44c172ab44834adaab4fcc840a73e391a)
+leak:ports_parse_plist
+
 # Purging TREEs after use was not considered
 #Direct leak of 16 byte(s) in 1 object(s) allocated from:
 #    #0 0x00010b871f12 in malloc+0x82 (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0xdff12)
@@ -163,14 +185,6 @@ leak:pkg_get_element
 #    #7 0x000109ebd1f2 in main main.c:809
 #    #8 0x7ff8018b92cc in start+0x70c (dyld:x86_64+0xfffffffffff4f2cc)
 leak:pkg_conflicts_append_chain
-
-# multiple repo-names not properly cleaned up
-#Direct leak of 8 byte(s) in 1 object(s) allocated from:
-#    #0 0x00011002a117 in realloc+0x87 (libclang_rt.asan_osx_dynamic.dylib:x86_64h+0xe0117)
-#    #1 0x00010e677c5a in exec_install install.c:142
-#    #2 0x00010e67d562 in main main.c:809
-#    #3 0x7ff80c3302cc in start+0x70c (dyld:x86_64+0xfffffffffff4f2cc)
-leak:exec_install
 
 # repo->meta not properly freed
 #Direct leak of 176 byte(s) in 1 object(s) allocated from:
@@ -271,6 +285,7 @@ leak:pkg_jobs_run_solver
 
 # reponames not freed
 leak:exec_fetch
+leak:exec_install
 
 # abi leaked after fixup_abi
 #Direct leak of 8 byte(s) in 1 object(s) allocated from:
@@ -285,7 +300,7 @@ leak:exec_fetch
 #    #8 0x7f063762a1c9  (/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9) (BuildId: 6d64b17fbac799e68da7ebd9985ddf9b5cb375e6)
 #    #9 0x7f063762a28a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2a28a) (BuildId: 6d64b17fbac799e68da7ebd9985ddf9b5cb375e6)
 #    #10 0x55c5bb247444 in _start (/home/runner/work/pkg/pkg/build.pkg/src/pkg+0x14a444) (BuildId: 2bd55d3c70bbeee491903cf8e0a5e4b4835de4a6)
-leak:exec_create
+leak:fixup_abi
 
 
 # pkg structures leaked
@@ -604,18 +619,19 @@ leak:exec_create
 #    #14 0x55becb424444 in _start (/home/runner/work/pkg/pkg/build.pkg/src/pkg+0x14a444) (BuildId: 237ea5dd207e51baca5b1cbcc9176924eae0ad89)
 leak:backup_library
 
+# pkghash never freed
+leak:triggers_execute
+
 # fakerepo->url never freed
 leak:pkg_fetch_file_to_fd
 
-# hash not freed
-leak:trigger_check_match
-
-# Lua memory is never returned
-leak:l_alloc
-
-# Test is leaking
-leak:atfu_parse_plist_body
-leak:atfu_parse_keyword_body
-leak:atfu_charv_t_body
+# LUA tests are leaking
 leak:atfu_execute_body
+leak:atfu_fileops_body
+leak:atfu_parse_keyword_body
+leak:atfu_parse_plist_body
+leak:atfu_prefix_path_body
+leak:atfu_print_msg_body
+leak:atfu_override_body
 leak:atfu_readdir_body
+leak:atfu_stat_body

--- a/src/main.c
+++ b/src/main.c
@@ -293,9 +293,6 @@ show_repository_info(void)
 static void
 show_version_info(int version)
 {
-	char *config;
-	pkg_kvl_t *lib;
-
 	if (version > 1)
 		printf("%-24s: ", "Version");
 
@@ -306,13 +303,16 @@ show_version_info(int version)
 
 	printf("%-24s: %s\n", "libpkg", pkg_libversion());
 
-	lib = pkg_external_libs_version();
-	for (size_t i = 0; i < lib->len; i++)
+	pkg_kvl_t *lib = pkg_external_libs_version();
+	for (size_t i = 0; i < lib->len; i++) {
 		printf("%-24s: %s\n", lib->d[i]->key, lib->d[i]->value);
+	}
+	free(lib);
 
-	config = pkg_config_dump();
+	char *config = pkg_config_dump();
 	printf("%s\n", config);
 	free(config);
+	
 	show_plugin_info();
 	show_repository_info();
 

--- a/tests/frontend/pkg.sh
+++ b/tests/frontend/pkg.sh
@@ -16,7 +16,7 @@ pkg_no_database_body() {
 	    -o empty \
 	    -e inline:"${PROGNAME}: package database non-existent\n" \
 	    -s exit:1 \
-	    env -i PATH="${PATH}" DYLD_LIBRARY_PATH="${DYLD_LIBRARY_PATH}" LD_LIBRARY_PATH="${LD_LIBRARY_PATH}" pkg -o PKG_DBDIR=/dev/null -N
+	    env -i UBSAN_OPTIONS="${UBSAN_OPTIONS}" LSAN_OPTIONS="${LSAN_OPTIONS}" ASAN_OPTIONS="${ASAN_OPTIONS}" PATH="${PATH}" DYLD_LIBRARY_PATH="${DYLD_LIBRARY_PATH}" LD_LIBRARY_PATH="${LD_LIBRARY_PATH}" pkg -o PKG_DBDIR=/dev/null -N
 }
 
 pkg_config_defaults_body()
@@ -47,7 +47,7 @@ pkg_config_defaults_body()
 	    -o match:'^ *SSH_RESTRICT_DIR = "";$' \
 	    -e empty              \
 	    -s exit:0             \
-	    env -i ASAN_OPTIONS="${ASAN_OPTIONS}" PATH="${PATH}" DYLD_LIBRARY_PATH="${DYLD_LIBRARY_PATH}" LD_LIBRARY_PATH="${LD_LIBRARY_PATH}" pkg -C "" -R "" -vv
+	    env -i UBSAN_OPTIONS="${UBSAN_OPTIONS}" LSAN_OPTIONS="${LSAN_OPTIONS}" ASAN_OPTIONS="${ASAN_OPTIONS}" PATH="${PATH}" DYLD_LIBRARY_PATH="${DYLD_LIBRARY_PATH}" LD_LIBRARY_PATH="${LD_LIBRARY_PATH}" pkg -C "" -R "" -vv
 }
 
 pkg_create_manifest_bad_syntax_body()


### PR DESCRIPTION
* Filter through suppressions and check if still relevant
* Tighten suppressions to match more specific functions
* Fix memory leak in show_version_info
* Fix pkg invocation with overriden environment to use all sanitizer options (incl. suppressions)
* Investigate and eventually disable reported Lua poisoning