### PR TITLE
backup_lib.c: call strrchr() before pkg_open_root and memset

### DIFF
--- a/libpkg/backup_lib.c
+++ b/libpkg/backup_lib.c
@@ -93,17 +93,18 @@ register_backup(struct pkgdb *db, int fd, const char *path)
 void
 backup_library(struct pkgdb *db, struct pkg *p, const char *path)
 {
-	const char *libname = strrchr(path, '/');
+	const char *libname;
 	char buf[BUFSIZ];
 	char *outbuf;
 	int from, to, backupdir;
 	ssize_t nread, nwritten;
 
+	if ((libname = strrchr(path, '/')) == NULL)
+		return;
+
 	pkg_open_root_fd(p);
 	to = -1;
 
-	if (libname == NULL)
-		return;
 	/* skip the initial / */
 	libname++;
 
@@ -141,6 +142,7 @@ backup_library(struct pkgdb *db, struct pkg *p, const char *path)
 		goto out;
 	}
 
+	memset(buf, '\0', sizeof(buf));
 	while ((nread = read(from, buf, sizeof(buf))) > 0) {
 		outbuf = buf;
 		do {


### PR DESCRIPTION
We are calling pkg_open_root() early but if strrchr() is NULL, then it's not executing the body anyway, so check the strrchr() condition before open_root.

Also, zero initialize the buffer. (valgrind warning).