### PR TITLE
Small improvements for pkg/signing bits

### DIFF
--- a/libpkg/pkg_repo.c
+++ b/libpkg/pkg_repo.c
@@ -174,6 +174,7 @@ pkg_repo_check_fingerprint(struct pkg_repo *repo, pkghash *sc, bool fatal)
 		hash = pkg_checksum_data(s->cert, s->certlen,
 		    PKG_HASH_TYPE_SHA256_HEX);
 		if (pkghash_get(repo->revoked_fp, hash) != NULL) {
+			pkg_debug(1, "Fingerprint '%s' has been revoked", hash);
 			if (fatal)
 				pkg_emit_error("At least one of the "
 					"certificates has been revoked");
@@ -185,6 +186,7 @@ pkg_repo_check_fingerprint(struct pkg_repo *repo, pkghash *sc, bool fatal)
 		if (pkghash_get(repo->trusted_fp, hash) != NULL) {
 			nbgood++;
 			s->trusted = true;
+			pkg_debug(1, "Fingerprint '%s' is trusted", hash);
 		}
 		free(hash);
 	}
@@ -695,6 +697,8 @@ pkg_repo_archive_extract_check_archive(int fd, const char *file,
 					"removing repository.");
 			goto cleanup;
 		}
+
+		pkg_debug(1, "Signature verified with key '%s'", rkey);
 	}
 	else if (pkg_repo_signature_type(repo) == SIG_FINGERPRINT) {
 		const char *signer_name = NULL;
@@ -721,6 +725,7 @@ pkg_repo_archive_extract_check_archive(int fd, const char *file,
 			ret = pkgsign_verify_cert(sctx, s->cert, s->certlen, s->sig,
 			     s->siglen, dest_fd);
 			if (ret == EPKG_OK && s->trusted) {
+				pkg_debug(1, "Signature verified with trusted fingerprint");
 				break;
 			}
 			ret = EPKG_FATAL;
@@ -1085,8 +1090,10 @@ pkg_repo_fetch_meta(struct pkg_repo *repo, time_t *t)
 
 			ret = pkgsign_verify_cert(sctx, s->cert, s->certlen, s->sig, s->siglen,
 				metafd);
-			if (ret == EPKG_OK && s->trusted)
+			if (ret == EPKG_OK && s->trusted) {
+				pkg_debug(1, "Signature verified with trusted fingerprint");
 				break;
+			}
 			ret = EPKG_FATAL;
 		}
 		if (ret != EPKG_OK) {

--- a/libpkg/pkgsign_ecc.c
+++ b/libpkg/pkgsign_ecc.c
@@ -985,6 +985,7 @@ ecc_verify_cert_cb(int fd, void *ud)
 		return (EPKG_FATAL);
 
 	ret = ecc_verify_internal(cbdata, sha256, strlen(sha256));
+	free(sha256);
 	if (ret != 0) {
 		pkg_emit_error("ecc signature verification failure");
 		return (EPKG_FATAL);

--- a/libpkg/pkgsign_ecc.c
+++ b/libpkg/pkgsign_ecc.c
@@ -509,17 +509,22 @@ ecc_extract_signature(const uint8_t *sig, size_t siglen, uint8_t *rawsig,
 			goto out;
 
 		sigdata = libder_obj_data(obj, &datasz);
-		if (datasz < 2 || datasz > compsz + 1)
-			goto out;
 
 		/*
 		 * We may see an extra lead byte if our high bit of the first
 		 * byte was set, since these numbers are positive by definition.
+		 *
+		 * We clip off the leading sign byte if necessary so that we can
+		 * do the exactly-right size check, rather than having to do an
+		 * off-by-one to account for this.
 		 */
-		if (sigdata[0] == 0 && (sigdata[1] & 0x80) != 0) {
+		if (datasz > 1 && sigdata[0] == 0 && (sigdata[1] & 0x80) != 0) {
 			sigdata++;
 			datasz--;
 		}
+
+		if (datasz == 0 || datasz > compsz)
+			goto out;
 
 		/* Sanity check: don't overflow the output. */
 		if (sigoff + datasz > rawlen)

--- a/libpkg/pkgsign_ecc.c
+++ b/libpkg/pkgsign_ecc.c
@@ -586,7 +586,7 @@ ecc_extract_key_params(const uint8_t *oid, size_t oidlen,
 	int ret;
 
 	if (oidlen >= sizeof(oid_secp) &&
-	    memcmp(oid, oid_secp, sizeof(oid_secp)) >= 0) {
+	    memcmp(oid, oid_secp, sizeof(oid_secp)) == 0) {
 		oid += sizeof(oid_secp);
 		oidlen -= sizeof(oid_secp);
 
@@ -614,7 +614,7 @@ ecc_extract_key_params(const uint8_t *oid, size_t oidlen,
 	}
 
 	if (oidlen >= sizeof(oid_brainpoolP) &&
-	    memcmp(oid, oid_brainpoolP, sizeof(oid_brainpoolP)) >= 0) {
+	    memcmp(oid, oid_brainpoolP, sizeof(oid_brainpoolP)) == 0) {
 		oid += sizeof(oid_brainpoolP);
 		oidlen -= sizeof(oid_brainpoolP);
 


### PR DESCRIPTION
This fixes a few nits in the ECC signer; none of it particularly exploitable.  Additionally, it adds some verbosity (at least under -d) to signature verification (noted by @xbeaudouin)