### PR TITLE
CI: Add reallocf(3) for non-BSD platforms

### DIFF
--- a/compat/Makefile.in
+++ b/compat/Makefile.in
@@ -3,7 +3,8 @@ LIB=	bsd_compat
 SRCS=	closefrom.c \
 	humanize_number.c \
 	strtonum.c \
-	funopen.c
+	funopen.c \
+	reallocf.c
 
 LOCAL_CFLAGS=	-I$(top_srcdir)/compat \
 		-I$(top_srcdir)/libpkg \

--- a/compat/bsd_compat.h
+++ b/compat/bsd_compat.h
@@ -169,4 +169,8 @@ extern char *__progname;
 # endif
 #endif
 
+#if !HAVE_REALLOCF
+void *reallocf(void *, size_t);
+#endif
+
 #endif

--- a/compat/reallocf.c
+++ b/compat/reallocf.c
@@ -1,0 +1,52 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 1998 M. Warner Losh <imp@FreeBSD.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include "bsd_compat.h"
+
+#if !HAVE_REALLOCF
+
+#include <stdlib.h>
+
+void *
+reallocf(void *ptr, size_t size)
+{
+	void *nptr;
+
+	nptr = realloc(ptr, size);
+
+	/*
+	 * When the System V compatibility option (malloc "V" flag) is
+	 * in effect, realloc(ptr, 0) frees the memory and returns NULL.
+	 * So, to avoid double free, call free() only when size != 0.
+	 * realloc(ptr, 0) can't fail when ptr != NULL.
+	 */
+	if (!nptr && ptr && size != 0)
+		free(ptr);
+	return (nptr);
+}
+
+#endif /* !HAVE_REALLOCF */

--- a/configure.def
+++ b/configure.def
@@ -194,7 +194,7 @@ cc_check_functions strchrnul
 cc_check_functions arc4random arc4random_stir chflagsat \
 	closefrom fopencookie funopen getprogname \
 	strtofflags strtonum utimensat __res_setservers \
-	fflagstostr strchrnul copy_file_range
+	fflagstostr strchrnul copy_file_range reallocf
 
 # humanize_number declaration
 cc_with "-includes libutil.h" cc_check_decls humanize_number


### PR DESCRIPTION
Alpine Linux (musl) systems lack the reallocf(3) function.

Add reallocf.c to the compat layer, using FreeBSD's implementation.

Fixes:	9b1f2b153 ("rwhich: implement file tracking and search for remote repositories")