### PR TITLE
libpkg: Handle getgrnam_r/getpwnam_r upon ERANGE

### DIFF
--- a/libpkg/pkg_add.c
+++ b/libpkg/pkg_add.c
@@ -1923,8 +1923,8 @@ pkg_add_fromdir(struct pkg *pkg, const char *src, struct pkgdb *db __unused)
 	int retcode;
 	hardlinks_t hardlinks = vec_init();
 	const char *path;
-	char buffer[1024];
-	size_t link_len;
+	char *buffer = NULL;
+	size_t link_len, bufsize;
 	bool install_as_user;
 	tempdirs_t tempdirs = vec_init();
 	struct pkg_add_context context;
@@ -1949,8 +1949,18 @@ pkg_add_fromdir(struct pkg *pkg, const char *src, struct pkgdb *db __unused)
 		if (d->perm == 0)
 			d->perm = st.st_mode & ~S_IFMT;
 		if (d->uname != NULL) {
-			err = getpwnam_r(d->uname, &pwent, buffer,
-			    sizeof(buffer), &pw);
+			bufsize = 1024;
+			for (;;) {
+				free(buffer);
+				buffer = xcalloc(1, bufsize);
+				err = getpwnam_r(d->uname, &pwent, buffer,
+				    bufsize, &pw);
+				if (err == ERANGE) {
+					bufsize *= 2;
+					continue;
+				}
+				break;
+			}
 			if (err != 0) {
 				pkg_emit_error("getpwnam_r(%s): %s", d->uname, strerror(err));
 				retcode = EPKG_FATAL;
@@ -1961,8 +1971,18 @@ pkg_add_fromdir(struct pkg *pkg, const char *src, struct pkgdb *db __unused)
 			d->uid = install_as_user ? st.st_uid : 0;
 		}
 		if (d->gname != NULL) {
-			err = getgrnam_r(d->gname, &grent, buffer,
-			    sizeof(buffer), &gr);
+			bufsize = 1024;
+			for (;;) {
+				free(buffer);
+				buffer = xcalloc(1, bufsize);
+				err = getgrnam_r(d->gname, &grent, buffer,
+				    bufsize, &gr);
+				if (err == ERANGE) {
+					bufsize *= 2;
+					continue;
+				}
+				break;
+			}
 			if (err != 0) {
 				pkg_emit_error("getgrnam_r(%s): %s", d->gname, strerror(err));
 				retcode = EPKG_FATAL;
@@ -2005,8 +2025,18 @@ pkg_add_fromdir(struct pkg *pkg, const char *src, struct pkgdb *db __unused)
 			pkg_fatal_errno("%s%s", src, f->path);
 		}
 		if (f->uname != NULL) {
-			err = getpwnam_r(f->uname, &pwent, buffer,
-			    sizeof(buffer), &pw);
+			bufsize = 1024;
+			for (;;) {
+				free(buffer);
+				buffer = xcalloc(1, bufsize);
+				err = getpwnam_r(f->uname, &pwent, buffer,
+				    bufsize, &pw);
+				if (err == ERANGE) {
+					bufsize *= 2;
+					continue;
+				}
+				break;
+			}
 			if (err != 0) {
 				pkg_emit_error("getpwnam_r(%s): %s", f->uname, strerror(err));
 				retcode = EPKG_FATAL;
@@ -2018,8 +2048,18 @@ pkg_add_fromdir(struct pkg *pkg, const char *src, struct pkgdb *db __unused)
 		}
 
 		if (f->gname != NULL) {
-			err = getgrnam_r(f->gname, &grent, buffer,
-			    sizeof(buffer), &gr);
+			bufsize = 1024;
+			for (;;) {
+				free(buffer);
+				buffer = xcalloc(1, bufsize);
+				err = getgrnam_r(f->gname, &grent, buffer,
+				    bufsize, &gr);
+				if (err == ERANGE) {
+					bufsize *= 2;
+					continue;
+				}
+				break;
+			}
 			if (err != 0) {
 				pkg_emit_error("getgrnam_r(%s): %s", f->gname, strerror(err));
 				retcode = EPKG_FATAL;
@@ -2110,6 +2150,7 @@ pkg_add_fromdir(struct pkg *pkg, const char *src, struct pkgdb *db __unused)
 
 cleanup:
 	vec_free_and_free(&hardlinks, free);
+	free(buffer);
 	close(fromfd);
 	return (retcode);
 }

--- a/libpkg/utils.c
+++ b/libpkg/utils.c
@@ -1142,17 +1142,28 @@ charv_search(charv_t *v, const char *el)
 uid_t
 get_uid_from_uname(const char *uname)
 {
-	static char user_buffer[1024];
 	static struct passwd pwent;
 	struct passwd *result;
+	static char *user_buffer = NULL;
+	size_t bufsize;
 	int err;
 	const char *testuname = uname ? uname : "";
 
 	if (pwent.pw_name != NULL && STREQ(testuname, pwent.pw_name))
 		goto out;
 	pwent.pw_name = NULL;
-	err = getpwnam_r(testuname, &pwent, user_buffer, sizeof(user_buffer),
-	    &result);
+	bufsize = 1024;
+	for (;;) {
+		free(user_buffer);
+		user_buffer = xcalloc(1, bufsize);
+		err = getpwnam_r(testuname, &pwent, user_buffer, bufsize,
+		    &result);
+		if (err == ERANGE) {
+			bufsize *= 2;
+			continue;
+		}
+		break;
+	}
 	if (err != 0) {
 		pkg_emit_error("getpwnam_r(%s): %s", testuname, strerror(err));
 		return (0);
@@ -1166,17 +1177,28 @@ out:
 gid_t
 get_gid_from_gname(const char *gname)
 {
-	static char group_buffer[1024];
 	static struct group grent;
 	struct group *result;
+	static char *group_buffer = NULL;
+	size_t bufsize;
 	int err;
 	const char *testgname = gname ? gname : "";
 
 	if (grent.gr_name != NULL && STREQ(testgname, grent.gr_name))
 		goto out;
 	grent.gr_name = NULL;
-	err = getgrnam_r(testgname, &grent, group_buffer, sizeof(group_buffer),
-	    &result);
+	bufsize = 1024;
+	for (;;) {
+		free(group_buffer);
+		group_buffer = xcalloc(1, bufsize);
+		err = getgrnam_r(testgname, &grent, group_buffer, bufsize,
+		    &result);
+		if (err == ERANGE) {
+			bufsize *= 2;
+			continue;
+		}
+		break;
+	}
 	if (err != 0) {
 		pkg_emit_error("getgrnam_r(%s): %s", testgname, strerror(err));
 		return (0);


### PR DESCRIPTION
Double the buffer size upon ERANGE to handle heavily populated systems.

As reported here: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=295672

Edit: Just realized buffer provides memory for the structure... Made this a draft for now