### PR TITLE
GitHub: Bump actions checkout and upload-artifact

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -99,7 +99,7 @@ jobs:
           sudo apt-get update --quiet || true
           sudo apt-get -yq --no-install-suggests --no-install-recommends install \
             ${{ join(matrix.pkgs, ' ') }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           path: src.pkg
       - name: setup environment
@@ -190,7 +190,7 @@ jobs:
         if: ${{ always() }}
 
       - name: archive build artefacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pkg-test${{ join(matrix.sanitize, '_') }}-${{ matrix.build-os }}-${{ matrix.compiler }}
           path: pkg*.tar


### PR DESCRIPTION
Avoid deprecation warnings by bumping the checkout action to version 6 and the upload-artifact action to version 7.

There are still warnings:
```
llvm@19 was installed but not linked because llvm@18 is already installed. To link this version, run: brew link llvm@19
```
But those can be safely ignored.