### PR TITLE
pkg_jobs: Fix UAF during additional SAT cycle

### DIFF
--- a/libpkg/pkg_jobs.c
+++ b/libpkg/pkg_jobs.c
@@ -925,7 +925,8 @@ pkg_jobs_find_upgrade(struct pkg_jobs *j, const char *pattern, match_t m)
 				"remote repo", pattern);
 		rc = pkg_jobs_universe_add_pkg(j->universe, p, &unit);
 		if (rc == EPKG_END) {
-			pkg_free(p);
+			if (!pkg_in_universe(j->universe, p))
+				pkg_free(p);
 			rc = EPKG_OK;
 		}
 	}


### PR DESCRIPTION
```
terminated by signal SIGSEGV (Address boundary error)
```

Use the same guard pattern as previous code.

While upgrading a boot environment from 15.1 -> 16-CURRENT following https://people.freebsd.org/~dch/posts/2026-01-18-upgrading-base-packages-to-current/ :

```
# pkg-static -v
2.8.1
# pkg-static -ddc /mnt -o IGNORE_OSVERSION=yes -o ABI=FreeBSD:16:amd64 upgrade -r base
...
DBG(1)[78731]> (jobs) check integrity for 222 items added
 done (18 conflicting)
  • FreeBSD-mandoc-16.snap20260724071143 [base] conflicts with FreeBSD-periodic-15.1 [installed] on /etc/periodic/weekly/320.whatis
  • FreeBSD-mandoc-16.snap20260724071143 [base] conflicts with FreeBSD-utilities-15.1p1 [installed] on /usr/libexec/makewhatis.local
  • FreeBSD-toolchain-15.1 [installed] conflicts with FreeBSD-clang-16.snap20260725095024 [base] on /usr/bin/addr2line
  • FreeBSD-toolchain-16.snap20260724071143 [base] conflicts with FreeBSD-clang-15.1p1 [installed] on /usr/bin/addr2line
  • FreeBSD-toolchain-16.snap20260724071143 [base] conflicts with FreeBSD-utilities-15.1p1 [installed] on /usr/bin/elfdump
  • FreeBSD-ncurses-lib-16.snap20260724071143 [base] conflicts with FreeBSD-runtime-15.1p1 [installed] on /etc/termcap
  • FreeBSD-ncurses-lib-16.snap20260724071143 [base] conflicts with FreeBSD-utilities-15.1p1 [installed] on /usr/share/tabset/3101
  • FreeBSD-yp-lib-16.snap20260724071143 [base] conflicts with FreeBSD-runtime-15.1p1 [installed] on /usr/lib/libypclnt.so.4
  • FreeBSD-googletest-16.snap20260725095024 [base] conflicts with FreeBSD-utilities-15.1p1 [installed] on /usr/lib/libprivategmock.so.0
  • FreeBSD-utilities-16.snap20260725095024 [base] conflicts with FreeBSD-diff3-15.1 [installed] on /usr/bin/diff3
  • FreeBSD-googletest-dev-16.snap20260725095024 [base] conflicts with FreeBSD-utilities-dev-15.1p1 [installed] on /usr/include/private/gmock/gmock-actions.h
  • FreeBSD-ppp-16.snap20260724071143 [base] conflicts with FreeBSD-utilities-15.1p1 [installed] on /usr/bin/chat
  • FreeBSD-yp-dev-16.snap20260724071143 [base] conflicts with FreeBSD-runtime-dev-15.1p1 [installed] on /usr/include/ypclnt.h
  • FreeBSD-clang-16.snap20260725095024 [base] conflicts with FreeBSD-utilities-15.1p1 [installed] on /usr/share/doc/llvm/COPYRIGHT.regex
  • FreeBSD-rdma-dev-16.snap20260724071143 [base] conflicts with FreeBSD-utilities-dev-15.1p1 [installed] on /usr/include/infiniband/arch.h
  • FreeBSD-rdma-lib-16.snap20260724071143 [base] conflicts with FreeBSD-utilities-15.1p1 [installed] on /lib/libbnxtre.so.1
  • FreeBSD-ncurses-16.snap20260724071143 [base] conflicts with FreeBSD-runtime-15.1p1 [installed] on /usr/share/man/man5/termcap.5.gz
  • FreeBSD-blocklist-lib-16.snap20260724071143 [base] conflicts with FreeBSD-blocklist-15.1 [installed] on /usr/lib/libblacklist.so.0
DBG(2)[78731]> (package) adding options: DOCS = on
DBG(2)[78731]> (jobs) non-automatic package with pattern pkg has not been found in remote repo
DBG(2)[78731]> select FreeBSD-mandoc in the chain of conflicts for FreeBSD-mandoc
DBG(2)[78731]> select FreeBSD-toolchain in the chain of conflicts for FreeBSD-toolchain
DBG(2)[78731]> select FreeBSD-ncurses-lib in the chain of conflicts for FreeBSD-ncurses-lib
DBG(2)[78731]> (jobs) set automatic flag for FreeBSD-pkgconf
DBG(2)[78731]> (jobs) set automatic flag for FreeBSD-googletest
DBG(2)[78731]> (jobs) set automatic flag for FreeBSD-googletest-dev
DBG(2)[78731]> (jobs) set automatic flag for FreeBSD-rdma-dev
DBG(2)[78731]> (jobs) set automatic flag for FreeBSD-rdma-lib
DBG(2)[78731]> (jobs) set automatic flag for FreeBSD-yp-lib
DBG(2)[78731]> (jobs) set automatic flag for FreeBSD-smart
DBG(2)[78731]> (jobs) set automatic flag for FreeBSD-smart-dbg
DBG(2)[78731]> (jobs) set automatic flag for FreeBSD-yp-dev
DBG(2)[78731]> (jobs) set automatic flag for FreeBSD-blocklist-lib
fish: Job 1, 'pkg-static -ddc /mnt -o IGNORE_…' terminated by signal SIGSEGV (Address boundary error)
```