### PR TITLE
pkg.8: Mention -vv + fix license

### DIFF
--- a/docs/pkg.8
+++ b/docs/pkg.8
@@ -11,6 +11,17 @@
 .\"    notice, this list of conditions and the following disclaimer in the
 .\"    documentation and/or other materials provided with the distribution.
 .\"
+.\" THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+.\" ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+.\" IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+.\" ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+.\" FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+.\" DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+.\" OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+.\" HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+.\" LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+.\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+.\" SUCH DAMAGE.
 .\"
 .\"     @(#)pkg.8
 .\"
@@ -67,6 +78,11 @@ The following options are supported by
 .It Fl v , Cm --version
 Display the current version of
 .Nm .
+Specify
+.Fl v
+twice to also show
+.Xr pkg.conf 5
+configuration.
 .It Fl d , Cm --debug
 Show debug information.
 .It Fl l , Cm --list


### PR DESCRIPTION
`pkg -vv` has been important for helping users with the kmods issue. Note it in the manual.

Can someone other than me please fix the license on all the manuals so I can work on them comfortably? Copyright and license makes me very nervous because of $dayjob.

Since the pkg project has a perfectly good license, I do not think these files even need their own license statement, but since they have one, I think it can not be truncated.

I did ask core and learned license without copyright is okay, so this only adds the truncated text back to the bottom.