### PR TITLE
libpkg: Set numeric uid/gid when adding archive entries

### DIFF
--- a/libpkg/packing.c
+++ b/libpkg/packing.c
@@ -233,10 +233,24 @@ packing_append_file_attr(struct packing *pack, const char *filepath,
 	if (uname != NULL && uname[0] != '\0') {
 		archive_entry_set_uname(entry, uname);
 	}
+#ifdef __FreeBSD__
+	/*
+	 * Set this so that libarchive does not embed the current user's ID,
+	 * breaking reproducibility.
+	 */
+	archive_entry_set_uid(entry, 65534 /* nobody */);
+#endif
 
 	if (gname != NULL && gname[0] != '\0') {
 		archive_entry_set_gname(entry, gname);
 	}
+#ifdef __FreeBSD__
+	/*
+	 * Set this so that libarchive does not embed the current user's ID,
+	 * breaking reproducibility.
+	 */
+	archive_entry_set_gid(entry, 65534 /* nobody */);
+#endif
 
 	if (fflags > 0)
 		archive_entry_set_fflags(entry, fflags, 0);


### PR DESCRIPTION
When pkg installs a package, it uses the embedded uname/gname to set the owner/group for an extracted file; see get_uid_from_archive() and get_gid_from_archive() in pkg_add.c.  However, the tar format also stores a numeric uid/gid, and if not specified, it's set to the current user's uid/gid.

This means unprivileged user-created packages (e.g., pkgbase packages) might have reproducibility issues if we compare packages built by different users.

Fix this by hard-coding a harmless, fixed value for the numeric uid/gid on FreeBSD.  We could alternately just set the uid/gid to 0/0.

Sponsored by:	The FreeBSD Foundation
Sponsored by:	Klara, Inc.