### PR TITLE
src: fix pkg bootstrap -y

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -736,7 +736,7 @@ main(int argc, char **argv)
 				break;
 			}
 		}
-		if (yes == 0 && force == 0) {
+		if (force == 0) {
 			printf("pkg(8) already installed, use -f to force.\n");
 			exit(EXIT_SUCCESS);
 		} else if (force == 1) {

--- a/src/main.c
+++ b/src/main.c
@@ -312,7 +312,7 @@ show_version_info(int version)
 	char *config = pkg_config_dump();
 	printf("%s\n", config);
 	free(config);
-	
+
 	show_plugin_info();
 	show_repository_info();
 
@@ -722,24 +722,25 @@ main(int argc, char **argv)
 		do_activation_test(argc);
 
 	if (argc >= 1 && STREQ(argv[0], "bootstrap")) {
-		int force = 0, yes = 0;
+		bool force = false;
+		bool yes = false;
 		while ((ch = getopt(argc, argv, "fy")) != -1) {
 			switch (ch) {
 			case 'f':
-				force = 1;
+				force = true;
 				break;
 			case 'y':
-				yes = 1;
+				yes = true;
 				break;
 			default:
 				errx(EXIT_FAILURE, "Invalid argument provided");
 				break;
 			}
 		}
-		if (force == 0) {
+		if (!force) {
 			printf("pkg(8) already installed, use -f to force.\n");
 			exit(EXIT_SUCCESS);
-		} else if (force == 1) {
+		} else {
 			if (access("/usr/sbin/pkg", R_OK) == 0) {
 				/* Only 10.0+ supported 'bootstrap -f' */
 #if __FreeBSD_version < 1000502
@@ -821,4 +822,3 @@ main(int argc, char **argv)
 
 	return (ret);
 }
-

--- a/tests/frontend/pkg.sh
+++ b/tests/frontend/pkg.sh
@@ -7,7 +7,8 @@ tests_init \
 	pkg_config_defaults \
 	pkg_create_manifest_bad_syntax \
 	pkg_repo_load_order \
-	double_entry
+	double_entry \
+	bootstrap
 
 pkg_no_database_body() {
         atf_skip_on Linux Test fails on Linux
@@ -100,4 +101,10 @@ PKG_ENV : {
 }
 EOF
 	atf_check -o ignore pkg -C ./pkg.conf -vv
+}
+
+bootstrap_body()
+{
+	atf_check -o ignore pkg bootstrap
+	atf_check -o ignore pkg bootstrap -y
 }


### PR DESCRIPTION
Currently, this causes pkg to exit with the very unhelpful error message
"pkg: unknown command: bootstrap"

This used to have the same behavior as `pkg bootstrap`in older versions
of pkg prior to commit https://github.com/freebsd/pkg/commit/fb9b33123ca608de0919fdcd3df6b43202dd4bf2.

This commit restores the old behavior of `pkg bootstrap -y` and does not
affect the behavior if `-f` is passed.

References: https://github.com/ifreund/pkgbasify/issues/6