### PR TITLE
tests: Fix OSVF test building on Ubuntu 20.04

### DIFF
--- a/tests/lib/pkg_osvf.c
+++ b/tests/lib/pkg_osvf.c
@@ -19,7 +19,7 @@ ATF_TC_WITHOUT_HEAD(osvfdetect);
 ATF_TC_WITHOUT_HEAD(osvfopen);
 ATF_TC_WITHOUT_HEAD(osvfparse);
 
-#ifndef(ATF_CHECK_INTEQ)
+#ifndef ATF_CHECK_INTEQ
 #define ATF_CHECK_INTEQ ATF_CHECK_EQ
 #endif
 


### PR DESCRIPTION
Ubuntu 20.04 have old ATF which does not have ATF_CHECK_INTEQ macro. Change test to use pure ATF_CHECK.