### PR TITLE
libpkg: Remove trailing semicolon from macro

### DIFF
--- a/libpkg/pkghash.h
+++ b/libpkg/pkghash.h
@@ -33,7 +33,7 @@ bool pkghash_next(pkghash_it *it);
 	else if (pkghash_get(_t, _k) != NULL)         \
 		break;                                \
 	pkghash_add(_t, _k, _v, _free_func);          \
-} while (0);
+} while (0)
 
 bool pkghash_del(pkghash *h, const char *key);
 void *pkghash_delete(pkghash *h, const char *key);


### PR DESCRIPTION
Remove a trailing semicolon from the pkghash_safe_add macro definition.

Note there are a couple more under external/libecc/src/arithmetic_tests/arithmetic_tests.c (this external library has been archived).