### PR TITLE
libpkg: allow filtering provided shlibs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 *.pico
 *.po
 *.Po
+*.Tpo
+*.Tpico
 *.lo
 *.la
 *.core

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ scripts/sbin/pkg2ng
 # Generated files:
 
 /autosetup/jimsh0
+/configure_call
 /Kyuafile
 /Makefile
 /compat/Makefile
@@ -95,6 +96,7 @@ scripts/sbin/pkg2ng
 /tests/frontend/libtest2fbsd.so.1
 /tests/frontend/libtestfbsd.so.1
 /tests/frontend/test_environment.sh
+/tests/hash
 /tests/lua
 /tests/metalog
 /tests/merge

--- a/libpkg/pkg.c
+++ b/libpkg/pkg.c
@@ -996,10 +996,6 @@ pkg_addshlib_provided(struct pkg *pkg, const char *name,
 	assert(pkg != NULL);
 	assert(name != NULL && name[0] != '\0');
 
-	/* ignore files which are not starting with lib */
-	if (strncmp(name, "lib", 3) != 0)
-		return (EPKG_OK);
-
 	char *full_name = pkg_shlib_name_with_flags(name, flags);
 
 	/* silently ignore duplicates in case of shlibs */

--- a/libpkg/pkg.c
+++ b/libpkg/pkg.c
@@ -966,14 +966,6 @@ pkg_addshlib_required(struct pkg *pkg, const char *name,
 
 	char *full_name = pkg_shlib_name_with_flags(name, flags);
 
-	if (match_ucl_lists(full_name,
-	    pkg_config_get("SHLIB_REQUIRE_IGNORE_GLOB"),
-	    pkg_config_get("SHLIB_REQUIRE_IGNORE_REGEX"))) {
-		dbg(3, "ignoring shlib %s required by package %s", full_name, pkg->name);
-		free(full_name);
-		return (EPKG_OK);
-	}
-
 	/* silently ignore duplicates in case of shlibs */
 	tll_foreach(pkg->shlibs_required, s) {
 		if (STREQ(s->item, full_name)) {

--- a/libpkg/pkg_config.c
+++ b/libpkg/pkg_config.c
@@ -430,6 +430,26 @@ static struct config_entry c[] = {
 	},
 	{
 		PKG_ARRAY,
+		"SHLIB_PROVIDE_PATHS_NATIVE",
+		NULL,
+	},
+	{
+		PKG_ARRAY,
+		"SHLIB_PROVIDE_PATHS_COMPAT_32",
+		NULL,
+	},
+	{
+		PKG_ARRAY,
+		"SHLIB_PROVIDE_PATHS_COMPAT_LINUX",
+		NULL,
+	},
+	{
+		PKG_ARRAY,
+		"SHLIB_PROVIDE_PATHS_COMPAT_LINUX_32",
+		NULL,
+	},
+	{
+		PKG_ARRAY,
 		"SHLIB_REQUIRE_IGNORE_GLOB",
 		NULL,
 	},

--- a/libpkg/pkg_config.c
+++ b/libpkg/pkg_config.c
@@ -450,6 +450,16 @@ static struct config_entry c[] = {
 	},
 	{
 		PKG_ARRAY,
+		"SHLIB_PROVIDE_IGNORE_GLOB",
+		NULL,
+	},
+	{
+		PKG_ARRAY,
+		"SHLIB_PROVIDE_IGNORE_REGEX",
+		NULL,
+	},
+	{
+		PKG_ARRAY,
 		"SHLIB_REQUIRE_IGNORE_GLOB",
 		NULL,
 	},

--- a/libpkg/pkg_elf.c
+++ b/libpkg/pkg_elf.c
@@ -227,7 +227,9 @@ analyse_elf(struct pkg *pkg, const char *fpath)
 			continue;
 		}
 
-
+		if (strncmp(shlib, "lib", 3) != 0) {
+			continue;
+		}
 
 		if (dyn->d_tag == DT_SONAME) {
 			pkg_addshlib_provided(pkg, shlib, flags);
@@ -237,8 +239,6 @@ analyse_elf(struct pkg *pkg, const char *fpath)
 			 * neovim is an example, skip them for now
 			 */
 			if (*shlib == '/')
-				continue;
-			if (strncmp(shlib, "lib", 3) != 0)
 				continue;
 			pkg_addshlib_required(pkg, shlib, flags);
 		}

--- a/libpkg/private/binfmt.h
+++ b/libpkg/private/binfmt.h
@@ -17,10 +17,12 @@ enum pkg_provide_flags {
 
 int pkg_elf_abi_from_fd(int fd, struct pkg_abi *abi);
 int pkg_analyse_init_elf(const char* stage);
-int pkg_analyse_elf(const bool developer_mode, struct pkg *pkg, const char *fpath);
+int pkg_analyse_elf(const bool developer_mode, struct pkg *pkg,
+    const char *fpath, char **provided, enum pkg_shlib_flags *provided_flags);
 int pkg_analyse_close_elf();
 
 int pkg_macho_abi_from_fd(int fd, struct pkg_abi *abi, enum pkg_arch arch_hint);
 int pkg_analyse_init_macho(const char* stage);
-int pkg_analyse_macho(const bool developer_mode, struct pkg *pkg, const char *fpath);
+int pkg_analyse_macho(const bool developer_mode, struct pkg *pkg,
+    const char *fpath, char **provided, enum pkg_shlib_flags *provided_flags);
 int pkg_analyse_close_macho();

--- a/libpkg/private/utils.h
+++ b/libpkg/private/utils.h
@@ -111,6 +111,7 @@ bool mkdirat_p(int fd, const char *path);
 int get_socketpair(int *);
 int checkflags(const char *mode, int *optr);
 bool match_ucl_lists(const char *buffer, const ucl_object_t *globs, const ucl_object_t *regexes);
+bool pkg_match_paths_list(const ucl_object_t *paths, const char *file);
 char *get_dirname(char *dir);
 char *rtrimspace(char *buf);
 void hidden_tempfile(char *buf, int buflen, const char *path);

--- a/tests/frontend/create-parsebin.sh
+++ b/tests/frontend/create-parsebin.sh
@@ -131,5 +131,6 @@ create_from_bin_body() {
     do
         do_check testbin $bin
         do_check testbin $bin "-o SHLIB_PROVIDE_PATHS_NATIVE=/does/not/exist"
+        do_check testbin $bin "-o SHLIB_PROVIDE_IGNORE_GLOB=*"
     done
 }


### PR DESCRIPTION
This branch adds several useful ways to filter the shared libraries automatically added to `shlibs_provided` by a pkg based on parsing the ELF/Mach-O binary. These two commits are the most relevant:

```
libpkg: add SHLIB_PROVIDE_PATHS_* options

This allows limiting the files in a package that can affect
shlibs_provided when ELF files are scanned during e.g. pkg create.

The ports system will be able to populate these options automatically
based on the already existing USE_LDCONFIG variable.
```

```
libpkg: add SHLIB_PROVIDE_IGNORE_{GLOB,REGEX} options

These are quite simple to implement and nicely complement the
SHLIB_REQUIRE_IGNORE_{GLOB,REGEX} options.
```