### PR TITLE
Introduce the PKG_EVENT_PKG_FETCH_BEGIN event type

### DIFF
--- a/libpkg/pkg.h.in
+++ b/libpkg/pkg.h.in
@@ -1308,6 +1308,7 @@ typedef enum {
 	PKG_EVENT_FETCHING,
 	PKG_EVENT_FETCH_BEGIN,
 	PKG_EVENT_FETCH_FINISHED,
+	PKG_EVENT_PKG_FETCH_BEGIN,
 	PKG_EVENT_UPDATE_ADD,
 	PKG_EVENT_UPDATE_REMOVE,
 	PKG_EVENT_INTEGRITYCHECK_BEGIN,
@@ -1397,6 +1398,9 @@ struct pkg_event {
 		struct {
 			const char *url;
 		} e_fetching;
+		struct {
+			struct pkg *pkg;
+		} e_pkg_fetching;
 		struct {
 			struct pkg *pkg;
 		} e_already_installed;

--- a/libpkg/pkg_event.c
+++ b/libpkg/pkg_event.c
@@ -680,6 +680,17 @@ pkg_emit_fetch_finished(const char *url)
 }
 
 void
+pkg_emit_pkg_fetch_begin(struct pkg *p)
+{
+	struct pkg_event ev;
+
+	ev.type = PKG_EVENT_PKG_FETCH_BEGIN;
+	ev.e_pkg_fetching.pkg = p;
+
+	pkg_emit_event(&ev);
+}
+
+void
 pkg_emit_update_remove(int total, int done)
 {
 	struct pkg_event ev;

--- a/libpkg/private/event.h
+++ b/libpkg/private/event.h
@@ -96,6 +96,7 @@ static const struct pkg_dbg_flags debug_flags[] = {
 void pkg_emit_already_installed(struct pkg *p);
 void pkg_emit_fetch_begin(const char *url);
 void pkg_emit_fetch_finished(const char *url);
+void pkg_emit_pkg_fetch_begin(struct pkg *p);
 void pkg_emit_update_add(int total, int done);
 void pkg_emit_update_remove(int total, int done);
 void pkg_emit_install_begin(struct pkg *p);

--- a/libpkg/repo/binary/fetch.c
+++ b/libpkg/repo/binary/fetch.c
@@ -221,6 +221,7 @@ pkg_repo_binary_try_fetch(struct pkg_repo *repo, struct pkg *pkg,
 		return EPKG_FATAL;
 	}
 
+	pkg_emit_pkg_fetch_begin(pkg);
 	retcode = pkg_fetch_file(repo, pkg->repopath, dest, 0, offset, pkg->pkgsize);
 
 	if (offset == -1)


### PR DESCRIPTION
Unlike plain PKG_EVENT_FETCH_BEGIN, the added event reports a struct pkg* being downloaded rather than textual URL. This is needed for PackageKit to accurately report the package downloading progress.