### PR TITLE
pkg-install.8: Optimize title to fit in one line

### DIFF
--- a/docs/pkg-install.8
+++ b/docs/pkg-install.8
@@ -19,7 +19,7 @@
 .Os
 .Sh NAME
 .Nm "pkg install"
-.Nd install packages from remote package repositories or local archives
+.Nd install packages from remote repositories or local archives
 .Sh SYNOPSIS
 .Nm
 .Op Fl AfIMnFqRUy


### PR DESCRIPTION
Remove the second instance of the word "packages".

Discussed with:	emaste, jrm, kevans