### PR TITLE
fetch: display curl IP address we are fetching from in debug mode

### DIFF
--- a/libpkg/fetch_libcurl.c
+++ b/libpkg/fetch_libcurl.c
@@ -196,6 +196,12 @@ curl_do_fetch(struct curl_userdata *data, CURL *cl, struct curl_repodata *cr, CU
 			CURL *eh = msg->easy_handle;
 			long response_code = 0;
 			curl_easy_getinfo(eh, CURLINFO_RESPONSE_CODE, &response_code);
+
+			char *ip = NULL;
+			if (curl_easy_getinfo(eh, CURLINFO_PRIMARY_IP, &ip) == CURLE_OK && ip != NULL) {
+				pkg_dbg(PKG_DBG_FETCH, 1, "CURL> connected to IP %s", ip);
+		}
+
 			return (response_code);
 		}
 	}


### PR DESCRIPTION
```
# pkg -d update -r FreeBSD-base
Updating FreeBSD-base repository catalogue...
DBG(1)[89424]> PkgRepo: verifying update for FreeBSD-base
DBG(1)[89424]> Pkgrepo, begin update of '/var/db/pkg/repos/FreeBSD-base/db'
DBG(1)[89424]> (fetch) Request to fetch pkg+https://pkg.FreeBSD.org/FreeBSD:15:amd64/base_release_0/meta.conf
DBG(1)[89424]> (fetch) Fetch: fetcher used: pkg+https
DBG(1)[89424]> (fetch) CURL> connected to IP 2600:9000:20c3:9c00:14:fc66:e9c0:93a1
DBG(1)[89424]> (fetch) Request to fetch pkg+https://pkg.FreeBSD.org/FreeBSD:15:amd64/base_release_0/data.pkg
DBG(1)[89424]> (fetch) Fetch: fetcher used: pkg+https
DBG(1)[89424]> (fetch) CURL> connected to IP 2600:9000:20c3:9c00:14:fc66:e9c0:93a1
FreeBSD-base repository is up to date.
FreeBSD-base is up to date.
```

curl docs say we don't need to free `*ip` https://curl.se/libcurl/c/CURLINFO_PRIMARY_IP.html it will get done during curl_easy_cleanup on our behalf.