### PR TITLE
Ease downstream OS support

### DIFF
--- a/libpkg/pkg_abi.c
+++ b/libpkg/pkg_abi.c
@@ -81,21 +81,19 @@ static const struct {
 /* This table does not include PKG_ARCH_AMD64 as the string translation of
    that arch is os-dependent. */
 static const struct {
-	enum pkg_arch arch;
 	const char *string;
 } arch_string_table[] = {
-	{ PKG_ARCH_UNKNOWN, "unknown"},
-	{ PKG_ARCH_I386, "i386"},
-	{ PKG_ARCH_ARMV6, "armv6"},
-	{ PKG_ARCH_ARMV7, "armv7"},
-	{ PKG_ARCH_AARCH64, "aarch64"},
-	{ PKG_ARCH_POWERPC, "powerpc"},
-	{ PKG_ARCH_POWERPC64, "powerpc64"},
-	{ PKG_ARCH_POWERPC64LE, "powerpc64le"},
-	{ PKG_ARCH_RISCV32, "riscv32"},
-	{ PKG_ARCH_RISCV64, "riscv64"},
-	{ PKG_ARCH_ANY,	"*"},
-	{ -1, NULL },
+	[PKG_ARCH_UNKNOWN] =		{"unknown"},
+	[PKG_ARCH_I386] =		{"i386"},
+	[PKG_ARCH_ARMV6] =		{"armv6"},
+	[PKG_ARCH_ARMV7] =		{"armv7"},
+	[PKG_ARCH_AARCH64] =		{"aarch64"},
+	[PKG_ARCH_POWERPC] =		{"powerpc"},
+	[PKG_ARCH_POWERPC64] =		{"powerpc64"},
+	[PKG_ARCH_POWERPC64LE] =	{"powerpc64le"},
+	[PKG_ARCH_RISCV32] =		{"riscv32"},
+	[PKG_ARCH_RISCV64] =		{"riscv64"},
+	[PKG_ARCH_ANY] =		{"*"},
 };
 
 const char *
@@ -151,13 +149,8 @@ pkg_arch_to_string(enum pkg_os os, enum pkg_arch arch)
 		}
 	}
 
-	for (size_t i = 0; arch_string_table[i].string != NULL; i++) {
-		if (arch == arch_string_table[i].arch) {
-			return arch_string_table[i].string;
-		}
-	}
-
-	assert(0);
+	assert(arch >= PKG_ARCH_UNKNOWN && arch <= PKG_ARCH_ANY);
+	return (arch_string_table[arch].string);
 }
 
 static enum pkg_arch
@@ -177,9 +170,10 @@ pkg_arch_from_string(enum pkg_os os, const char *string)
 		}
 	}
 
-	for (size_t i = 0; arch_string_table[i].string != NULL; i++) {
-		if (STREQ(string, arch_string_table[i].string)) {
-			return arch_string_table[i].arch;
+	for (int i = 0; i < nitems(arch_string_table); i++) {
+		if (arch_string_table[i].string != NULL &&
+		    STREQ(string, arch_string_table[i].string)) {
+			return ((enum pkg_arch)i);
 		}
 	}
 

--- a/libpkg/pkg_abi.c
+++ b/libpkg/pkg_abi.c
@@ -27,13 +27,15 @@
 
 #define _PATH_UNAME "/usr/bin/uname"
 
+#ifndef nitems
+#define	nitems(x)	(sizeof((x)) / sizeof((x)[0]))
+#endif
+
 /* All possibilities on FreeBSD as of 5/26/2014 */
-struct arch_trans {
+static const struct {
 	const char *elftype;
 	const char *archid;
-};
-
-static const struct arch_trans machine_arch_translation[] = {
+} machine_arch_translation[] = {
 	{ "x86:32", "i386" },
 	{ "x86:64", "amd64" },
 
@@ -60,8 +62,6 @@ static const struct arch_trans machine_arch_translation[] = {
 	{ "riscv:32:sf", "riscv32sf" },
 	{ "riscv:64:hf", "riscv64" },
 	{ "riscv:64:sf", "riscv64sf" },
-
-	{ NULL, NULL }
 };
 
 static const struct {
@@ -434,7 +434,6 @@ int
 pkg_arch_to_legacy(const char *arch, char *dest, size_t sz)
 {
 	int i = 0;
-	const struct arch_trans *arch_trans;
 
 	memset(dest, '\0', sz);
 	/* Lower case the OS */
@@ -457,10 +456,9 @@ pkg_arch_to_legacy(const char *arch, char *dest, size_t sz)
 
 	dest[i++] = ':';
 
-	for (arch_trans = machine_arch_translation; arch_trans->elftype != NULL;
-	    arch_trans++) {
-		if (STREQ(arch + i, arch_trans->archid)) {
-			strlcpy(dest + i, arch_trans->elftype,
+	for (int j = 0; j < nitems(machine_arch_translation); j++) {
+		if (STREQ(arch + i, machine_arch_translation[j].archid)) {
+			strlcpy(dest + i, machine_arch_translation[j].elftype,
 			    sz - (arch + i - dest));
 			return (0);
 		}

--- a/libpkg/pkg_abi.c
+++ b/libpkg/pkg_abi.c
@@ -33,22 +33,36 @@ struct arch_trans {
 	const char *archid;
 };
 
-static const struct arch_trans machine_arch_translation[] = { { "x86:32", "i386" },
-	{ "x86:64", "amd64" }, { "powerpc:32:eb", "powerpc" },
-	{ "powerpc:64:eb", "powerpc64" }, { "powerpc:64:el", "powerpc64le" },
-	{ "sparc64:64", "sparc64" }, { "ia64:64", "ia64" },
-	/* All the ARM stuff */
-	{ "armv6:32:el:eabi:hardfp", "armv6" },
-	{ "armv7:32:el:eabi:hardfp", "armv7" }, { "aarch64:64", "aarch64" },
-	/* And now MIPS */
-	{ "mips:32:el:o32", "mipsel" }, { "mips:32:el:n32", "mipsn32el" },
-	{ "mips:32:eb:o32", "mips" }, { "mips:32:eb:n32", "mipsn32" },
-	{ "mips:64:el:n64", "mips64el" }, { "mips:64:eb:n64", "mips64" },
-	/* And RISC-V */
-	{ "riscv:32:hf", "riscv32" }, { "riscv:32:sf", "riscv32sf" },
-	{ "riscv:64:hf", "riscv64" }, { "riscv:64:sf", "riscv64sf" },
+static const struct arch_trans machine_arch_translation[] = {
+	{ "x86:32", "i386" },
+	{ "x86:64", "amd64" },
 
-	{ NULL, NULL } };
+	{ "powerpc:32:eb", "powerpc" },
+	{ "powerpc:64:eb", "powerpc64" },
+	{ "powerpc:64:el", "powerpc64le" },
+
+	{ "sparc64:64", "sparc64" },
+
+	{ "ia64:64", "ia64" },
+
+	{ "armv6:32:el:eabi:hardfp", "armv6" },
+	{ "armv7:32:el:eabi:hardfp", "armv7" },
+	{ "aarch64:64", "aarch64" },
+
+	{ "mips:32:el:o32", "mipsel" },
+	{ "mips:32:el:n32", "mipsn32el" },
+	{ "mips:32:eb:o32", "mips" },
+	{ "mips:32:eb:n32", "mipsn32" },
+	{ "mips:64:el:n64", "mips64el" },
+	{ "mips:64:eb:n64", "mips64" },
+
+	{ "riscv:32:hf", "riscv32" },
+	{ "riscv:32:sf", "riscv32sf" },
+	{ "riscv:64:hf", "riscv64" },
+	{ "riscv:64:sf", "riscv64sf" },
+
+	{ NULL, NULL }
+};
 
 static const struct {
 	enum pkg_os os;

--- a/libpkg/pkg_abi.c
+++ b/libpkg/pkg_abi.c
@@ -65,17 +65,15 @@ static const struct {
 };
 
 static const struct {
-	enum pkg_os os;
 	const char *string;
 } os_string_table[] = {
-	{ PKG_OS_UNKNOWN, "Unknown" },
-	{ PKG_OS_FREEBSD, "FreeBSD" },
-	{ PKG_OS_NETBSD, "NetBSD" },
-	{ PKG_OS_DRAGONFLY, "dragonfly" },
-	{ PKG_OS_LINUX, "Linux" },
-	{ PKG_OS_DARWIN, "Darwin" },
-	{ PKG_OS_ANY, "*" },
-	{ -1, NULL },
+	[PKG_OS_UNKNOWN] =	{ "Unknown" },
+	[PKG_OS_FREEBSD] =	{ "FreeBSD" },
+	[PKG_OS_NETBSD] =	{ "NetBSD" },
+	[PKG_OS_DRAGONFLY] =	{ "dragonfly" },
+	[PKG_OS_LINUX] =	{ "Linux" },
+	[PKG_OS_DARWIN] =	{ "Darwin" },
+	[PKG_OS_ANY] =		{ "*" },
 };
 
 /* This table does not include PKG_ARCH_AMD64 as the string translation of
@@ -99,20 +97,17 @@ static const struct {
 const char *
 pkg_os_to_string(enum pkg_os os)
 {
-	for (size_t i = 0; os_string_table[i].string != NULL; i++) {
-		if (os == os_string_table[i].os) {
-			return os_string_table[i].string;
-		}
-	}
-	assert(0);
+	assert(os >= PKG_OS_UNKNOWN && os <= PKG_OS_ANY);
+
+	return (os_string_table[os].string);
 }
 
 static enum pkg_os
 pkg_os_from_string(const char *string)
 {
-	for (size_t i = 0; os_string_table[i].string != NULL; i++) {
+	for (int i = 0; i < nitems(os_string_table); i++) {
 		if (STREQ(string, os_string_table[i].string)) {
-			return os_string_table[i].os;
+			return ((enum pkg_os)i);
 		}
 	}
 	return (PKG_OS_UNKNOWN);

--- a/libpkg/pkg_abi.c
+++ b/libpkg/pkg_abi.c
@@ -66,13 +66,15 @@ static const struct {
 
 static const struct {
 	const char *string;
-} os_string_table[] = {
+	const char *amd64_string;
+	bool major_version_only;
+} os_table[] = {
 	[PKG_OS_UNKNOWN] =	{ "Unknown" },
-	[PKG_OS_FREEBSD] =	{ "FreeBSD" },
-	[PKG_OS_NETBSD] =	{ "NetBSD" },
-	[PKG_OS_DRAGONFLY] =	{ "dragonfly" },
-	[PKG_OS_LINUX] =	{ "Linux" },
-	[PKG_OS_DARWIN] =	{ "Darwin" },
+	[PKG_OS_FREEBSD] =	{ "FreeBSD",	"amd64",	true },
+	[PKG_OS_NETBSD] =	{ "NetBSD",	"x86_64",	true },
+	[PKG_OS_DRAGONFLY] =	{ "dragonfly",	"x86:64",	false },
+	[PKG_OS_LINUX] =	{ "Linux",	"x86_64",	false },
+	[PKG_OS_DARWIN] =	{ "Darwin",	"x86_64",	true },
 	[PKG_OS_ANY] =		{ "*" },
 };
 
@@ -99,48 +101,26 @@ pkg_os_to_string(enum pkg_os os)
 {
 	assert(os >= PKG_OS_UNKNOWN && os <= PKG_OS_ANY);
 
-	return (os_string_table[os].string);
+	return (os_table[os].string);
 }
 
 static enum pkg_os
 pkg_os_from_string(const char *string)
 {
-	for (int i = 0; i < nitems(os_string_table); i++) {
-		if (STREQ(string, os_string_table[i].string)) {
+	for (int i = 0; i < nitems(os_table); i++) {
+		if (STREQ(string, os_table[i].string)) {
 			return ((enum pkg_os)i);
 		}
 	}
 	return (PKG_OS_UNKNOWN);
 }
 
-/* Returns true if the OS uses "amd64" rather than "x86_64" */
-static bool
-pkg_os_uses_amd64_name(enum pkg_os os)
-{
-	switch (os) {
-	case PKG_OS_FREEBSD:
-		return (true);
-	case PKG_OS_DARWIN:
-	case PKG_OS_NETBSD:
-	case PKG_OS_LINUX:
-		return (false);
-	case PKG_OS_DRAGONFLY:
-	case PKG_OS_UNKNOWN:
-	default:
-		assert(0);
-	}
-}
-
 const char *
 pkg_arch_to_string(enum pkg_os os, enum pkg_arch arch)
 {
 	if (arch == PKG_ARCH_AMD64) {
-		if (os == PKG_OS_DRAGONFLY) {
-			return ("x86:64");
-		} else if (pkg_os_uses_amd64_name(os)) {
-			return ("amd64");
-		} else {
-			return ("x86_64");
+		if (os_table[os].amd64_string != NULL) {
+			return (os_table[os].amd64_string);
 		}
 	}
 
@@ -151,16 +131,8 @@ pkg_arch_to_string(enum pkg_os os, enum pkg_arch arch)
 static enum pkg_arch
 pkg_arch_from_string(enum pkg_os os, const char *string)
 {
-	if (os == PKG_OS_DRAGONFLY) {
-		if (STREQ(string, "x86:64")) {
-			return (PKG_ARCH_AMD64);
-		}
-	} else if (pkg_os_uses_amd64_name(os)) {
-		if (STREQ(string, "amd64")) {
-			return (PKG_ARCH_AMD64);
-		}
-	} else {
-		if (STREQ(string, "x86_64")) {
+	if (os_table[os].amd64_string != NULL) {
+		if (STREQ(string, os_table[os].amd64_string)) {
 			return (PKG_ARCH_AMD64);
 		}
 	}
@@ -178,18 +150,9 @@ pkg_arch_from_string(enum pkg_os os, const char *string)
 bool
 pkg_abi_string_only_major_version(enum pkg_os os)
 {
-	switch (os) {
-	case PKG_OS_FREEBSD:
-	case PKG_OS_NETBSD:
-	case PKG_OS_DARWIN:
-		return (true);
-	case PKG_OS_DRAGONFLY:
-	case PKG_OS_LINUX:
-		return (false);
-	case PKG_OS_UNKNOWN:
-	default:
-		assert (0);
-	}
+	assert(os > PKG_OS_UNKNOWN && os < PKG_OS_ANY);
+
+	return (os_table[os].major_version_only);
 }
 
 char *


### PR DESCRIPTION
Limit the number of places pkg_abi needs to be modified to add a new OS by refactoring. Along the way, take advantage of of the various arrays being static and simplify their initialization and use.

This is motivated by 6c740ac388db9c0ea53688e2606ffff27bab2a03 breaking the ability to download CheriBSD packages.