### PR TITLE
pkg_install: Add --register-only

### DIFF
--- a/docs/pkg-install.8
+++ b/docs/pkg-install.8
@@ -22,13 +22,13 @@
 .Nd install packages from remote repositories or local archives
 .Sh SYNOPSIS
 .Nm
-.Op Fl AfIMnFqRUy
+.Op Fl AfIMnFqRXUy
 .Op Fl r Ar reponame
 .Op Fl Cgix
 .Ar <pkg-origin|pkg-name|pkg-name-version> ...
 .Pp
 .Nm
-.Op Cm --{automatic,force,no-scripts,ignore-missing}
+.Op Cm --{automatic,force,no-scripts,ignore-missing,register-only}
 .Op Cm --{dry-run,fetch-only,quiet,recursive,no-repo-update,yes}
 .Op Cm --repository Ar reponame
 .Op Cm --{case-sensitive,glob,case-insensitive,regex}
@@ -133,6 +133,8 @@ If any installation scripts (pre-install or post-install) exist for a given
 package, do not execute them.
 When a package is updated, deinstallation
 scripts (pre-deinstall or post-deinstall) are not run either.
+.It Fl i , Cm --register-only
+Record the packages installation in the database but do not extract any files
 .It Fl i , Cm --case-insensitive
 Make the standard or the regular expression
 .Fl ( x )

--- a/libpkg/pkg.h.in
+++ b/libpkg/pkg.h.in
@@ -416,7 +416,8 @@ typedef enum _pkg_flags {
 	PKG_FLAG_USE_IPV6 = (1U << 12),
 	PKG_FLAG_UPGRADE_VULNERABLE = (1U << 13),
 	PKG_FLAG_NOEXEC = (1U << 14),
-	PKG_FLAG_KEEPFILES = (1U << 15)
+	PKG_FLAG_KEEPFILES = (1U << 15),
+	PKG_FLAG_REGISTER_ONLY = (1U << 16)
 } pkg_flags;
 
 typedef enum _pkg_stats_t {
@@ -1054,6 +1055,7 @@ int pkg_add(struct pkgdb *db, const char *path, unsigned flags,
 #define PKG_ADD_FORCE_MISSING		(1U << 5)
 #define PKG_ADD_SPLITTED_UPGRADE	(1U << 6)
 #define PKG_ADD_NOEXEC			(1U << 7)
+#define PKG_ADD_REGISTER_ONLY		(1U << 8)
 
 /**
  * Allocate a new pkg_jobs.

--- a/libpkg/pkg_add.c
+++ b/libpkg/pkg_add.c
@@ -1351,6 +1351,9 @@ pkg_add_common(struct pkgdb *db, const char *path, unsigned flags,
 	if (flags & PKG_ADD_AUTOMATIC)
 		pkg->automatic = true;
 
+	if (flags & PKG_ADD_REGISTER_ONLY)
+		extract = false;
+
 	/*
 	 * Additional checks for non-remote package
 	 */
@@ -1453,7 +1456,8 @@ pkg_add_common(struct pkgdb *db, const char *path, unsigned flags,
 	/* Update configuration file content with db with newer versions */
 	pkgdb_update_config_file_content(pkg, db->sqlite);
 
-	retcode = pkg_extract_finalize(pkg, &tempdirs);
+	if (extract)
+		retcode = pkg_extract_finalize(pkg, &tempdirs);
 
 	pkgdb_register_finale(db, retcode, NULL);
 	openxact = false;

--- a/libpkg/pkg_jobs.c
+++ b/libpkg/pkg_jobs.c
@@ -1989,6 +1989,8 @@ pkg_jobs_handle_install(struct pkg_solved *ps, struct pkg_jobs *j)
 		flags |= PKG_ADD_NOSCRIPT;
 	if ((j->flags & PKG_FLAG_FORCE_MISSING) == PKG_FLAG_FORCE_MISSING)
 		flags |= PKG_ADD_FORCE_MISSING;
+	if ((j->flags & PKG_FLAG_REGISTER_ONLY) == PKG_FLAG_REGISTER_ONLY)
+		flags |= PKG_ADD_REGISTER_ONLY;
 	if (ps->type != PKG_SOLVED_INSTALL) {
 		flags |= PKG_ADD_UPGRADE;
 		if (ps->type == PKG_SOLVED_UPGRADE_INSTALL)

--- a/src/install.c
+++ b/src/install.c
@@ -88,6 +88,7 @@ exec_install(int argc, char **argv)
 		{ "recursive",		no_argument,		NULL,   'R' },
 		{ "no-repo-update",	no_argument,		NULL,	'U' },
 		{ "regex",		no_argument,		NULL,	'x' },
+		{ "register-only",	no_argument,		NULL,	'X' },
 		{ "yes",		no_argument,		NULL,	'y' },
 		{ NULL,			0,			NULL,	0   },
 	};
@@ -149,6 +150,9 @@ exec_install(int argc, char **argv)
 			break;
 		case 'x':
 			match = MATCH_REGEX;
+			break;
+		case 'X':
+			f |= PKG_FLAG_REGISTER_ONLY | PKG_FLAG_NOSCRIPT;
 			break;
 		case 'y':
 			yes = true;


### PR DESCRIPTION
This just register the package installaltion (and config file) in the database but do not extract any files.
This will allow us to pkgbasify a system more easily.

Sponsored by:	Beckhoff Automation GmbH & Co. KG