### PR TITLE
Bound repository signature extraction

### DIFF
--- a/libpkg/pkg_repo.c
+++ b/libpkg/pkg_repo.c
@@ -71,6 +71,9 @@ struct sig_cert {
 	bool trusted;
 };
 
+#define PKG_REPO_MAX_SIGNATURE_ENTRIES	8
+#define PKG_REPO_MAX_SIGNATURE_SIZE	(1024 * 1024)
+
 int
 pkg_repo_fetch_remote_tmp(struct pkg_repo *repo,
   const char *filename, const char *extension, time_t *t, int *rc, bool silent)
@@ -258,6 +261,7 @@ pkg_repo_meta_extract_signature_pubkey(int fd, void *ud)
 	struct archive_entry *ae = NULL;
 	struct pkg_extract_cbdata *cb = ud;
 	int siglen;
+	int64_t entry_size;
 	int rc = EPKG_FATAL;
 
 	pkg_debug(1, "PkgRepo: extracting signature of repo in a sandbox");
@@ -270,7 +274,12 @@ pkg_repo_meta_extract_signature_pubkey(int fd, void *ud)
 
 	while (archive_read_next_header(a, &ae) == ARCHIVE_OK) {
 		if (cb->need_sig && STREQ(archive_entry_pathname(ae), "signature")) {
-			siglen = archive_entry_size(ae);
+			entry_size = archive_entry_size(ae);
+			if (entry_size <= 0 || entry_size > PKG_REPO_MAX_SIGNATURE_SIZE) {
+				pkg_emit_error("invalid repository signature entry size");
+				break;
+			}
+			siglen = entry_size;
 			rc = pkg_repo_write_sig_from_archive(a, fd, siglen);
 			if (rc != EPKG_OK)
 				break;
@@ -304,6 +313,8 @@ pkg_repo_meta_extract_signature_fingerprints(int fd, void *ud)
 	struct pkg_extract_cbdata *cb = ud;
 	const char *type;
 	int siglen, keylen, typelen;
+	int signature_entries = 0;
+	int64_t entry_size;
 	uint8_t *sig, *sigdata;
 	int rc = EPKG_FATAL;
 	char key[MAXPATHLEN], t;
@@ -320,14 +331,23 @@ pkg_repo_meta_extract_signature_fingerprints(int fd, void *ud)
 	while (archive_read_next_header(a, &ae) == ARCHIVE_OK) {
 		if (str_ends_with(archive_entry_pathname(ae), ".sig") ||
 		    str_ends_with(archive_entry_pathname(ae), ".pub")) {
+			if (++signature_entries > PKG_REPO_MAX_SIGNATURE_ENTRIES) {
+				pkg_emit_error("too many repository signature entries");
+				return (EPKG_FATAL);
+			}
+			entry_size = archive_entry_size(ae);
+			if (entry_size <= 0 || entry_size > PKG_REPO_MAX_SIGNATURE_SIZE) {
+				pkg_emit_error("invalid repository signature entry size");
+				return (EPKG_FATAL);
+			}
 			t = str_ends_with(archive_entry_pathname(ae), ".sig") ? 0 : 1;
 			snprintf(key, sizeof(key), "%.*s",
 					(int) strlen(archive_entry_pathname(ae)) - 4,
 					archive_entry_pathname(ae));
 			type = NULL;
-			siglen = archive_entry_size(ae);
+			siglen = entry_size;
 			sigdata = sig = xmalloc(siglen);
-			if (archive_read_data(a, sig, siglen) == -1) {
+			if (archive_read_data(a, sig, siglen) != siglen) {
 				pkg_emit_errno("pkg_repo_meta_extract_signature",
 						"archive_read_data failed");
 				free(sig);

--- a/libpkg/pkg_sandbox.c
+++ b/libpkg/pkg_sandbox.c
@@ -54,6 +54,8 @@
 #include <xmalloc.h>
 #include "pkg.h"
 
+#define PKG_SANDBOX_MAX_OUTPUT	(8 * 1024 * 1024)
+
 int
 pkg_handle_sandboxed_call(pkg_sandbox_cb func, int fd, void *ud)
 {
@@ -119,7 +121,9 @@ pkg_handle_sandboxed_get_string(pkg_sandbox_cb func, char **result, int64_t *len
 	pid_t pid;
 	struct rlimit rl_zero;
 	int	status, ret = EPKG_OK;
-	int pair[2], r, allocated_len = 0, off = 0;
+	int pair[2];
+	ssize_t r;
+	size_t allocated_len = 0, off = 0;
 	char *buf = NULL;
 
 	if (socketpair(AF_UNIX, SOCK_STREAM, 0, pair) == -1) {
@@ -147,7 +151,20 @@ pkg_handle_sandboxed_get_string(pkg_sandbox_cb func, char **result, int64_t *len
 		allocated_len = BUFSIZ;
 		do {
 			if (off >= allocated_len) {
-				allocated_len *= 2;
+				if (allocated_len >= PKG_SANDBOX_MAX_OUTPUT) {
+					pkg_emit_error("sandboxed callback output exceeds %d bytes",
+					    PKG_SANDBOX_MAX_OUTPUT);
+					free(buf);
+					close(pair[1]);
+					kill(pid, SIGTERM);
+					while (waitpid(pid, &status, 0) == -1 && errno == EINTR)
+						;
+					return (EPKG_FATAL);
+				}
+				if (allocated_len > PKG_SANDBOX_MAX_OUTPUT / 2)
+					allocated_len = PKG_SANDBOX_MAX_OUTPUT;
+				else
+					allocated_len *= 2;
 				buf = xrealloc(buf, allocated_len);
 			}
 
@@ -158,7 +175,7 @@ pkg_handle_sandboxed_get_string(pkg_sandbox_cb func, char **result, int64_t *len
 				return (EPKG_FATAL);
 			}
 			else if (r > 0) {
-				off += r;
+				off += (size_t)r;
 			}
 		} while (r > 0);
 


### PR DESCRIPTION
Repository signature entries are sent to the parent process before fingerprint
verification. A spoofed repository response can use many or oversized .sig and
.pub entries to exhaust memory during pkg update.

Limit signature entries and individual or aggregate signature data before it
crosses the sandbox boundary. Oversized repository metadata is rejected before
verification.