### PR TITLE
Drop privileges in sandboxed callbacks

### DIFF
--- a/libpkg/pkg_sandbox.c
+++ b/libpkg/pkg_sandbox.c
@@ -100,6 +100,8 @@ pkg_handle_sandboxed_call(pkg_sandbox_cb func, int fd, void *ud)
 		err(EXIT_FAILURE, "Unable to setrlimit(RLIMIT_NPROC)");
 
 	/* Here comes child process */
+	pkg_drop_privileges();
+
 #ifdef HAVE_CAPSICUM
 #ifndef COVERAGE
 	if (cap_enter() < 0 && errno != ENOSYS) {


### PR DESCRIPTION
Archive and signature parser callbacks are forked but retain root identity. They also inherit the descriptor for `/`, so entering Capsicum alone does not remove the filesystem authority already held by the process.

A malicious repository input that exploits a parser vulnerability can therefore execute with root identity and root filesystem authority, increasing the impact of a compromise.

Drop privileges to nobody before entering Capsicum, matching the existing string-returning callback path.