### PR TITLE
pkgdb: track uname, gname, permissions and fflags in pkgdb

### DIFF
--- a/docs/pkg-query.8
+++ b/docs/pkg-query.8
@@ -223,14 +223,38 @@ for the package origin, and
 for the package version.
 .It Cm \&%C
 Expands to the list of categories the matched package belongs to.
-.It Cm \&%F Ns Op ps
+.It Cm \&%F Ns Op psugmft
 Expands to the list of files of the matched package, where
 .Cm p
-stands for path, and
+stands for path,
 .Cm s
-for sum.
+for checksum,
+.Cm u
+for owner,
+.Cm g
+for group,
+.Cm m
+for mode (permissions),
+.Cm f
+for file flags, and
+.Cm t
+for the symlink target (or empty string if no symlink).
 .It Cm \&%D
 Expands to the list of directories of the matched package.
+.It Cm \&%S Ns Op pugmf
+Expands to the list of (sub-)directories of the matched package, where
+.Cm p
+stands for path,
+.Cm u
+for owner,
+.Cm g
+for group,
+.Cm m
+for mode (permissions), and
+.Cm f
+for file flags. Same as
+.Cm \&%D
+but allows specifying suboptions.
 .It Cm \&%O Ns Op kvdD
 Expands to the list of options of the matched package, where
 .Cm k

--- a/docs/pkg-query.8
+++ b/docs/pkg-query.8
@@ -223,7 +223,7 @@ for the package origin, and
 for the package version.
 .It Cm \&%C
 Expands to the list of categories the matched package belongs to.
-.It Cm \&%F Ns Op psugmft
+.It Cm \&%F Ns Op psugmftl
 Expands to the list of files of the matched package, where
 .Cm p
 stands for path,
@@ -236,7 +236,9 @@ for group,
 .Cm m
 for mode (permissions),
 .Cm f
-for file flags, and
+for file flags,
+.Cm l
+for last modification time, and
 .Cm t
 for the symlink target (or empty string if no symlink).
 .It Cm \&%D

--- a/docs/pkg_printf.3
+++ b/docs/pkg_printf.3
@@ -512,6 +512,9 @@ File flags [string]
 .It Cm %Fg
 File ownership: group name [string]
 .Vt struct pkg_file *
+.It Cm %Fl
+File last modification time [epoch]
+.Vt struct pkg_file *
 .It Cm %\^Fn
 File path name [string]
 .Vt struct pkg_file *

--- a/docs/pkg_printf.3
+++ b/docs/pkg_printf.3
@@ -485,6 +485,9 @@ Directories [array]
 .Pp
 Default row format:
 .Cm "%D%{%Dn\en%|%}"
+.It Cm %Df
+Directory file flags [string]
+.Vt struct pkg_dir *
 .It Cm %Dg
 Directory ownership: group name [string]
 .Vt struct pkg_dir *
@@ -503,6 +506,9 @@ Files [array]
 .Pp
 Default row format:
 .Cm "%F%{%Fn\en%|%}"
+.It Cm %Ff
+File flags [string]
+.Vt struct pkg_file *
 .It Cm %Fg
 File ownership: group name [string]
 .Vt struct pkg_file *
@@ -514,6 +520,9 @@ File permissions [mode]
 .Vt struct pkg_file *
 .It Cm %Fs
 File SHA256 checksum [string]
+.Vt struct pkg_file *
+.It Cm %Ft
+File Symlink target [string]
 .Vt struct pkg_file *
 .It Cm %Fu
 File ownership: user name [string]

--- a/libpkg/pkg.c
+++ b/libpkg/pkg.c
@@ -493,13 +493,13 @@ pkg_addrdep(struct pkg *pkg, const char *name, const char *origin, const char *v
 int
 pkg_addfile(struct pkg *pkg, const char *path, const char *sum, bool check_duplicates)
 {
-	return (pkg_addfile_attr(pkg, path, sum, NULL, NULL, 0, 0, check_duplicates));
+	return (pkg_addfile_attr(pkg, path, sum, NULL, NULL, 0, 0, NULL, check_duplicates));
 }
 
 int
 pkg_addfile_attr(struct pkg *pkg, const char *path, const char *sum,
-    const char *uname, const char *gname, mode_t perm, u_long fflags,
-    bool check_duplicates)
+		 const char *uname, const char *gname, mode_t perm, u_long fflags,
+		 const char *symlink_target, bool check_duplicates)
 {
 	struct pkg_file *f = NULL;
 	char abspath[MAXPATHLEN];
@@ -537,6 +537,9 @@ pkg_addfile_attr(struct pkg *pkg, const char *path, const char *sum,
 
 	if (fflags != 0)
 		f->fflags = fflags;
+
+	if (symlink_target != NULL)
+		strlcpy(f->symlink_target, symlink_target, sizeof(f->symlink_target));
 
 	pkghash_safe_add(pkg->filehash, f->path, f, NULL);
 	DL_APPEND(pkg->files, f);

--- a/libpkg/pkg.c
+++ b/libpkg/pkg.c
@@ -493,12 +493,13 @@ pkg_addrdep(struct pkg *pkg, const char *name, const char *origin, const char *v
 int
 pkg_addfile(struct pkg *pkg, const char *path, const char *sum, bool check_duplicates)
 {
-	return (pkg_addfile_attr(pkg, path, sum, NULL, NULL, 0, 0, NULL, check_duplicates));
+	return (pkg_addfile_attr(pkg, path, sum, NULL, NULL, 0, 0, 0, NULL, check_duplicates));
 }
 
 int
 pkg_addfile_attr(struct pkg *pkg, const char *path, const char *sum,
-		 const char *uname, const char *gname, mode_t perm, u_long fflags,
+		 const char *uname, const char *gname, mode_t perm,
+		 u_long fflags, time_t mtime,
 		 const char *symlink_target, bool check_duplicates)
 {
 	struct pkg_file *f = NULL;
@@ -540,6 +541,9 @@ pkg_addfile_attr(struct pkg *pkg, const char *path, const char *sum,
 
 	if (symlink_target != NULL)
 		strlcpy(f->symlink_target, symlink_target, sizeof(f->symlink_target));
+
+	if (mtime > 0)
+		f->time[1].tv_sec = mtime;
 
 	pkghash_safe_add(pkg->filehash, f->path, f, NULL);
 	DL_APPEND(pkg->files, f);

--- a/libpkg/pkg_add.c
+++ b/libpkg/pkg_add.c
@@ -374,15 +374,15 @@ fill_timespec_buf(const struct stat *aest, struct timespec tspec[2])
 {
 #ifdef HAVE_STRUCT_STAT_ST_MTIM
 	tspec[0].tv_sec = aest->st_atim.tv_sec;
-	tspec[0].tv_nsec = aest->st_atim.tv_nsec;
+	tspec[0].tv_nsec = 0;
 	tspec[1].tv_sec = aest->st_mtim.tv_sec;
-	tspec[1].tv_nsec = aest->st_mtim.tv_nsec;
+	tspec[1].tv_nsec = 0;
 #else
 # if defined(_DARWIN_C_SOURCE) || defined(__APPLE__)
 	tspec[0].tv_sec = aest->st_atimespec.tv_sec;
-	tspec[0].tv_nsec = aest->st_atimespec.tv_nsec;
+	tspec[0].tv_nsec = 0;
 	tspec[1].tv_sec = aest->st_mtimespec.tv_sec;
-	tspec[1].tv_nsec = aest->st_mtimespec.tv_nsec;
+	tspec[1].tv_nsec = 0;
 # else
 	/* Portable unix version */
 	tspec[0].tv_sec = aest->st_atime;

--- a/libpkg/pkg_create.c
+++ b/libpkg/pkg_create.c
@@ -132,6 +132,9 @@ pkg_create_from_dir(struct pkg *pkg, const char *root,
 				}
 				file->symlink_target[linklen] = '\0';
 			}
+
+			file->time[0] = st.st_atim;
+			file->time[1] = st.st_mtim;
 		}
 
 		counter_count();

--- a/libpkg/pkg_ports.c
+++ b/libpkg/pkg_ports.c
@@ -407,12 +407,12 @@ meta_file(struct plist *p, char *line, struct file_attr *a, bool is_config)
 				       a->owner ? a->owner : p->uname,
 				       a->group ? a->group : p->gname,
 				       a->mode ? a->mode : p->perm,
-				       a->fflags,
+				       a->fflags, st.st_mtim.tv_sec,
 				       linklen > 0 ? symlink_target : NULL,
 				       true);
 	} else {
 		ret = pkg_addfile_attr(p->pkg, path, buf, p->uname,
-				       p->gname, p->perm, 0,
+				       p->gname, p->perm, 0, st.st_mtim.tv_sec,
 				       linklen > 0 ? symlink_target : NULL,
 				       true);
 	}

--- a/libpkg/pkgdb_iterator.c
+++ b/libpkg/pkgdb_iterator.c
@@ -388,7 +388,7 @@ pkgdb_load_files(sqlite3 *sqlite, struct pkg *pkg)
 	sqlite3_stmt	*stmt = NULL;
 	int		 ret;
 	const char	 sql[] = ""
-		"SELECT path, sha256, uname, gname, perm, fflags, symlink_target "
+		"SELECT path, sha256, uname, gname, perm, fflags, mtime, symlink_target "
 		"  FROM files"
 		"  WHERE package_id = ?1"
 		"  ORDER BY PATH ASC";
@@ -418,9 +418,10 @@ pkgdb_load_files(sqlite3 *sqlite, struct pkg *pkg)
 		const char *gname = sqlite3_column_text(stmt, 3);
 		mode_t perm = sqlite3_column_int64(stmt, 4);
 		u_long fflags = sqlite3_column_int64(stmt, 5);
-		const char *symlink_target = sqlite3_column_text(stmt, 6);
+		time_t mtime = sqlite3_column_int64(stmt, 6);
+		const char *symlink_target = sqlite3_column_text(stmt, 7);
 		pkg_addfile_attr(pkg, path, sum, uname, gname, perm, fflags,
-				 symlink_target, false);
+				 mtime, symlink_target, false);
 	}
 	sqlite3_finalize(stmt);
 

--- a/libpkg/private/db_upgrades.h
+++ b/libpkg/private/db_upgrades.h
@@ -733,6 +733,7 @@ static struct db_upgrades {
 	"ALTER TABLE files ADD COLUMN gname TEXT; "
 	"ALTER TABLE files ADD COLUMN perm INTEGER; "
 	"ALTER TABLE files ADD COLUMN fflags INTEGER; "
+	"ALTER TABLE files ADD COLUMN mtime INTEGER; "
 	"ALTER TABLE files ADD COLUMN symlink_target TEXT; "
 	"ALTER TABLE directories ADD COLUMN uname TEXT; "
 	"ALTER TABLE directories ADD COLUMN gname TEXT; "

--- a/libpkg/private/db_upgrades.h
+++ b/libpkg/private/db_upgrades.h
@@ -728,6 +728,16 @@ static struct db_upgrades {
 	"DROP VIEW IF EXISTS lua_scripts; "
 	"DROP VIEW IF EXISTS options; "
 	"DROP VIEW IF EXISTS scripts; "
+	}, { 37,
+	"ALTER TABLE files ADD COLUMN uname TEXT; "
+	"ALTER TABLE files ADD COLUMN gname TEXT; "
+	"ALTER TABLE files ADD COLUMN perm INTEGER; "
+	"ALTER TABLE files ADD COLUMN fflags INTEGER; "
+	"ALTER TABLE files ADD COLUMN symlink_target TEXT; "
+	"ALTER TABLE directories ADD COLUMN uname TEXT; "
+	"ALTER TABLE directories ADD COLUMN gname TEXT; "
+	"ALTER TABLE directories ADD COLUMN perm INTEGER; "
+	"ALTER TABLE directories ADD COLUMN fflags INTEGER; "
 	},
 	/* Mark the end of the array */
 	{ -1, NULL }

--- a/libpkg/private/pkg.h
+++ b/libpkg/private/pkg.h
@@ -377,6 +377,7 @@ struct pkg_file {
 	gid_t		 gid;
 	char		 temppath[MAXPATHLEN];
 	u_long		 fflags;
+	char		 symlink_target[MAXPATHLEN];
 	struct pkg_config_file *config;
 	struct timespec	 time[2];
 	struct pkg_file	*next, *prev;
@@ -791,7 +792,7 @@ int pkg_addfile(struct pkg *pkg, const char *path, const char *sha256,
     bool check_duplicates);
 int pkg_addfile_attr(struct pkg *pkg, const char *path, const char *sha256,
     const char *uname, const char *gname, mode_t perm, u_long fflags,
-    bool check_duplicates);
+    const char *symlink_target, bool check_duplicates);
 
 int pkg_adddir(struct pkg *pkg, const char *path, bool check_duplicates);
 int pkg_adddir_attr(struct pkg *pkg, const char *path, const char *uname,

--- a/libpkg/private/pkg.h
+++ b/libpkg/private/pkg.h
@@ -792,7 +792,7 @@ int pkg_addfile(struct pkg *pkg, const char *path, const char *sha256,
     bool check_duplicates);
 int pkg_addfile_attr(struct pkg *pkg, const char *path, const char *sha256,
     const char *uname, const char *gname, mode_t perm, u_long fflags,
-    const char *symlink_target, bool check_duplicates);
+    time_t mtime, const char *symlink_target, bool check_duplicates);
 
 int pkg_adddir(struct pkg *pkg, const char *path, bool check_duplicates);
 int pkg_adddir_attr(struct pkg *pkg, const char *path, const char *uname,

--- a/libpkg/private/pkg_printf.h
+++ b/libpkg/private/pkg_printf.h
@@ -93,6 +93,7 @@ typedef enum _fmt_code_t {
 	PP_PKG_DIRECTORIES,
 	PP_PKG_FILE_FFLAGS,
 	PP_PKG_FILE_GROUP,
+	PP_PKG_FILE_MTIME,
 	PP_PKG_FILE_PATH,
 	PP_PKG_FILE_PERMS,
 	PP_PKG_FILE_SHA256,
@@ -185,6 +186,7 @@ _static xstring *format_directory_path(xstring *, const void *, struct percent_e
 _static xstring *format_directory_perms(xstring *, const void *, struct percent_esc *);
 _static xstring *format_directory_user(xstring *, const void *, struct percent_esc *);
 _static xstring *format_files(xstring *, const void *, struct percent_esc *);
+_static xstring *format_file_mtime(xstring *, const void *, struct percent_esc *);
 _static xstring *format_file_group(xstring *, const void *, struct percent_esc *);
 _static xstring *format_file_path(xstring *, const void *, struct percent_esc *);
 _static xstring *format_file_perms(xstring *, const void *, struct percent_esc *);

--- a/libpkg/private/pkg_printf.h
+++ b/libpkg/private/pkg_printf.h
@@ -85,15 +85,18 @@ typedef enum _fmt_code_t {
 	PP_PKG_SHLIBS_REQUIRED,
 	PP_PKG_CATEGORY_NAME,
 	PP_PKG_CATEGORIES,
+	PP_PKG_DIRECTORY_FFLAGS,
 	PP_PKG_DIRECTORY_GROUP,
 	PP_PKG_DIRECTORY_PATH,
 	PP_PKG_DIRECTORY_PERMS,
 	PP_PKG_DIRECTORY_USER,
 	PP_PKG_DIRECTORIES,
+	PP_PKG_FILE_FFLAGS,
 	PP_PKG_FILE_GROUP,
 	PP_PKG_FILE_PATH,
 	PP_PKG_FILE_PERMS,
 	PP_PKG_FILE_SHA256,
+	PP_PKG_FILE_SYMLINK_TARGET,
 	PP_PKG_FILE_USER,
 	PP_PKG_FILES,
 	PP_PKG_GROUP_NAME,
@@ -176,6 +179,7 @@ _static xstring *format_shlib_name(xstring *, const void *, struct percent_esc *
 _static xstring *format_categories(xstring *, const void *, struct percent_esc *);
 _static xstring *format_category_name(xstring *, const void *, struct percent_esc *);
 _static xstring *format_directories(xstring *, const void *, struct percent_esc *);
+_static xstring *format_directory_fflags(xstring *, const void *, struct percent_esc *);
 _static xstring *format_directory_group(xstring *, const void *, struct percent_esc *);
 _static xstring *format_directory_path(xstring *, const void *, struct percent_esc *);
 _static xstring *format_directory_perms(xstring *, const void *, struct percent_esc *);
@@ -186,6 +190,8 @@ _static xstring *format_file_path(xstring *, const void *, struct percent_esc *)
 _static xstring *format_file_perms(xstring *, const void *, struct percent_esc *);
 _static xstring *format_file_sha256(xstring *, const void *, struct percent_esc *);
 _static xstring *format_file_user(xstring *, const void *, struct percent_esc *);
+_static xstring *format_file_fflags(xstring *, const void *, struct percent_esc *);
+_static xstring *format_file_symlink_target(xstring *, const void *, struct percent_esc *);
 _static xstring *format_groups(xstring *, const void *, struct percent_esc *);
 _static xstring *format_group_name(xstring *, const void *, struct percent_esc *);
 _static xstring *format_row_counter(xstring *, const void *, struct percent_esc *);

--- a/src/query.c
+++ b/src/query.c
@@ -45,9 +45,10 @@ static const struct query_flags accepted_query_flags[] = {
 	{ 'd', "nov",		1, PKG_LOAD_DEPS },
 	{ 'r', "nov",		1, PKG_LOAD_RDEPS },
 	{ 'C', "",		1, PKG_LOAD_CATEGORIES },
-	{ 'F', "ps",		1, PKG_LOAD_FILES },
+	{ 'F', "psugmft",	1, PKG_LOAD_FILES },
 	{ 'O', "kvdD",		1, PKG_LOAD_OPTIONS },
 	{ 'D', "",		1, PKG_LOAD_DIRS },
+	{ 'S', "pugmf",		1, PKG_LOAD_DIRS }, /* sub directories - directory with options */
 	{ 'L', "",		1, PKG_LOAD_LICENSES },
 	{ 'U', "",		1, PKG_LOAD_USERS },
 	{ 'G', "",		1, PKG_LOAD_GROUPS },
@@ -154,6 +155,7 @@ format_str(struct pkg *pkg, xstring *dest, const char *qstr, const void *data)
 					pkg_fprintf(dest->fp, "%?O", pkg);
 					break;
 				case 'D':
+				case 'S':
 					pkg_fprintf(dest->fp, "%?D", pkg);
 					break;
 				case 'L':
@@ -253,6 +255,16 @@ format_str(struct pkg *pkg, xstring *dest, const char *qstr, const void *data)
 					pkg_fprintf(dest->fp, "%Fn", data);
 				else if (qstr[0] == 's')
 					pkg_fprintf(dest->fp, "%Fs", data);
+				else if (qstr[0] == 'u')
+					pkg_fprintf(dest->fp, "%Fu", data);
+				else if (qstr[0] == 'g')
+					pkg_fprintf(dest->fp, "%Fg", data);
+				else if (qstr[0] == 'm')
+					pkg_fprintf(dest->fp, "%Fp", data);
+				else if (qstr[0] == 'f')
+					pkg_fprintf(dest->fp, "%Ff", data);
+				else if (qstr[0] == 't')
+					pkg_fprintf(dest->fp, "%Ft", data);
 				break;
 			case 'O':
 				qstr++;
@@ -267,6 +279,19 @@ format_str(struct pkg *pkg, xstring *dest, const char *qstr, const void *data)
 				break;
 			case 'D':
 				pkg_fprintf(dest->fp, "%Dn", data);
+				break;
+			case 'S':
+				qstr++;
+				if (qstr[0] == 'p')
+					pkg_fprintf(dest->fp, "%Dn", data);
+				else if (qstr[0] == 'u')
+					pkg_fprintf(dest->fp, "%Du", data);
+				else if (qstr[0] == 'g')
+					pkg_fprintf(dest->fp, "%Dg", data);
+				else if (qstr[0] == 'm')
+					pkg_fprintf(dest->fp, "%Dp", data);
+				else if (qstr[0] == 'f')
+					pkg_fprintf(dest->fp, "%Df", data);
 				break;
 			case 'L':
 				pkg_fprintf(dest->fp, "%Ln", data);
@@ -391,6 +416,7 @@ print_query(struct pkg *pkg, char *qstr, char multiline)
 		}
 		break;
 	case 'D':
+	case 'S':
 		while (pkg_dirs(pkg, &dir) == EPKG_OK) {
 			format_str(pkg, output, qstr, dir);
 			printf("%s\n", output->buf);
@@ -580,6 +606,7 @@ format_sql_condition(const char *str, xstring *sqlcond, bool for_remote)
 							fprintf(sqlcond->fp, "(SELECT %s FROM pkg_option AS d WHERE d.package_id=p.id)", sqlop);
 							break;
 						case 'D':
+						case 'S':
 							if (for_remote)
 								goto bad_option;
 							fprintf(sqlcond->fp, "(SELECT %s FROM pkg_directories AS d WHERE d.package_id=p.id)", sqlop);

--- a/src/query.c
+++ b/src/query.c
@@ -45,7 +45,7 @@ static const struct query_flags accepted_query_flags[] = {
 	{ 'd', "nov",		1, PKG_LOAD_DEPS },
 	{ 'r', "nov",		1, PKG_LOAD_RDEPS },
 	{ 'C', "",		1, PKG_LOAD_CATEGORIES },
-	{ 'F', "psugmft",	1, PKG_LOAD_FILES },
+	{ 'F', "psugmftl",	1, PKG_LOAD_FILES },
 	{ 'O', "kvdD",		1, PKG_LOAD_OPTIONS },
 	{ 'D', "",		1, PKG_LOAD_DIRS },
 	{ 'S', "pugmf",		1, PKG_LOAD_DIRS }, /* sub directories - directory with options */
@@ -265,6 +265,8 @@ format_str(struct pkg *pkg, xstring *dest, const char *qstr, const void *data)
 					pkg_fprintf(dest->fp, "%Ff", data);
 				else if (qstr[0] == 't')
 					pkg_fprintf(dest->fp, "%Ft", data);
+				else if (qstr[0] == 'l')
+					pkg_fprintf(dest->fp, "%Fl", data);
 				break;
 			case 'O':
 				qstr++;

--- a/tests/frontend/create-parsebin.sh
+++ b/tests/frontend/create-parsebin.sh
@@ -25,7 +25,14 @@ genmanifest() {
         cp -a ${file1} ${TMPDIR}/${file1_base}
 
         PKG_FILES="${PKG_FILES}/${file1_base}: {perm: 0644}${NL}"
-        PKG_SHA256="${PKG_SHA256}${NL}    /${file1_base} = \"1\$${file1_sha}\";"
+	PKG_SHA256="${PKG_SHA256}
+    /${file1_base} {
+        sum = \"1\$${file1_sha}\";
+        uname = \"root\";
+        gname = \"wheel\";
+        perm = \"0644\";
+        fflags = 0;
+    }"
 
         PKG_FLATSIZE=$((${PKG_FLATSIZE}+${file1_size}))
         shift

--- a/tests/frontend/create-parsebin.sh
+++ b/tests/frontend/create-parsebin.sh
@@ -23,6 +23,7 @@ genmanifest() {
         local file1_size=$(wc -c < ${file1})
         local file1_sha=$(openssl dgst -sha256 -hex ${file1} | sed -nE 's/.*=[[:space:]]*([[:xdigit:]]+)/\1/p')
         cp -a ${file1} ${TMPDIR}/${file1_base}
+	file1_mtime=$(q_mtime ${TMPDIR}/${file1_base})
 
         PKG_FILES="${PKG_FILES}/${file1_base}: {perm: 0644}${NL}"
 	PKG_SHA256="${PKG_SHA256}
@@ -32,6 +33,7 @@ genmanifest() {
         gname = \"wheel\";
         perm = \"0644\";
         fflags = 0;
+        mtime = ${file1_mtime};
     }"
 
         PKG_FLATSIZE=$((${PKG_FLATSIZE}+${file1_size}))

--- a/tests/frontend/create.sh
+++ b/tests/frontend/create.sh
@@ -422,6 +422,7 @@ post-install:
 EOF
 	touch A
 	mkdir B
+	A_mtime=$(q_mtime A)
 
 	atf_check \
 		-o empty \
@@ -457,6 +458,7 @@ files {
         gname = "wheel";
         perm = "0000";
         fflags = 0;
+        mtime = ${A_mtime};
     }
 }
 directories {
@@ -482,6 +484,7 @@ EOF
 create_from_manifest_and_plist_body() {
 	genmanifest
 	touch testfile
+	testfile_mtime=$(q_mtime testfile)
 	genplist "testfile"
 	atf_check \
 		-o empty \
@@ -511,6 +514,7 @@ files {
         gname = "wheel";
         perm = "0000";
         fflags = 0;
+        mtime = ${testfile_mtime};
     }
 }
 EOF
@@ -532,6 +536,8 @@ files: {
 EOF
 	touch testfile
 	ln -s sym-target sym-file
+	test_file_mtime=$(q_mtime testfile)
+	sym_file_mtime=$(q_mtime sym-file)
 	atf_check \
 		-o empty \
 		-e empty \
@@ -560,6 +566,7 @@ files {
         gname = "wheel";
         perm = "0644";
         fflags = 0;
+        mtime = ${test_file_mtime};
     }
     /sym-file {
         sum = "1\$a83552cc4e1e92707178239c630b7f05d51124ff2afa7c5595ff4e76cb96cfa4";
@@ -568,6 +575,7 @@ files {
         perm = "0644";
         fflags = 0;
         symlink_target = "sym-target";
+        mtime = ${sym_file_mtime};
     }
 }
 EOF

--- a/tests/frontend/create.sh
+++ b/tests/frontend/create.sh
@@ -451,10 +451,21 @@ categories [
     "test",
 ]
 files {
-    /A = "1\$e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+    /A {
+        sum = "1\$e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+        uname = "root";
+        gname = "wheel";
+        perm = "0000";
+        fflags = 0;
+    }
 }
 directories {
-    /B = "y";
+    /B {
+        uname = "root";
+        gname = "wheel";
+        perm = "0000";
+        fflags = 0;
+    }
 }
 scripts {
     post-install = "# args: A B\necho A B";
@@ -494,7 +505,13 @@ categories [
     "test",
 ]
 files {
-    /testfile = "1\$e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+    /testfile {
+        sum = "1\$e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+        uname = "root";
+        gname = "wheel";
+        perm = "0000";
+        fflags = 0;
+    }
 }
 EOF
 
@@ -510,9 +527,11 @@ create_from_manifest_body() {
 	cat <<EOF >> +MANIFEST
 files: {
      /testfile: {perm: 0644}
+     /sym-file: {perm: 0644}
 }
 EOF
 	touch testfile
+	ln -s sym-target sym-file
 	atf_check \
 		-o empty \
 		-e empty \
@@ -529,13 +548,27 @@ www = "http://test";
 abi = "*";
 arch = "*";
 prefix = "/";
-flatsize = 0;
+flatsize = 10;
 desc = "Yet another test";
 categories [
     "test",
 ]
 files {
-    /testfile = "1\$e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+    /testfile {
+        sum = "1\$e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+        uname = "root";
+        gname = "wheel";
+        perm = "0644";
+        fflags = 0;
+    }
+    /sym-file {
+        sum = "1\$a83552cc4e1e92707178239c630b7f05d51124ff2afa7c5595ff4e76cb96cfa4";
+        uname = "root";
+        gname = "wheel";
+        perm = "0644";
+        fflags = 0;
+        symlink_target = "sym-target";
+    }
 }
 EOF
 

--- a/tests/frontend/query.sh
+++ b/tests/frontend/query.sh
@@ -31,12 +31,14 @@ files: {
 		"gname": "groot"
 		"perm": "777"
 		"fflags": "schg,nodump"
+		"mtime": 2342
 	}
 	"${TMPDIR}/bla": {
 		"sum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 		"uname": "utoor"
 		"gname": "gtoor"
 		"perm": "1765"
+		"mtime": 4223
 	}
 	"${TMPDIR}/sym": {
 		"sum": ""
@@ -44,6 +46,7 @@ files: {
 		"gname": "sym-gtoor"
 		"perm": "0644"
 		"symlink_target": "sym-target"
+		"mtime": 123432
 	}
 }
 EOF
@@ -164,12 +167,12 @@ EOF
 
 	if [ "${OS}" = "FreeBSD" ]; then
 	    atf_check \
-		-o match:"^${TMPDIR}/bla utoor gtoor 1765 - $" \
-		-o match:"^${TMPDIR}/plop uroot groot 777 schg,nodump $" \
-		-o match:"^${TMPDIR}/sym sym-root sym-gtoor 644 - sym-target$" \
+		-o match:"^${TMPDIR}/bla utoor gtoor 1765 - 4223 $" \
+		-o match:"^${TMPDIR}/plop uroot groot 777 schg,nodump 2342 $" \
+		-o match:"^${TMPDIR}/sym sym-root sym-gtoor 644 - 123432 sym-target$" \
 		-e empty \
 		-s exit:0 \
-		pkg query "%Fp %Fu %Fg %Fm %Ff %Ft" test
+		pkg query "%Fp %Fu %Fg %Fm %Ff %Fl %Ft" test
 
 	    atf_check \
 		-o inline:"${TMPDIR}/test-dir uroot groot 660 arch,nodump\n" \

--- a/tests/frontend/test_environment.sh.in
+++ b/tests/frontend/test_environment.sh.in
@@ -49,6 +49,14 @@ atf_require() {
 }
 
 
+q_mtime() {
+    if [ "${OS}" = "FreeBSD" ]; then
+	stat -f "%m" "$1"
+    else
+	stat -c "%Y" "$1"
+    fi
+}
+
 # helper function to obtain expected values for binaries used by the test cases
 
 bin_meta() {


### PR DESCRIPTION
and allow pkg-query to list those attributes using new format specifiers.

The idea is to embed the file and directory metadata (user, group, permissions, file flags) during package creation time in +MANIFEST. Later, this metadata will be written into the package database during install time. Support for querying metadata is provided in this patch.

This patch does not change the way which metadata is used during installation time. The metadata used during package installation still relies on the tar embedded metadata (which should be equal to the metadata in the +MANIFEST, but we don't verify this yet).

Partially addresses #1088 and allows to implement a metadata aware pkg-check later.