### PR TITLE
libpkg: Fill out package file uname and gname fields at extraction time

### DIFF
--- a/libpkg/pkg_add.c
+++ b/libpkg/pkg_add.c
@@ -463,6 +463,8 @@ do_extract_dir(struct pkg_add_context* context, struct archive *a __unused, stru
 	d->perm = aest->st_mode;
 	d->uid = get_uid_from_uname(archive_entry_uname(ae));
 	d->gid = get_gid_from_gname(archive_entry_gname(ae));
+	strlcpy(d->uname, archive_entry_uname(ae), sizeof(d->uname));
+	strlcpy(d->gname, archive_entry_gname(ae), sizeof(d->gname));
 	fill_timespec_buf(aest, d->time);
 	archive_entry_fflags(ae, &d->fflags, &clear);
 
@@ -537,8 +539,9 @@ retry:
 
 /* In case of a symlink create it directly with a random name */
 static int
-do_extract_symlink(struct pkg_add_context *context, struct archive *a __unused, struct archive_entry *ae,
-    const char *path, struct pkg *local __unused, tempdirs_t *tempdirs)
+do_extract_symlink(struct pkg_add_context *context, struct archive *a __unused,
+    struct archive_entry *ae, const char *path, struct pkg *local __unused,
+    tempdirs_t *tempdirs)
 {
 	struct pkg_file *f;
 	const struct stat *aest;
@@ -554,6 +557,8 @@ do_extract_symlink(struct pkg_add_context *context, struct archive *a __unused, 
 	archive_entry_fflags(ae, &f->fflags, &clear);
 	f->uid = get_uid_from_uname(archive_entry_uname(ae));
 	f->gid = get_gid_from_gname(archive_entry_gname(ae));
+	strlcpy(f->uname, archive_entry_uname(ae), sizeof(f->uname));
+	strlcpy(f->gname, archive_entry_gname(ae), sizeof(f->gname));
 	f->perm = aest->st_mode;
 	fill_timespec_buf(aest, f->time);
 	archive_entry_fflags(ae, &f->fflags, &clear);
@@ -800,6 +805,8 @@ do_extract_regfile(struct pkg_add_context *context, struct archive *a, struct ar
 	f->perm = aest->st_mode;
 	f->uid = get_uid_from_uname(archive_entry_uname(ae));
 	f->gid = get_gid_from_gname(archive_entry_gname(ae));
+	strlcpy(f->uname, archive_entry_uname(ae), sizeof(f->uname));
+	strlcpy(f->gname, archive_entry_gname(ae), sizeof(f->gname));
 	fill_timespec_buf(aest, f->time);
 	archive_entry_fflags(ae, &f->fflags, &clear);
 


### PR DESCRIPTION
Otherwise these are left unset, which can trip up other code, particularly a WIP lua function whose purpose is to duplicate a metalog entry for a packaged file in order to implement @sample.

This is required for #2553 to work properly.