### PR TITLE
pkg.conf(5) BACKUP_LIBRARIES, BACKUP_LIBRARY_PATH

### DIFF
--- a/docs/pkg.conf.5
+++ b/docs/pkg.conf.5
@@ -122,13 +122,13 @@ Default: NO.
 .It Cm BACKUP_LIBRARIES: boolean
 If set to
 .Sy true
+and if an upgrade will remove a library, then
 .Xr pkg 8
-will backup ancient libraries if they are removed as the result of an upgrade
-and keep a copy in the path define in
-.Cm BACKUP_LIBRARY_PATH .
-If it does not exist yet a new package
+will backup the library to the path defined by
+.Cm BACKUP_LIBRARY_PATH
+. An initial backup will create the 
 .Qq compat-libraries
-will be created. the version will be bumped each time a new library is backed up
+package. The package version will be bumped whenever an additional library is backed up.
 Default: NO.
 .It Cm BACKUP_LIBRARY_PATH: string
 Location where the libraries are backed up.


### PR DESCRIPTION
Minor corrections:

* punctuation
* uppercase beginnings to sentences
* 'define by' should be 'defined by'.

Whilst here, aim to make the sections a little clearer and more consistent.