### PR TITLE
libpkg: fix --register-only with empty packages

### DIFF
--- a/libpkg/pkg_add.c
+++ b/libpkg/pkg_add.c
@@ -1664,7 +1664,7 @@ pkg_add_common(struct pkgdb *db, const char *path, unsigned flags,
 			pkg_delete_dirs(db, pkg, NULL);
 			goto cleanup;
 		}
-	} else if (flags & PKG_ADD_REGISTER_ONLY) {
+	} else if (flags & PKG_ADD_REGISTER_ONLY && nfiles > 0) {
 		/* Need to populate config file contents so they can be stored in
 		   the database */
 		retcode = populate_config_file_contents(a, ae, pkg);

--- a/tests/frontend/install.sh
+++ b/tests/frontend/install.sh
@@ -9,6 +9,7 @@ tests_init \
 	post_script_ignored \
 	install_missing_dep \
 	install_register_only \
+	install_register_only_empty \
 	install_autoremove \
 	install_autoremove_flag \
 	install_suggest_clear_automatic \
@@ -265,6 +266,46 @@ EOF
 		-e ignore \
 		-s exit:1 \
 		test -d dir
+}
+
+install_register_only_empty_body()
+{
+	test_setup
+
+	atf_check -s exit:0 sh ${RESOURCEDIR}/test_subr.sh new_pkg "test" "test" "1" "${TMPDIR}"
+
+	mkdir repoconf
+	cat << EOF > repoconf/repo.conf
+repo: {
+	url: file:///$TMPDIR/repo,
+	enabled: true
+}
+EOF
+
+	mkdir repo
+
+	atf_check \
+		-o empty \
+		-e empty \
+		-s exit:0 \
+		pkg create -M test.ucl -o repo
+
+	atf_check \
+		-o ignore \
+		-e empty \
+		-s exit:0 \
+		pkg repo repo
+
+	export REPOS_DIR="${TMPDIR}/repoconf"
+	atf_check \
+		-o ignore \
+		-s exit:0 \
+		pkg install -r repo -y --register-only test
+
+	atf_check \
+		-o inline:"0\n" \
+		-e empty \
+		pkg query "%a" test
 }
 
 install_autoremove_body() {


### PR DESCRIPTION
Currently we end up calling archive_read_next_header() in populate_config_file_contents() even when there are no files in the package. This results in the following libarchive error:

pkg: archive_read_next_header(): INTERNAL ERROR: Function 'archive_read_next_header' invoked with archive structure in state 'eof', should be in state 'header/data'

This commit fixes the error and adds a test to prevent regression.

Sponsored by:	The FreeBSD Foundation