### PR TITLE
pkg_create: use -t specified timestamp for MANIFEST file timestamps

### DIFF
--- a/libpkg/pkg_create.c
+++ b/libpkg/pkg_create.c
@@ -137,8 +137,13 @@ pkg_create_from_dir(struct pkg *pkg, const char *root,
 				file->symlink_target[linklen] = '\0';
 			}
 
-			file->time[0] = st.st_atim;
-			file->time[1] = st.st_mtim;
+			if (pc->timestamp > (time_t)-1) {
+				file->time[0].tv_sec = pc->timestamp;
+				file->time[1].tv_sec = pc->timestamp;
+			} else {
+				file->time[0] = st.st_atim;
+				file->time[1] = st.st_mtim;
+			}
 		}
 
 		counter_count();


### PR DESCRIPTION
This is necessary to provide pkg archive reproducibility after https://github.com/freebsd/pkg/commit/08bf9b3d79b127b127ecf597286ba14c016af8c4