### PR TITLE
tests: Fix after fflags change

### DIFF
--- a/tests/frontend/create-parsebin.sh
+++ b/tests/frontend/create-parsebin.sh
@@ -32,7 +32,6 @@ genmanifest() {
         uname = \"root\";
         gname = \"wheel\";
         perm = \"0644\";
-        fflags = 0;
         mtime = ${file1_mtime};
     }"
 

--- a/tests/frontend/create.sh
+++ b/tests/frontend/create.sh
@@ -10,7 +10,8 @@ tests_init \
 	create_from_plist_gather_mode \
 	create_from_plist_set_mode \
 	create_from_plist_mini \
-	create_from_plist_fflags create_from_plist_bad_fflags \
+	create_from_plist_fflags \
+	create_from_plist_bad_fflags \
 	create_from_plist_with_keyword_arguments \
 	create_from_plist_missing_file \
 	create_from_manifest_and_plist \
@@ -457,7 +458,6 @@ files {
         uname = "root";
         gname = "wheel";
         perm = "0644";
-        fflags = 0;
         mtime = ${A_mtime};
     }
 }
@@ -466,7 +466,6 @@ directories {
         uname = "root";
         gname = "wheel";
         perm = "0755";
-        fflags = 0;
     }
 }
 scripts {
@@ -513,7 +512,6 @@ files {
         uname = "root";
         gname = "wheel";
         perm = "0644";
-        fflags = 0;
         mtime = ${testfile_mtime};
     }
 }
@@ -566,7 +564,6 @@ files {
         uname = "root";
         gname = "wheel";
         perm = "0644";
-        fflags = 0;
         symlink_target = "sym-target";
         mtime = ${sym_file_mtime};
     }
@@ -575,7 +572,6 @@ files {
         uname = "root";
         gname = "wheel";
         perm = "0644";
-        fflags = 0;
         mtime = ${test_file_mtime};
     }
 }


### PR DESCRIPTION
An fflags line is now only emitted if non-zero.  Update the expected outputs of several tests which were broken by this change.

Fixes:		c11b97870a4e ("fflags: emit in string value")