### PR TITLE
make minor & major version upgrades easy

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,5 @@
 Changes from 2.6.99.6 to 2.7.99.1
+- config: allow VERSION_MAJOR and VERSION_MINOR to be overridden via -o
 - rcscript: rewrite entirely to be safer
 - triggers: make the per-package trigger per file instead of per directory
 - delete: add -G/--exclude-glob

--- a/docs/pkg-upgrade.8
+++ b/docs/pkg-upgrade.8
@@ -216,6 +216,19 @@ which prevents scripts from both running and being recorded,
 .Cm --script-no-exec
 only suppresses execution.
 .El
+.Sh EXAMPLES
+To upgrade base system packages from 15.0-RELEASE to 15.1-RELEASE using
+the FreeBSD-base repository:
+.Pp
+.Dl pkg -o VERSION_MINOR=1 upgrade -r FreeBSD-base
+.Pp
+This overrides the
+.Va VERSION_MINOR
+variable used in repository URL expansion, allowing the repository URL
+to resolve to the 15.1 package set.
+See
+.Xr pkg.conf 5
+for details on variable expansion in repository configurations.
 .Sh ENVIRONMENT
 The following environment variables affect the execution of
 .Nm .

--- a/docs/pkg.conf.5
+++ b/docs/pkg.conf.5
@@ -731,8 +731,18 @@ Expands to the name of the target operating system.
 Expands to the full version of the target operating system.
 .It Va VERSION_MAJOR
 Expands to the major version of the target operating system.
+Can be overridden via
+.Fl o Ar VERSION_MAJOR Ns = Ns Ar value
+or by setting the
+.Ev VERSION_MAJOR
+environment variable.
 .It Va VERSION_MINOR
 Expands to the minor version of the target operating system.
+Can be overridden via
+.Fl o Ar VERSION_MINOR Ns = Ns Ar value
+or by setting the
+.Ev VERSION_MINOR
+environment variable.
 .It Va OSVERSION
 If targeting
 .Fx ,

--- a/libpkg/pkg_config.c
+++ b/libpkg/pkg_config.c
@@ -832,10 +832,18 @@ config_parser_vars_register(struct ucl_parser *p)
 	}
 	ucl_parser_register_variable(p, "RELEASE", vars->release);
 
-	xasprintf(&vars->version_major, "%d", ctx.abi.major);
+	const char *env_version_major = getenv("VERSION_MAJOR");
+	if (env_version_major != NULL)
+		vars->version_major = xstrdup(env_version_major);
+	else
+		xasprintf(&vars->version_major, "%d", ctx.abi.major);
 	ucl_parser_register_variable(p, "VERSION_MAJOR", vars->version_major);
 
-	xasprintf(&vars->version_minor, "%d", ctx.abi.minor);
+	const char *env_version_minor = getenv("VERSION_MINOR");
+	if (env_version_minor != NULL)
+		vars->version_minor = xstrdup(env_version_minor);
+	else
+		xasprintf(&vars->version_minor, "%d", ctx.abi.minor);
 	ucl_parser_register_variable(p, "VERSION_MINOR", vars->version_minor);
 
 	ucl_parser_register_variable(p, "ARCH",

--- a/tests/frontend/config.sh
+++ b/tests/frontend/config.sh
@@ -8,6 +8,7 @@ tests_init \
 	repo_ssh_args \
 	nameserver \
 	expansion \
+	expansion_override \
 	validate_shlib_provide_paths
 #	duplicate_pkgs_allowed \
 
@@ -188,6 +189,32 @@ expansion_body() {
 	echo "DOT_FILE=\${ARCH}" > pkg.conf
 	atf_check -o inline:"${ARCH}\n" pkg -C ${TMPDIR}/pkg.conf config dot_file
 
+}
+
+expansion_override_body() {
+	atf_skip_on Darwin "N/A"
+	atf_skip_on Linux "N/A"
+
+	# VERSION_MINOR override via -o in config value
+	echo "DOT_FILE=\${VERSION_MINOR}" > pkg.conf
+	atf_check -o inline:"1\n" \
+		pkg -o VERSION_MINOR=1 -C ${TMPDIR}/pkg.conf config dot_file
+
+	# VERSION_MAJOR override via -o in config value
+	echo "DOT_FILE=\${VERSION_MAJOR}" > pkg.conf
+	atf_check -o inline:"99\n" \
+		pkg -o VERSION_MAJOR=99 -C ${TMPDIR}/pkg.conf config dot_file
+
+	# VERSION_MINOR override expands in repo URL
+	mkdir -p reposconf
+	cat > reposconf/test.conf << EOF
+myrepo: {
+    url: "pkg+https://pkg.FreeBSD.org/\${ABI}/base_release_\${VERSION_MINOR}",
+}
+EOF
+	atf_check \
+		-o match:'pkg\+https://pkg.FreeBSD.org/.*/base_release_42' \
+		pkg -o VERSION_MINOR=42 -o REPOS_DIR="${TMPDIR}/reposconf" -vv
 }
 
 validate_shlib_provide_paths_body() {


### PR DESCRIPTION
This simplifies base system package upgrades enormously for the
bulk of users, who have not configured custom repositories, and
makes intuitive use of the obvious VERSION_MINOR var found in both
`/etc/pkg/FreeBSD.conf` and `/usr/local/etc/pkg.conf` to allow
the user to go from 15.0-RELEASE to 15.1, and in future to 16.0:

```
pkg -o VERSION_MINOR=1 upgrade -r FreeBSD-base
...
```

Alternatively, we could allow OSVERSION by itself to assume same
ABI as the running system, but this requires users to figure out
what OSVERSION should be, and isn't as nice for major version
upgrades.

- OSVERSION on its own does not work

```
dch@akai /r/pkg> pkg  -oOSVERSION=1501000 repos |grep release
    url             : "pkg+https://pkg.FreeBSD.org/FreeBSD:15:amd64/base_release_0",
```

- needs the ABI as well, not nice UX

```
dch@akai /r/pkg> pkg -oABI=FreeBSD:15:amd64 -oOSVERSION=1501000 repos |grep release
    url             : "pkg+https://pkg.FreeBSD.org/FreeBSD:15:amd64/base_release_1",
```

- with patch applied

```
dch@akai /r/pkg> /repos/pkg/src/pkg-static -oVERSION_MINOR=1 repos |grep release
    url             : "pkg+https://pkg.FreeBSD.org/FreeBSD:15:amd64/base_release_1",
```
