### PR TITLE
Fix build on macOS

### DIFF
--- a/external/libcurl/Makefile.autosetup
+++ b/external/libcurl/Makefile.autosetup
@@ -48,6 +48,7 @@ SRCS=	\
 	idn.c \
 	if2ip.c \
 	llist.c \
+	macos.c \
 	mime.c \
 	mprintf.c \
 	multi.c \

--- a/libpkg/Makefile.autosetup
+++ b/libpkg/Makefile.autosetup
@@ -125,7 +125,9 @@ LOCAL_LDFLAGS+= -ldl
 @endif
 
 @if pkgos_darwin
-LOCAL_LDFLAGS+=	-lresolv
+LOCAL_LDFLAGS+=	-lresolv -lz \
+	-framework CoreFoundation -framework CoreServices \
+	-framework SystemConfiguration
 @else
 @if pkgos_freebsd
 LOCAL_LDFLAGS+=	-Wl,--version-script=$(top_srcdir)/libpkg/libpkg.ver,--undefined-version

--- a/src/Makefile.autosetup
+++ b/src/Makefile.autosetup
@@ -86,8 +86,12 @@ OTHER_LIBS+=	@PKG_LIBCURL_LDFLAGS@ @PKG_LIBCURL_LIBS@
 @endif
 
 @if pkgos_darwin
-LOCAL_LDFLAGS=	$(LIBPKGFLAT) $(LIBS) $(OTHER_LIBS) -lresolv
-STATIC_LDFLAGS=	$(LIBPKGFLAT) $(LIBS) $(OTHER_LIBS) -lresolv
+LOCAL_LDFLAGS=	$(LIBPKGFLAT) $(LIBS) $(OTHER_LIBS) -lresolv -lz \
+	-framework CoreFoundation -framework CoreServices \
+	-framework SystemConfiguration
+STATIC_LDFLAGS=	$(LIBPKGFLAT) $(LIBS) $(OTHER_LIBS) -lresolv -lz \
+	-framework CoreFoundation -framework CoreServices \
+	-framework SystemConfiguration
 # OSX doesn't support static binaries, sigh
 STATIC_ARG=
 @else


### PR DESCRIPTION
Add missing file and libraries required by curl.

Resolves:

```
Undefined symbols for architecture arm64:
  "_Curl_macos_init", referenced from:
      _curl_global_init in libcurl_pic.a[18](easy.pico)
      _curl_global_init_mem in libcurl_pic.a[18](easy.pico)
      _curl_easy_init in libcurl_pic.a[18](easy.pico)
```

```
Undefined symbols for architecture arm64:
  "_CFRelease", referenced from:
      _Curl_macos_init in libcurl_pic.a[39](macos.pico)
  "_SCDynamicStoreCopyProxies", referenced from:
      _Curl_macos_init in libcurl_pic.a[39](macos.pico)
  "_inflate", referenced from:
      _inflate_stream in libcurl_pic.a[11](content_encoding.pico)
  "_inflateEnd", referenced from:
      _deflate_do_write in libcurl_pic.a[11](content_encoding.pico)
      _deflate_do_close in libcurl_pic.a[11](content_encoding.pico)
      _inflate_stream in libcurl_pic.a[11](content_encoding.pico)
      _inflate_stream in libcurl_pic.a[11](content_encoding.pico)
      _inflate_stream in libcurl_pic.a[11](content_encoding.pico)
      _inflate_stream in libcurl_pic.a[11](content_encoding.pico)
      _inflate_stream in libcurl_pic.a[11](content_encoding.pico)
      ...
  "_inflateInit2_", referenced from:
      _inflate_stream in libcurl_pic.a[11](content_encoding.pico)
      _gzip_do_init in libcurl_pic.a[11](content_encoding.pico)
  "_inflateInit_", referenced from:
      _deflate_do_init in libcurl_pic.a[11](content_encoding.pico)
  "_zlibVersion", referenced from:
      _curl_version in libcurl_pic.a[2](version.pico)
      _curl_version_info in libcurl_pic.a[2](version.pico)
```