### PR TITLE
Introduce config option MINOR_OSVER_CONFIRM

### DIFF
--- a/docs/pkg.conf.5
+++ b/docs/pkg.conf.5
@@ -192,6 +192,9 @@ data.
 .It Cm IGNORE_OSVERSION: boolean [FreeBSD specific]
 Ignore FreeBSD OS version check, useful on -STABLE and -CURRENT branches.
 Default: NO.
+.It Cm MINOR_OSVER_CONFIRM: boolean [FreeBSD specific]
+Ask user to confirm minor FreeBSD OS version mismatch.
+Default: YES.
 .It Cm INDEXDIR: string
 If set, the directory to search for
 .Cm INDEXFILE

--- a/libpkg/pkg_config.c
+++ b/libpkg/pkg_config.c
@@ -370,6 +370,10 @@ static struct config_entry c[] = {
 	},
 	{
 		PKG_BOOL,
+		"MINOR_OSVER_CONFIRM",
+		"YES",
+	{
+		PKG_BOOL,
 		"BACKUP_LIBRARIES",
 		"NO",
 	},

--- a/libpkg/utils.c
+++ b/libpkg/utils.c
@@ -459,16 +459,18 @@ is_valid_os_version(struct pkg *pkg)
 		int abi_osversion = pkg_abi_get_freebsd_osversion(&ctx.abi);
 		if (pkg_osversion > abi_osversion) {
 			if (pkg_osversion - abi_osversion < 100000) {
-				/* Negligible difference, ask user to enforce */
+				/* Negligible difference, optionally require confirmation */
+				if (!(pkg_object_bool(pkg_config_get("MINOR_OSVER_CONFIRM")))
+					osver_mismatch_allowed = 1;
 				if (osver_mismatch_allowed == -1) {
 					snprintf(query_buf, sizeof(query_buf),
 							"Newer FreeBSD version for package %s:\n"
-							"To ignore this error set IGNORE_OSVERSION=yes\n"
+							"To disable minor version confirmation, set MINOR_OSVER_CONFIRM=no\n"
 							"- package: %d\n"
 							"- running userland: %d\n"
-							"Ignore the mismatch and continue? ", pkg->name,
+							"Allow minor version mismatch and continue? ", pkg->name,
 							pkg_osversion, abi_osversion);
-					ret = pkg_emit_query_yesno(false, query_buf);
+					ret = pkg_emit_query_yesno(true, query_buf);
 					osver_mismatch_allowed = ret;
 				}
 

--- a/scripts/completion/_pkg.in
+++ b/scripts/completion/_pkg.in
@@ -131,6 +131,7 @@ _pkg_config_opts() {
 		'LOCK_RETRIES[number of retries to obtain a lock]:retries' \
 		'LOCK_WAIT[wait time to regain a lock]:wait time (seconds):' \
 		'METALOG[if set, write a METALOG of the extracted files]:string' \
+		'MINOR_OSVER_CONFIRM[ask user to confirm minor FreeBSD OS version mismatch]:boolean:(yes no)' \
 		'NAMESERVER[hostname or IPv\[46\] address of a nameserver for DNS resolution]:name server:_hosts' \
 		'OSVERSION[FreeBSD OS version]:version' \
 		'PERMISSIVE[ignore conflicts while registering a package]:boolean:(yes no)' \


### PR DESCRIPTION
Message from FreeBSD bug report 285194
(https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=285194): If we compile ports on stable branch, packages created by pkg(1) show
Annotations    :
        FreeBSD_version: __FreeBSD_version
__FreeBSD_version increases for each base API change, while ABI compatibility
is strictly maintained throughout the branch (fixed major OS version).

pkg(1) checks for th OS version mismatch before installing a package, but currently doesn't allow to catch MAJOR version mismatches only, which is the only necessary check.

In my opinion, the default to not install a package with a minor version mismatch is wrong and the IGNORE_OSVERSION=yes option is not an appropriate setting to allow minor version mismatches.

To keep the old behaviour, my proposed patch, introducing the MINOR_OSVER_CONFIRM config option, keeps the confirmation dialog for minor version mismatches, but defaults to install the package. Defining MINOR_OSVER_CONFIRM=no doesn't completely skip the OSVERSION check as IGNORE_OSVERSION=yes does, hence major (thus problematic) mismatch will be catched.

I'd prefer to have MINOR_OSVER_CONFIRM=no as the default, contrary to what the patch currently defines!