### PR TITLE
check: plug more iterator leaks

### DIFF
--- a/src/check.c
+++ b/src/check.c
@@ -352,7 +352,7 @@ exec_check(int argc, char **argv)
 		 * in multiple matches and only run this top-loop once. */
 		if ((it = pkgdb_query(db, argv[i], match)) == NULL) {
 			rc = EXIT_FAILURE;
-			goto cleanup;
+			break;
 		}
 		nbactions = pkgdb_it_count(it);
 		if (nbactions == 0 && match != MATCH_ALL) {
@@ -360,7 +360,7 @@ exec_check(int argc, char **argv)
 			rc = EXIT_FAILURE;
 			pkgdb_it_free(it);
 			it = NULL;
-			goto cleanup;
+			break;
 		}
 
 		if (msg == NULL)
@@ -444,20 +444,19 @@ exec_check(int argc, char **argv)
 					rc = EXIT_FAILURE;
 				}
 				if (rc == EXIT_FAILURE)
-					goto cleanup;
+					break;
 				pkgdb_downgrade_lock(db, PKGDB_LOCK_EXCLUSIVE,
 				    PKGDB_LOCK_ADVISORY);
 			}
 			else {
 				rc = EXIT_FAILURE;
-				goto cleanup;
+				break;
 			}
 		}
 		i++;
 	} while (i < argc);
 	assert(it == NULL);
 
-cleanup:
 	if (!verbose)
 		progressbar_stop();
 	xstring_free(msg);

--- a/src/check.c
+++ b/src/check.c
@@ -359,6 +359,7 @@ exec_check(int argc, char **argv)
 			warnx("No packages matching: %s", argv[i]);
 			rc = EXIT_FAILURE;
 			pkgdb_it_free(it);
+			it = NULL;
 			goto cleanup;
 		}
 
@@ -417,6 +418,9 @@ exec_check(int argc, char **argv)
 					printf(" done\n");
 			}
 		}
+		pkgdb_it_free(it);
+		it = NULL;
+
 		if (!quiet && !verbose)
 			progressbar_tick(processed, total);
 		fflush(out->fp);
@@ -449,9 +453,9 @@ exec_check(int argc, char **argv)
 				goto cleanup;
 			}
 		}
-		pkgdb_it_free(it);
 		i++;
 	} while (i < argc);
+	assert(it == NULL);
 
 cleanup:
 	if (!verbose)


### PR DESCRIPTION
Free the iterator when we are done using it, preventing more leaks when we goto cleanup.
Also replace the cleanup label with a break.

Noticed by: kevans