### PR TITLE
libpkg: link with "libtool --mode=link $(CC)" on macOS

### DIFF
--- a/libpkg/Makefile.autosetup
+++ b/libpkg/Makefile.autosetup
@@ -183,7 +183,7 @@ lib$(LIB)$(LIBSOEXT): $(STATIC_LIBS)
 
 @if pkgos_darwin
 lib$(LIB)_flat.a: $(STATIC_LIBS)
-	libtool -static -o lib$(LIB)_flat.a $(STATIC_LIBS)
+	libtool --mode=link --tag=CC $(CC) -static -o lib$(LIB)_flat.a $(STATIC_LIBS)
 @else
 lib$(LIB)_flat.a: ${STATIC_LIBS} mergelib_script
 	$(AR) -M < mergelib_script


### PR DESCRIPTION
This avoids the following error on macOS, with libtool from pkgsrc:
```
libtool: Missing --mode=XXX
```

Tested on Darwin/amd64.