### PR TITLE
Enforce signed package size while fetching

### DIFF
--- a/libpkg/fetch.c
+++ b/libpkg/fetch.c
@@ -176,6 +176,7 @@ pkg_fetch_file(struct pkg_repo *repo, const char *url, char *dest, time_t t,
 
 	fi.offset = offset;
 	fi.size = size;
+	fi.expected_size = size;
 	fi.mtime = t;
 
 	retcode = pkg_fetch_file_to_fd(repo, fd, &fi, false);
@@ -295,6 +296,11 @@ pkg_fetch_file_to_fd(struct pkg_repo *repo, int dest, struct fetch_item *fi,
 	if ((retcode = repo->fetcher->open(repo, fi)) != EPKG_OK)
 		goto cleanup;
 	pkg_dbg(PKG_DBG_FETCH, 1, "Fetch: fetcher used: %s", repo->fetcher->scheme);
+	if (fi->expected_size > 0 && fi->size > fi->expected_size) {
+		pkg_emit_error("fetch exceeds expected package size");
+		retcode = EPKG_FATAL;
+		goto cleanup;
+	}
 
 	retcode = repo->fetcher->fetch(repo, dest, fi);
 	if (retcode == EPKG_OK)

--- a/libpkg/fetch_file.c
+++ b/libpkg/fetch_file.c
@@ -129,6 +129,14 @@ stdio_fetch(struct pkg_repo *repo, int dest, struct fetch_item *fi)
 	left = sizeof(buf);
 	if (fi->size > 0)
 		left = fi->size - done;
+	if (fi->expected_size > 0) {
+		if (done > fi->expected_size) {
+			pkg_emit_error("fetch exceeds expected package size");
+			return (EPKG_FATAL);
+		}
+		if (fi->size == 0 || left > fi->expected_size - done)
+			left = fi->expected_size - done;
+	}
 
 	while ((r = fread(buf, 1, left < buflen ? left : buflen, repo->fh)) > 0) {
 		if (write(dest, buf, r) != r) {
@@ -136,17 +144,29 @@ stdio_fetch(struct pkg_repo *repo, int dest, struct fetch_item *fi)
 			return (EPKG_FATAL);
 		}
 		done += r;
-		if (fi->size > 0) {
+		if (fi->size > 0 || fi->expected_size > 0) {
 			left -= r;
+		}
+		if (fi->size > 0) {
 			pkg_dbg(PKG_DBG_FETCH, 1, "Read status: %jd over %jd", (intmax_t)done, (intmax_t)fi->size);
 		} else
 			pkg_dbg(PKG_DBG_FETCH, 1,  "Read status: %jd", (intmax_t)done);
 		if (fi->size > 0)
 			pkg_emit_progress_tick(done, fi->size);
 	}
+	if (fi->expected_size > 0 && done == fi->expected_size &&
+	    (fi->size == 0 || fi->size > fi->expected_size) &&
+	    fgetc(repo->fh) != EOF) {
+		pkg_emit_error("fetch exceeds expected package size");
+		return (EPKG_FATAL);
+	}
 	if (ferror(repo->fh)) {
 		pkg_emit_error("An error occurred while fetching package");
 		return(EPKG_FATAL);
+	}
+	if (fi->expected_size > 0 && done != fi->expected_size) {
+		pkg_emit_error("fetch size does not match expected package size");
+		return (EPKG_FATAL);
 	}
 	return (EPKG_OK);
 }

--- a/libpkg/private/fetch.h
+++ b/libpkg/private/fetch.h
@@ -30,6 +30,7 @@
 struct fetch_item {
 	const char *url;
 	off_t size;
+	off_t expected_size;
 	off_t offset;
 	time_t mtime;
 };


### PR DESCRIPTION
Package downloads replace the repository-recorded expected size with response metadata and validate the cache file only after transfer. An attacker who can modify an HTTP response can fill the package cache filesystem before the package is rejected.

Preserve the expected size separately from response metadata, reject known oversized responses before writing, and cap unknown-length responses at the expected size while confirming EOF at that boundary.