### PR TITLE
libpkg: Provide the METALOG path to pkg scripts

### DIFF
--- a/docs/pkg-lua-script.5
+++ b/docs/pkg-lua-script.5
@@ -11,7 +11,7 @@
 .\"    notice, this list of conditions and the following disclaimer in the
 .\"    documentation and/or other materials provided with the distribution.
 .\"
-.Dd July 27, 2022
+.Dd July 14, 2025
 .Dt PKG-LUA-SCRIPT 5
 .Os
 .Sh NAME
@@ -88,6 +88,13 @@ by the
 .Fl r
 arguments passed to
 .Xr pkg 8 .
+.It Va pkg_metalog
+String containing the path to a
+.Xr mtree 5
+METALOG file in which package file metadata (e.g., ownership, mode) should be
+recorded.
+This is typically used when installing packages as a non-root user.
+If no METALOG is configured, this variable is unset and is equal to nil.
 .It Va pkg_upgrade
 Boolean to inform the scripts that it is running or not in the context of an upgrade
 .El

--- a/docs/pkg-script.5
+++ b/docs/pkg-script.5
@@ -11,7 +11,7 @@
 .\"    notice, this list of conditions and the following disclaimer in the
 .\"    documentation and/or other materials provided with the distribution.
 .\"
-.Dd March 26, 2021
+.Dd July 24, 2025
 .Dt PKG-SCRIPT 5
 .Os
 .Sh NAME
@@ -59,6 +59,12 @@ by the
 .Fl r
 arguments passed to
 .Xr pkg 8 .
+.It Ev PKG_METALOG
+When set, provides the path to a
+.Xr mtree 5
+METALOG file in which package file metadata (e.g., ownership, mode) should be
+recorded.
+This is typically used when installing packages as a non-root user.
 .It Ev PKG_MSGFD
 Number of a file descriptor to be used to be able to send messages to the user
 that will be shown at the end of the

--- a/libpkg/lua_scripts.c
+++ b/libpkg/lua_scripts.c
@@ -89,6 +89,10 @@ pkg_lua_script_run(struct pkg * const pkg, pkg_lua_script type, bool upgrade)
 				ctx.pkg_rootdir = "/";
 			lua_pushstring(L, ctx.pkg_rootdir);
 			lua_setglobal(L, "pkg_rootdir");
+			if (ctx.metalog != NULL) {
+				lua_pushstring(L, ctx.metalog);
+				lua_setglobal(L, "pkg_metalog");
+			}
 			lua_pushboolean(L, (upgrade));
 			lua_setglobal(L, "pkg_upgrade");
 			luaL_newlib(L, pkg_lib);

--- a/libpkg/pkg_config.c
+++ b/libpkg/pkg_config.c
@@ -77,6 +77,7 @@ struct pkg_ctx ctx = {
 	.debug_level = 0,
 	.developer_mode = false,
 	.pkg_rootdir = NULL,
+	.metalog = NULL,
 	.dbdir = NULL,
 	.cachedir = NULL,
 	.rootfd = -1,
@@ -1559,6 +1560,7 @@ pkg_ini(const char *path, const char *reposdir, pkg_init_flags flags)
 	if (err != EPKG_OK)
 		goto out;
 	ctx.developer_mode = pkg_object_bool(pkg_config_get("DEVELOPER_MODE"));
+	ctx.metalog = pkg_object_string(pkg_config_get("METALOG"));
 	ctx.dbdir = pkg_object_string(pkg_config_get("PKG_DBDIR"));
 	ctx.cachedir = pkg_object_string(pkg_config_get("PKG_CACHEDIR"));
 	ctx.backup_libraries = pkg_object_bool(pkg_config_get("BACKUP_LIBRARIES"));
@@ -1630,19 +1632,15 @@ pkg_ini(const char *path, const char *reposdir, pkg_init_flags flags)
 			pkg_emit_error("Unable to set nameserver, ignoring");
 
 	/* Open metalog */
-	metalog = pkg_object_string(pkg_config_get("METALOG"));
-	if (metalog != NULL) {
-		if(metalog_open(metalog) != EPKG_OK) {
-			err = EPKG_FATAL;
-			goto out;
-		}
+	if (ctx.metalog != NULL && metalog_open(ctx.metalog) != EPKG_OK) {
+		err = EPKG_FATAL;
+		goto out;
 	}
 
 out:
 	config_parser_vars_free(parser_vars);
 
 	return err;
-
 }
 
 static struct pkg_repo_ops*

--- a/libpkg/private/pkg.h
+++ b/libpkg/private/pkg.h
@@ -129,6 +129,7 @@ struct pkg_ctx {
 	uint64_t debug_flags;
 	bool developer_mode;
 	const char *pkg_rootdir;
+	const char *metalog;
 	const char *dbdir;
 	const char *cachedir;
 	const char *compression_format;

--- a/libpkg/scripts.c
+++ b/libpkg/scripts.c
@@ -119,6 +119,8 @@ pkg_script_run(struct pkg * const pkg, pkg_script type, bool upgrade, bool noexe
 			if (ctx.pkg_rootdir == NULL)
 				ctx.pkg_rootdir = "/";
 			setenv("PKG_ROOTDIR", ctx.pkg_rootdir, 1);
+			if (ctx.metalog != NULL)
+				setenv("PKG_METALOG", ctx.metalog, 1);
 			if (ctx.ischrooted)
 				setenv("PKG_CHROOTED", "true", 1);
 			debug = pkg_object_bool(pkg_config_get("DEBUG_SCRIPTS"));


### PR DESCRIPTION
This is useful for non-root package installations.  For instance, the pkg post-install and post-deinstall for ca_root_nss just runs "certctl rehash", but certctl can take a METALOG path parameter.  With this feature and a bit of work, that post-install script can be run as a non-root user.