### PR TITLE
libpkg: add the path when we fail to do a 3way merge

### DIFF
--- a/libpkg/pkg_add.c
+++ b/libpkg/pkg_add.c
@@ -247,7 +247,7 @@ attempt_to_merge(int rootfd, struct pkg_config_file *rcf, struct pkg *local,
 	newconf = xstring_new();
 	if (merge_3way(lcf->content, localconf, rcf->content, newconf) != 0) {
 		xstring_free(newconf);
-		pkg_emit_error("Impossible to merge configuration file");
+		pkg_emit_error("Impossible to merge configuration file: %s", rcf->path);
 	} else {
 		char *conf = xstring_get(newconf);
 		rcf->newcontent = conf;


### PR DESCRIPTION
When a pkg has multiple configuration files, it's nice to be able to identify the failure at a glance.