### PR TITLE
Fix duplicate words in comments and docs

### DIFF
--- a/docs/pkg.conf.5
+++ b/docs/pkg.conf.5
@@ -726,7 +726,7 @@ Expands to the ABI string
 .Ql FreeBSD:14:amd64
 .Pc .
 .It Va OSNAME
-Expands to the the name of the target operating system.
+Expands to the name of the target operating system.
 .It Va RELEASE
 Expands to the full version of the target operating system.
 .It Va VERSION_MAJOR

--- a/libpkg/merge3.c
+++ b/libpkg/merge3.c
@@ -105,7 +105,7 @@ static int sameEdit(
 }
 
 /*
-** Copy N lines of text from from into to.
+** Copy N lines of text from into to.
 ** The return value is the number of characters copied, normally including
 ** the \n and should be used to advance the 'from' pointer.
 **

--- a/libpkg/pkg_version.c
+++ b/libpkg/pkg_version.c
@@ -57,7 +57,7 @@ split_version(const char *pkgname, const char **endname,
 		return (NULL);
 	}
 
-	/* Look for the last '-' the the pkgname */
+	/* Look for the last '-' in the pkgname */
 	ch = strrchr(pkgname, '-');
 	/* Cheat if we are just passed a version, not a valid package name */
 	versionstr = ch ? ch + 1 : pkgname;

--- a/libpkg/private/pkg_abi.h
+++ b/libpkg/private/pkg_abi.h
@@ -102,7 +102,7 @@ bool pkg_abi_from_string(struct pkg_abi *abi, const char *string);
 
 /*
  * Return true if the canonical ABI string format for the given OS uses only
- * the major version rather than both the the major and minor version.
+ * the major version rather than both the major and minor version.
  */
 bool pkg_abi_string_only_major_version(enum pkg_os os);
 


### PR DESCRIPTION
Fix a handful of double-word typos ("the the", "from from") in comments and a manual page that were missed in previous typo-fixing passes.

- libpkg/pkg_version.c: "the the pkgname" → "in the pkgname"
- libpkg/private/pkg_abi.h: "both the the major" → "both the major"
- docs/pkg.conf.5: "to the the name" → "to the name"
- libpkg/merge3.c: "from from into" → "from into"