### PR TITLE
install: Support -X for --register-only

### DIFF
--- a/src/install.c
+++ b/src/install.c
@@ -103,7 +103,7 @@ exec_install(int argc, char **argv)
 		quiet = true;
 	}
 
-	while ((ch = getopt_long(argc, argv, "+ACfFgiIlMnqr:RUxy", longopts, NULL)) != -1) {
+	while ((ch = getopt_long(argc, argv, "+ACfFgiIlMnqr:RUXxy", longopts, NULL)) != -1) {
 		switch (ch) {
 		case 'A':
 			f |= PKG_FLAG_AUTOMATIC;


### PR DESCRIPTION
This was documented but not actually implemented.

Fixes:		cb296b1d164f ("pkg_install: Add --register-only")