### PR TITLE
pkg_autoremove: Fix order

### DIFF
--- a/libpkg/pkg_jobs.c
+++ b/libpkg/pkg_jobs.c
@@ -524,9 +524,6 @@ pkg_jobs_process_delete_request(struct pkg_jobs *j)
 	pkgs_t to_process = vec_init();
 	pkghash_it it;
 
-	if (force)
-		return (EPKG_OK);
-
 	/*
 	 * Need to add also all reverse deps here
 	 */


### PR DESCRIPTION
If package A depends on package B (on a binary or script for example), when autoremove is called currently the order is (likely) by alphabetic. This cause problems as if package A is removed first and package B needs a script from package A it will fails to clean up correctly the system. Since autoremove is considered as force internally simply extend the check so we will process the removals in the correct order.

Sponsored by:	Beckhoff Automation GmbH & Co. KG