### PR TITLE
pkg: avoid a warning around enum pkg_shlib_flags

### DIFF
--- a/libpkg/pkg_abi.c
+++ b/libpkg/pkg_abi.c
@@ -591,7 +591,7 @@ pkg_analyse_files(struct pkgdb *db __unused, struct pkg *pkg, const char *stage)
 			case PKG_SHLIB_FLAGS_COMPAT_LINUX:
 				paths = pkg_config_get("SHLIB_PROVIDE_PATHS_COMPAT_LINUX");
 				break;
-			case (PKG_SHLIB_FLAGS_COMPAT_32 | PKG_SHLIB_FLAGS_COMPAT_LINUX):
+			case PKG_SHLIB_FLAGS_COMPAT_LINUX_32:
 				paths = pkg_config_get("SHLIB_PROVIDE_PATHS_COMPAT_LINUX_32");
 				break;
 			default:

--- a/libpkg/private/pkg.h
+++ b/libpkg/private/pkg.h
@@ -858,6 +858,7 @@ enum pkg_shlib_flags {
 	PKG_SHLIB_FLAGS_NONE = 0,
 	PKG_SHLIB_FLAGS_COMPAT_32 = 1 << 0,
 	PKG_SHLIB_FLAGS_COMPAT_LINUX = 1 << 1,
+	PKG_SHLIB_FLAGS_COMPAT_LINUX_32 = (1 << 0) | (1 << 1),
 };
 /* Determine shlib flags by comparing the shlib abi with ctx.abi */
 enum pkg_shlib_flags pkg_shlib_flags_from_abi(const struct pkg_abi *shlib_abi);


### PR DESCRIPTION
I am currently looking into importing pkg into FreeBSD's base system. Compilation warnings during that build process are strict and often considered as errors.

These changes add a value to `enum pkg_shlib_flags` for the combined flags of Linux and 32-bit compatibility, as used in pkg_abi.c.

Sponsored by:	The FreeBSD Foundation