### PR TITLE
delete.c: pkgbase: add a hint about base packages

### DIFF
--- a/src/delete.c
+++ b/src/delete.c
@@ -237,7 +237,8 @@ exec_delete(int argc, char **argv)
 			goto cleanup;
 		}
 		rc = query_yesno(false,
-		            "\nProceed with deinstalling packages? ");
+		            "\nProceed? Note that if base (FreeBSD-) packages are deleted, "
+			    "FreeBSD itself will be affected. ");
 	}
 	else
 		rc = yes;


### PR DESCRIPTION
Expand the wording of the [y/N] prompt.

Make the user aware of the relationship between:

-   FreeBSD-* packages
-   FreeBSD   (the operating system).