### PR TITLE
libpkg: config: only assume repository enabled once

### DIFF
--- a/libpkg/pkg_config.c
+++ b/libpkg/pkg_config.c
@@ -619,7 +619,7 @@ add_repo(const ucl_object_t *obj, struct pkg_repo *r, const char *rname, pkg_ini
 	const ucl_object_t *cur, *env;
 	ucl_object_iter_t it = NULL;
 	struct pkg_kv *kv;
-	bool enable = true;
+	bool enable = r != NULL ? r->enable : true;
 	const char *url = NULL, *pubkey = NULL, *mirror_type = NULL;
 	const char *signature_type = NULL, *fingerprints = NULL;
 	const char *ssh_args = NULL;

--- a/tests/frontend/repositories.sh
+++ b/tests/frontend/repositories.sh
@@ -8,6 +8,7 @@ tests_init \
 	list_disabled \
 	override_disable \
 	override_enable \
+	override_inherit_enable \
 	override_reset \
 	override_shown_in_vv \
 	override_unknown_repo \
@@ -111,6 +112,34 @@ override_enable_body()
 		-o match:'repo_b' \
 		-s exit:0 \
 		pkg -o REPOS_DIR="${TMPDIR}/reposconf" repositories -le
+}
+
+override_inherit_enable_body()
+{
+
+	# This test isn't very well placed, but we don't currently have an
+	# obvious place for explicit tests for pkg.conf.  We default
+	# repositories to enabled, but that default only really be applied the
+	# first time we encounter a definition.  Later overrides should be
+	# doable without having to re-specify whether the repository should
+	# remain enabled or disabled.
+	mkdir -p reposconf
+	cat > reposconf/base.conf << EOF
+repo_a: {
+    url: "file:///tmp/repo_a",
+    enabled: false
+}
+EOF
+	cat > reposconf/override.conf << EOF
+repo_a: {
+    priority: 5
+}
+EOF
+
+	atf_check \
+		-o match:'repo_a' \
+		-s exit:0 \
+		pkg -o REPOS_DIR="${TMPDIR}/reposconf" repositories -ld
 }
 
 override_reset_body()


### PR DESCRIPTION
The current model means that one might have to track different modifications that can be made to a repository in separate places, which can be more challenging for, e.g., generated configuration.  Implicit enable makes a lot of sense in general, but it can be quite confusing from a user-perspective that we'll enable a repository that was disabled elsewhere when the overriding config is only specifying unrelated things.

This is a potentially breaking change, but I think I'd be a little surprised if anyone relies on this behavior in practice.

Closess #2671