### PR TITLE
libpkg: fix PKCS#8 encoding of ECDSA public keys

### DIFF
--- a/external/libder/CMakeLists.txt
+++ b/external/libder/CMakeLists.txt
@@ -2,9 +2,14 @@ cmake_minimum_required(VERSION 3.18)
 
 project(libder)
 
-if(CMAKE_BUILD_TYPE STREQUAL "Debug" AND NOT CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
-	add_compile_options(-fsanitize=address,undefined -fstrict-aliasing)
-	add_link_options(-fsanitize=address,undefined -fstrict-aliasing)
+add_compile_options(-Wall -Wextra)
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+	if(NOT CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
+		add_compile_options(-fsanitize=address,undefined -fstrict-aliasing)
+		add_link_options(-fsanitize=address,undefined -fstrict-aliasing)
+	endif()
+
+	add_compile_options(-Werror)
 endif()
 
 # AppleClang is excluded for the time being; the version used in GitHub Action
@@ -20,5 +25,6 @@ else()
 endif()
 
 add_subdirectory(libder)
+add_subdirectory(derbuild)
 add_subdirectory(derdump)
 add_subdirectory(tests)

--- a/external/libder/Makefile.in
+++ b/external/libder/Makefile.in
@@ -8,6 +8,7 @@ VPATH=	$(top_srcdir)/external/libder/libder
 SRCS=	libder.c \
 	libder_error.c \
 	libder_obj.c \
+	libder_oid.c \
 	libder_read.c \
 	libder_type.c \
 	libder_write.c

--- a/external/libder/libder/libder.h
+++ b/external/libder/libder/libder.h
@@ -159,6 +159,7 @@ uint8_t			*libder_write(struct libder_ctx *, struct libder_object *, uint8_t *,
 	    (var) = (tvar))
 
 struct libder_object	*libder_obj_alloc(struct libder_ctx *, struct libder_tag *, const uint8_t *, size_t);
+struct libder_object	*libder_obj_alloc_oid(struct libder_ctx *, const char *);
 struct libder_object	*libder_obj_alloc_simple(struct libder_ctx *, uint8_t, const uint8_t *,
 		    size_t);
 void		 libder_obj_free(struct libder_object *);

--- a/external/libder/libder/libder_obj.c
+++ b/external/libder/libder/libder_obj.c
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2024 Kyle Evans <kevans@FreeBSD.org>
+ * Copyright (c) 2024, 2026 Kyle Evans <kevans@FreeBSD.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -79,6 +79,34 @@ libder_obj_alloc(struct libder_ctx *ctx, struct libder_tag *type,
 			free(payload);
 		}
 
+		libder_set_error(ctx, LDE_NOMEM);
+	}
+
+	return (obj);
+}
+
+struct libder_object *
+libder_obj_alloc_oid(struct libder_ctx *ctx, const char *oidstr)
+{
+	struct libder_object *obj;
+	struct libder_tag *type;
+	uint8_t *payload;
+	size_t payloadsz;
+
+	type = libder_type_alloc_simple(ctx, BT_OID);
+	if (type == NULL)
+		return (NULL);
+
+	payload = libder_oid_parse(oidstr, &payloadsz);
+	if (payload == NULL) {
+		libder_type_free(type);
+		return (NULL);
+	}
+
+	obj = libder_obj_alloc_internal(ctx, type, payload, payloadsz, LDO_OWNTAG);
+	if (obj == NULL) {
+		libder_bzero(payload, payloadsz);
+		libder_type_free(type);
 		libder_set_error(ctx, LDE_NOMEM);
 	}
 
@@ -472,6 +500,16 @@ libder_obj_dump_internal(const struct libder_object *obj, FILE *fp, int lvl)
 					printb = obj->payload[i];
 
 				col += fprintf(fp, "%.02x ", printb);
+			}
+
+			if (libder_type_is(obj->type, BT_OID)) {
+				char *oidstr;
+
+				fprintf(fp, "\n%.*s    ", lvl, spacer);
+
+				oidstr = libder_oid_stringify(obj->payload, obj->length);
+				fprintf(fp, "\"%s\"", oidstr != NULL ? oidstr : "<INVALID>");
+				free(oidstr);
 			}
 		}
 

--- a/external/libder/libder/libder_oid.c
+++ b/external/libder/libder/libder_oid.c
@@ -1,0 +1,234 @@
+/*-
+ * Copyright (c) 2026 Kyle Evans <kevans@FreeBSD.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <ctype.h>
+#include <errno.h>
+#include <limits.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "libder_private.h"
+
+static size_t
+arc_encoded_len(uint64_t oval)
+{
+	int nbits;
+
+	if (oval == 0)
+		return (1);
+
+	nbits = 64 - __builtin_clzll(oval);
+	return ((nbits + 6) / 7);
+}
+
+static bool
+arc_encode(FILE *fp, uint64_t oval)
+{
+	off_t fpos;
+	size_t writesz;
+	uint8_t arcb;
+
+#define oid_write(b) do {			\
+	arcb = (b);				\
+	writesz = fwrite(&arcb, 1, 1, fp);	\
+	if (writesz != 1)			\
+		return (false);			\
+} while(0)
+
+	/*
+	 * Base-128 Encoding: calculate how many bytes are needed for
+	 * the representation and extend our stream in advance, then
+	 * work backwards.
+	 */
+	fseek(fp, arc_encoded_len(oval) - 1, SEEK_CUR);
+	fpos = ftello(fp);
+	oid_write(oval & 0x7f);
+	oval >>= 7;
+
+	while (oval != 0) {
+		fseek(fp, -2, SEEK_CUR);
+		oid_write(0x80 | (oval & 0x7f));
+		oval >>= 7;
+	}
+
+	fseeko(fp, fpos + 1, SEEK_SET);
+#undef oid_write
+	return (true);
+}
+
+static bool
+oid_root_sane(uint64_t root, uint64_t sec)
+{
+
+	switch (root) {
+	case 0:
+	case 1:
+		/* Limited to 0-40 do to our (root * 40) + sec formula. */
+		return (sec < 40);
+	case 2:
+		/* Just can't overflow UINT64_MAX */
+		return (sec <= (UINT64_MAX - (root * 40)));
+	default:
+		break;
+	}
+
+	return (false);
+}
+
+uint8_t *
+libder_oid_parse(const char *oidstr, size_t *outsz)
+{
+	unsigned long long root, sec;
+	FILE *oidf;
+	char *buf;
+	size_t oidsz;
+	int order = 0, serrno;
+
+	/* X.690 Encoding */
+	if (sscanf(oidstr, "%llu.%llu", &root, &sec) != 2) {
+		errno = EINVAL;
+		return (NULL);
+	} else if (!oid_root_sane(root, sec)) {
+		/* Covers overflow and invalid root values. */
+		errno = EINVAL;
+		return (NULL);
+	}
+
+	oidf = open_memstream(&buf, &oidsz);
+	if (oidf == NULL)
+		return (NULL);
+
+	/*
+	 * This will usually just be a single byte, but technically it can be
+	 * larger and must also be base-128 encoded.
+	 */
+	if (!arc_encode(oidf, (root * 40) + sec))
+		goto failed;
+
+	for (size_t start = 0, nsep = strcspn(oidstr, "."); oidstr[start] != '\0';
+	    start = oidstr[nsep] == '\0' ? nsep : nsep + 1,
+	    nsep = start + strcspn(&oidstr[start], ".")) {
+		char *endp;
+		unsigned long long oval;
+
+		/*
+		 * We're checking before skipping the first two components
+		 * because sscanf will happily accept a sign, so we just want to
+		 * additionally validate the first two.
+		 */
+		if (!isdigit(oidstr[start])) {
+			errno = EINVAL;
+			goto failed;
+		}
+
+		if (order < 2) {
+			/* Skip the first two components. */
+			order++;
+			continue;
+		}
+
+		errno = 0;
+		oval = strtoull(&oidstr[start], &endp, 10);
+		if (errno != 0 || endp != &oidstr[nsep]) {
+			/*  overflow and invalid sequences. */
+			if (*endp != '.')
+				errno = EINVAL;
+			goto failed;
+		}
+
+		if (!arc_encode(oidf, oval))
+			goto failed;
+	}
+
+	if (ferror(oidf))
+		goto failed;
+
+	fclose(oidf);
+	*outsz = oidsz;
+	return ((uint8_t *)buf);
+
+failed:
+	serrno = errno;
+	fclose(oidf);
+	free(buf);
+	errno = serrno;
+	return (NULL);
+}
+
+static bool
+arc_decode_next(const uint8_t **oidp, size_t *oidszp, uint64_t *valp)
+{
+	const uint8_t *oid = *oidp;
+	size_t oidsz = *oidszp;
+	uint64_t val = 0;
+	uint8_t obyte;
+
+	do {
+		if (oidsz == 0)
+			return (false);
+
+		obyte = *oid;
+		oid++;
+		oidsz--;
+
+		val <<= 7;
+		val |= obyte & 0x7f;
+	} while ((obyte & 0x80) != 0);
+
+	*oidp = oid;
+	*oidszp = oidsz;
+	*valp = val;
+	return (true);
+}
+
+char *
+libder_oid_stringify(const uint8_t *oid, size_t oidsz)
+{
+	FILE *oidstrf;
+	char *buf;
+	size_t bufsz;
+	uint64_t val;
+	int serrno;
+	bool rooted = false;
+
+	oidstrf = open_memstream(&buf, &bufsz);
+	if (oidstrf == NULL)
+		return (NULL);
+
+	while (oidsz != 0) {
+		if (!arc_decode_next(&oid, &oidsz, &val))
+			goto failed;
+
+		if (!rooted) {
+			unsigned long long root, sec;
+
+			/* 2 is unbounded, 0-1 occupy no more than 0-39. */
+			root = MIN(val / 40, 2);
+			sec = val - (root * 40);
+			rooted = true;
+
+			fprintf(oidstrf, "%llu.%llu", root, sec);
+			continue;
+		}
+
+		fprintf(oidstrf, ".%llu", (unsigned long long)val);
+	}
+
+	if (ferror(oidstrf))
+		goto failed;
+
+	fclose(oidstrf);
+	return (buf);
+failed:
+	serrno = errno;
+	fclose(oidstrf);
+	free(buf);
+	errno = serrno;
+	return (NULL);
+}

--- a/external/libder/libder/libder_private.h
+++ b/external/libder/libder/libder_private.h
@@ -173,6 +173,9 @@ bool			 libder_obj_may_coalesce_children(const struct libder_object *);
 bool			 libder_obj_coalesce_children(struct libder_object *, struct libder_ctx *);
 bool			 libder_obj_normalize(struct libder_object *, struct libder_ctx *);
 
+uint8_t			*libder_oid_parse(const char *, size_t *);
+char			*libder_oid_stringify(const uint8_t *, size_t);
+
 struct libder_tag	*libder_type_alloc(void);
 void			 libder_type_release(struct libder_tag *);
 void			 libder_normalize_type(struct libder_ctx *, struct libder_tag *);

--- a/external/libder/tests/CMakeLists.txt
+++ b/external/libder/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(FUZZERS fuzz_parallel fuzz_stream fuzz_write)
+set(FUZZERS fuzz_oidparser fuzz_parallel fuzz_stream fuzz_write)
 set(UTILS )
 set(TESTS test_privkey test_pubkey)
 

--- a/external/libder/tests/fuzz_oidparser.c
+++ b/external/libder/tests/fuzz_oidparser.c
@@ -1,0 +1,53 @@
+/*-
+ * Copyright (c) 2026 Kyle Evans <kevans@FreeBSD.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <sys/param.h>
+#include <sys/socket.h>
+
+#include <assert.h>
+#include <ctype.h>
+#include <signal.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <libder.h>
+
+#include "fuzzers.h"
+
+int
+LLVMFuzzerTestOneInput(const uint8_t *data, size_t sz)
+{
+	struct libder_ctx *ctx;
+	struct libder_object *obj;
+	uint32_t root, sec;
+
+	/* Looking for C-style strings here. */
+	if (sz == 0 || data[sz - 1] != '\0' || memchr(data, 0, sz - 1) != NULL)
+		return (-1);
+
+	/*
+	 * Let's accept only canonically-valid OIDs; only roots 0, 1, and 2 exist,
+	 * and roots 0/1 are constrainted to 0-39.  Root 2 is unbounded.
+	 */
+	if (sscanf((const char *)data, "%d.%d", &root, &sec) != 2 || root > 2)
+		return (-1);
+	if (root < 2 && sec > 39)
+		return (-1);
+
+	ctx = libder_open();
+	obj = libder_obj_alloc_oid(ctx, (const char *)data);
+	if (obj == NULL) {
+		libder_close(ctx);
+		return (-1);
+	}
+
+	libder_obj_free(obj);
+	libder_close(ctx);
+	return (0);
+}

--- a/libpkg/pkgsign_ecc.c
+++ b/libpkg/pkgsign_ecc.c
@@ -67,8 +67,6 @@ static const uint8_t oid_ecpubkey[] = \
 
 static const uint8_t oid_secp[] = \
     { 0x2b, 0x81, 0x04, 0x00 };
-static const uint8_t oid_secp256k1[] = \
-    { 0x2b, 0x81, 0x04, 0x00, 0x0a };
 static const uint8_t oid_brainpoolP[] = \
     { 0x2b, 0x24, 0x03, 0x03, 0x02, 0x08, 0x01, 0x01 };
 
@@ -124,10 +122,9 @@ ecc_pkgkey_params(const uint8_t *curve, size_t curvesz)
  *      }
  *
  */
-/* XXX Should eventually support other kinds of keys. */
 static int
-ecc_pubkey_write_pkcs8(const uint8_t *keydata, size_t keysz,
-    uint8_t **buf, size_t *buflen)
+ecc_pubkey_write_pkcs8(const ec_params *ecparams, const uint8_t *keydata,
+    size_t keysz, uint8_t **buf, size_t *buflen)
 {
 	uint8_t keybuf[EC_PUB_KEY_MAX_SIZE + 2], *outbuf;
 	struct libder_ctx *ctx;
@@ -162,12 +159,7 @@ ecc_pubkey_write_pkcs8(const uint8_t *keydata, size_t keysz,
 	ok = libder_obj_append(params, oid);
 	assert(ok);
 
-	/*
-	 * secp256k1, we should eventually allow other curves and actually
-	 * construct the OID.
-	 */
-	oid = libder_obj_alloc_simple(ctx, BT_OID, oid_secp256k1,
-	    sizeof(oid_secp256k1));
+	oid = libder_obj_alloc_oid(ctx, ecparams->curve_oid);
 	if (oid == NULL)
 		goto out;
 	ok = libder_obj_append(params, oid);
@@ -1234,7 +1226,7 @@ ecc_pubkey(struct pkgsign_ctx *sctx, char **pubkey, size_t *pubkeylen)
 			    sctx->path);
 			return (EPKG_FATAL);
 		}
-	} else if (ecc_pubkey_write_pkcs8(keybuf, keylen,
+	} else if (ecc_pubkey_write_pkcs8(&keyinfo->params, keybuf, keylen,
 	    (uint8_t **)pubkey, pubkeylen) != EPKG_OK) {
 		pkg_emit_error("%s: failed to write DER-encoded key", sctx->path);
 		return (EPKG_FATAL);

--- a/tests/frontend/key.sh
+++ b/tests/frontend/key.sh
@@ -55,6 +55,19 @@ key_pubout_body() {
 	# Make sure it's functional.
 	atf_check -o save:msg.sign openssl dgst -sign repo -sha256 -binary msg
 	atf_check -o ignore openssl dgst -sha256 -verify repo.pub -signature msg.sign msg
+
+	# Check all of our ECC curves as well.
+	for curve in secp256k1 secp384r1 secp521r1 \
+	    brainpoolP256r1 brainpoolP256t1 brainpoolP320r1 brainpoolP320t1 \
+	    brainpoolP384r1 brainpoolP384t1 brainpoolP512r1 brainpoolP512t1; do
+		rm -f repo repo.pub
+
+		atf_check openssl ecparam -genkey -name "$curve" -out repo -outform DER
+		atf_check -o match:":$curve" openssl asn1parse -inform DER -in repo
+
+		atf_check -o save:repo.pub pkg key --public -t ecdsa repo
+		atf_check -o match:":$curve" openssl asn1parse -inform DER -in repo.pub
+	done
 }
 
 key_sign_head() {
@@ -69,7 +82,7 @@ key_sign_body() {
 		# Generate a key with pkg
 		atf_check -o save:repo.pub -e ignore \
 		    pkg key --create -t "$signer" repo.key
-		
+
 		atf_check -o save:msg.sig \
 		    pkg key --sign -t "$signer" repo.key < msg
 


### PR DESCRIPTION
We previously just emitted the secp256k1 curve OID no matter the key, but libder has grown a facility to translate the OID provided by libecc so that we can embed that instead.  Thus, the pkg part of this is relatively boring while the libder side sees most of the change.