### PR TITLE
fetch: Fix pkg_fetch_file_to_fd cleanup

### DIFF
--- a/libpkg/fetch.c
+++ b/libpkg/fetch.c
@@ -301,8 +301,20 @@ cleanup:
 		unsetenv(vec_pop(&envtounset));
 	vec_free(&envtounset);
 
-	if (repo->fetcher != NULL && repo->fetcher->close != NULL)
-		repo->fetcher->close(repo);
+	if (repo->fetcher != NULL) {
+		if (repo->fetcher->close != NULL) {
+			repo->fetcher->close(repo);
+		}
+
+		if (repo->fetcher->cleanup != NULL) {
+			repo->fetcher->cleanup(repo);
+		}
+	}
+
+	if (fakerepo)
+	{
+		free(fakerepo->url);
+	}
 	free(fakerepo);
 
 	if (retcode == EPKG_OK) {

--- a/libpkg/fetch_libcurl.c
+++ b/libpkg/fetch_libcurl.c
@@ -578,5 +578,6 @@ curl_cleanup(struct pkg_repo *repo)
 	curl_multi_cleanup(cr->cm);
 	if (cr->url != NULL)
 		curl_url_cleanup(cr->url);
+	free(repo->fetch_priv);
 	repo->fetch_priv = NULL;
 }


### PR DESCRIPTION
There is memory blocks which are not freed when leaving function pkg_fetch_file_to_fd

This commit makes sure that cleanup is called if it's available for chosen scheme and id repo is not provided and created in function then memory is freed as expected at the cleanup

This was found using LLVM version 21 `lsan` when debugging OSVF audit code