### PR TITLE
check: fix iterator leak

### DIFF
--- a/src/check.c
+++ b/src/check.c
@@ -358,6 +358,7 @@ exec_check(int argc, char **argv)
 		if (nbactions == 0 && match != MATCH_ALL) {
 			warnx("No packages matching: %s", argv[i]);
 			rc = EXIT_FAILURE;
+			pkgdb_it_free(it);
 			goto cleanup;
 		}
 


### PR DESCRIPTION
It is allocated using `pkgdb_query` a few lines up.
This stops `sqlite3_close` from returning `SQLITE_BUSY` when closing.

The warning message can be reproduced by attempting to check a non-existent package, e.g `pkg check nonexistent`.