### PR TITLE
Introduce the FORCE_CAN_REMOVE_VITAL boolean config option

### DIFF
--- a/libpkg/pkg_config.c
+++ b/libpkg/pkg_config.c
@@ -330,6 +330,11 @@ static struct config_entry c[] = {
 	},
 	{
 		PKG_BOOL,
+		"FORCE_CAN_REMOVE_VITAL",
+		"YES",
+	},
+	{
+		PKG_BOOL,
 		"PKG_CREATE_VERBOSE",
 		"NO",
 	},

--- a/libpkg/pkg_solve.c
+++ b/libpkg/pkg_solve.c
@@ -686,6 +686,7 @@ pkg_solve_process_universe_variable(struct pkg_solve_problem *problem,
 	struct pkg_job_request *jreq = NULL;
 	bool chain_added = false;
 	bool force = j->flags & PKG_FLAG_FORCE;
+	bool force_overrides_vital = pkg_object_bool(pkg_config_get("FORCE_CAN_REMOVE_VITAL"));
 
 	LL_FOREACH(var, cur_var) {
 		pkg = cur_var->unit->pkg;
@@ -741,7 +742,8 @@ pkg_solve_process_universe_variable(struct pkg_solve_problem *problem,
 		}
 
 		/* Vital flag */
-		if (pkg->vital && !force) {
+		bool add_vital = force_overrides_vital ? !force : true;
+		if (pkg->vital && add_vital) {
 			if (pkg_solve_add_vital_rule(problem, cur_var) != EPKG_OK) {
 				continue;
 			}

--- a/src/pkg.conf.sample
+++ b/src/pkg.conf.sample
@@ -35,6 +35,7 @@
 #PLUGINS_CONF_DIR = "/usr/local/etc/pkg/";
 #PERMISSIVE = false;
 #REPO_AUTOUPDATE = true;
+#FORCE_CAN_REMOVE_VITAL = true;
 #NAMESERVER = "";
 #HTTP_USER_AGENT = "Custom_User_Manager";
 #EVENT_PIPE = "";

--- a/tests/frontend/upgrade.sh
+++ b/tests/frontend/upgrade.sh
@@ -11,7 +11,8 @@ tests_init \
 	dir_become_file \
 	dir_is_symlink_to_a_dir \
 	vital \
-	vital_force
+	vital_force \
+	vital_force_cant_remove
 
 issue1881_body() {
 	atf_check -s exit:0 sh ${RESOURCEDIR}/test_subr.sh new_pkg pkg1 pkg_a 1
@@ -379,4 +380,44 @@ Number of packages to be upgraded: 1
 "
 	ERROR=""
 	atf_check -o inline:"${OUTPUT}" -e inline:"${ERROR}" -s exit:0 pkg -o REPOS_DIR="$TMPDIR/repoconf" -r ${TMPDIR}/target -o PKG_CACHEDIR="$TMPDIR" upgrade -fy myplop-2
+}
+
+vital_force_cant_remove_body() {
+	atf_check -s exit:0 sh ${RESOURCEDIR}/test_subr.sh new_pkg "meta" "mymeta" "1"
+	mkdir file-pkg-1
+	cat << EOF >> meta.ucl
+vital = true;
+EOF
+	echo entry > file-pkg-1/file
+	echo "${TMPDIR}/file-pkg-1/file" > plist-1
+	atf_check pkg create -M meta.ucl -p plist-1
+	mkdir target
+	atf_check -o ignore pkg -o REPOS_DIR="${TMPDIR}" -r ${TMPDIR}/target install -Uy ${TMPDIR}/mymeta-1.pkg
+	atf_check -s exit:0 sh ${RESOURCEDIR}/test_subr.sh new_pkg "plop" "myplop" "1"
+	atf_check pkg create -M plop.ucl
+	atf_check -o ignore pkg -o REPOS_DIR="${TMPDIR}" -r ${TMPDIR}/target install -Uy ${TMPDIR}/myplop-1.pkg
+	atf_check -s exit:0 sh ${RESOURCEDIR}/test_subr.sh new_pkg "plop" "myplop" "2"
+	echo "${TMPDIR}/file-pkg-1/file" > plist-2
+	atf_check pkg create -M plop.ucl -p plist-2
+	mkdir repoconf
+	cat << EOF > repoconf/repo.conf
+local: {
+	url: file:///$TMPDIR,
+	enabled: true
+}
+EOF
+
+	atf_check -o ignore pkg repo .
+	atf_check -o ignore pkg -o REPOS_DIR="$TMPDIR/repoconf" -r ${TMPDIR}/target -o PKG_CACHEDIR="$TMPDIR" update
+	OUTPUT="Updating local repository catalogue...
+local repository is up to date.
+All repositories are up to date.
+Checking integrity... done (1 conflicting)
+  - myplop-2 conflicts with mymeta-1 on ${TMPDIR}/file-pkg-1/file
+Cannot solve problem using SAT solver, trying another plan
+Checking integrity... done (0 conflicting)
+Your packages are up to date.
+"
+	ERROR=""
+	atf_check -o inline:"${OUTPUT}" -e inline:"${ERROR}" -s exit:0 pkg -o REPOS_DIR="$TMPDIR/repoconf" -r ${TMPDIR}/target -o PKG_CACHEDIR="$TMPDIR" -o FORCE_CAN_REMOVE_VITAL=NO upgrade -fy myplop-2
 }


### PR DESCRIPTION
When set to YES (default) it allows vital packages to be removed if -f was passed. Otherwise, vital packages are guaranteed to stay.