### PR TITLE
CI: fix sanitizer issues

### DIFF
--- a/external/libucl/src/ucl_util.c
+++ b/external/libucl/src/ucl_util.c
@@ -185,14 +185,15 @@ char *basename(char *path)
 #define ucl_realpath realpath
 #endif
 
-typedef void (*ucl_object_dtor)(ucl_object_t *obj);
-static void ucl_object_free_internal(ucl_object_t *obj, bool allow_rec,
-									 ucl_object_dtor dtor);
-static void ucl_object_dtor_unref(ucl_object_t *obj);
+typedef void (*ucl_object_dtor)(void *ptr);
+static void ucl_object_free_internal(ucl_object_t *obj, bool allow_rec, ucl_object_dtor dtor);
+static void ucl_object_dtor_unref(void *obj);
 
 static void
-ucl_object_dtor_free(ucl_object_t *obj)
+ucl_object_dtor_free(void *ptr)
 {
+	ucl_object_t *obj = ptr;
+
 	if (obj->trash_stack[UCL_TRASH_KEY] != NULL) {
 		UCL_FREE(obj->hh.keylen, obj->trash_stack[UCL_TRASH_KEY]);
 	}
@@ -235,8 +236,9 @@ ucl_object_dtor_unref_single(ucl_object_t *obj)
 }
 
 static void
-ucl_object_dtor_unref(ucl_object_t *obj)
+ucl_object_dtor_unref(void *ptr)
 {
+	ucl_object_t *obj = ptr;
 	if (obj->ref == 0) {
 		ucl_object_dtor_free(obj);
 	}

--- a/src/upgrade.c
+++ b/src/upgrade.c
@@ -321,6 +321,7 @@ exec_upgrade(int argc, char **argv)
 			break;
 		default:
 			usage_upgrade();
+			vec_free(&reponames);
 			return (EXIT_FAILURE);
 			/* NOTREACHED */
 		}
@@ -344,23 +345,30 @@ exec_upgrade(int argc, char **argv)
 
 	if (retcode == EPKG_ENOACCESS) {
 		warnx("Insufficient privilege to upgrade packages");
+		vec_free(&reponames);
 		return (EXIT_FAILURE);
-	} else if (retcode != EPKG_OK)
+	} else if (retcode != EPKG_OK) {
+		vec_free(&reponames);
 		return (EXIT_FAILURE);
-	else
+	} else
 		retcode = EXIT_FAILURE;
 
 	/* first update the remote repositories if needed */
 	if (auto_update &&
-	    (updcode = pkgcli_update(false, false, &reponames)) != EPKG_OK)
+	    (updcode = pkgcli_update(false, false, &reponames)) != EPKG_OK) {
+		vec_free(&reponames);
 		return (updcode);
+	}
 
-	if (pkgdb_open_all2(&db, PKGDB_REMOTE, &reponames) != EPKG_OK)
+	if (pkgdb_open_all2(&db, PKGDB_REMOTE, &reponames) != EPKG_OK) {
+		vec_free(&reponames);
 		return (EXIT_FAILURE);
+	}
 
 	if (pkgdb_obtain_lock(db, lock_type) != EPKG_OK) {
 		pkgdb_close(db);
 		warnx("Cannot get an advisory lock on a database, it is locked by another process");
+		vec_free(&reponames);
 		return (EXIT_FAILURE);
 	}
 
@@ -443,6 +451,8 @@ cleanup:
 
 	if (newpkgversion && (!rc || !done))
 		newpkgversion = false;
+
+	vec_free(&reponames);
 
 	return (retcode);
 }


### PR DESCRIPTION
~gmake destroys the top level Makefile by doing a bad substitution using the .in: rule in mk/commmon.mk. This change allows everything to build (sanitizer runs are still broken due to memory leaks).~
Fix a couple remaining sanitizer issues.