### PR TITLE
pkg.conf(5): updates for FreeBSD 15

### DIFF
--- a/docs/pkg.conf.5
+++ b/docs/pkg.conf.5
@@ -682,7 +682,7 @@ example: {
     url: http://pkgrepo.example.com/${ABI}
 }
 EOF
-# cat > /usr/local/etc/pkg/repos/FreeBSD.conf <<EOF
+# cat >> /usr/local/etc/pkg/repos/FreeBSD.conf <<EOF
 FreeBSD-ports: {
     enabled: NO
 }


### PR DESCRIPTION
The name of the FreeBSD repo is no longer ambiguous, it is now FreeBSD-ports.

FreeBSD-kmods is now FreeBSD-ports-kmods.

https://lists.freebsd.org/archives/freebsd-current/2025-August/008463.html

https://github.com/freebsd/freebsd-src/commit/c83705a5756e