### PR TITLE
liblua: Use POSIX

### DIFF
--- a/external/liblua/Makefile.autosetup
+++ b/external/liblua/Makefile.autosetup
@@ -37,6 +37,6 @@ SRCS=	lapi.c \
 	loadlib.c \
 	linit.c
 
-LOCAL_CFLAGS=	-I$(top_srcdir)/external/lua/src
+LOCAL_CFLAGS=	-I$(top_srcdir)/external/lua/src -DLUA_USE_POSIX
 
 include $(MK)/static-lib.mk


### PR DESCRIPTION
Use the posix methods to avoid unsafe function warnings on FreeBSD. Fixes the ports system warning about using tmpnam.

There is also USE_DLOPEN, but I'm not sure pkg needs to ever dlopen something in its lua functions, so I'm leaving that one out.