### PR TITLE
Extend the boolean syntax

### DIFF
--- a/external/libucl/src/ucl_internal.h
+++ b/external/libucl/src/ucl_internal.h
@@ -437,6 +437,26 @@ ucl_maybe_parse_boolean(ucl_object_t *obj, const unsigned char *start, size_t le
 			val = true;
 		}
 	}
+	else if (len == 1) {
+		switch (p[0]) {
+		case '0':
+		case 'F':
+		case 'f':
+		case 'N':
+		case 'n':
+			ret = true;
+			val = false;
+			break;
+		case '1':
+		case 'T':
+		case 't':
+		case 'Y':
+		case 'y':
+			ret = true;
+			val = true;
+			break;
+		}
+	}
 
 	if (ret && obj != NULL) {
 		obj->type = UCL_BOOLEAN;

--- a/libpkg/pkg_config.c
+++ b/libpkg/pkg_config.c
@@ -1455,12 +1455,7 @@ pkg_ini(const char *path, const char *reposdir, pkg_init_flags flags)
 			break;
 		case UCL_BOOLEAN:
 			o = ucl_object_fromstring_common(val, 0,
-			    UCL_STRING_PARSE_BOOLEAN|UCL_STRING_PARSE_INT);
-			if (o->type == UCL_INT) {
-				bool bval = ucl_object_toint(o) != 0;
-				ucl_object_unref(o);
-				o = ucl_object_frombool(bval);
-			}
+			    UCL_STRING_PARSE_BOOLEAN);
 			if (o->type != UCL_BOOLEAN) {
 				pkg_emit_error("Invalid type for environment "
 				    "variable %s, got %s, while expecting a boolean",


### PR DESCRIPTION
* Extend libucl's boolean parser to also accept “y” / “n”, “t” / “f”, and “1” / “0” as valid boolean values. This has also been submitted to libucl as vstakhov/libucl/pull/379.
* Drop our own integer to boolean conversion now that libucl accepts “1” / “0”. Note that this means that e.g. “2” or “-1” would previously have been interpreted as boolean true but now results in an error message; this is considered a feature.