### PR TITLE
pkg_repo: Fix incompatible pointer

### DIFF
--- a/libpkg/pkg_repo.c
+++ b/libpkg/pkg_repo.c
@@ -977,7 +977,7 @@ pkg_repo_save_filesite(struct pkg_repo *repo, time_t orig_mtime)
 	int clevel = pkg_object_int(pkg_config_get("COMPRESSION_LEVEL"));
 	if (clevel == -1)
 		clevel = 19;
-	char *clevel_buf[16];
+	char clevel_buf[16];
 	snprintf(clevel_buf, sizeof(clevel_buf), "%d", clevel);
 	archive_write_set_filter_option(aw, NULL, "compression-level", clevel_buf);
 	outfd = openat(repo->dfd, "files",


### PR DESCRIPTION
Fix incompatible variable pointer which causes compile to fail in Linux systems.

Error can be spotted from Debian CI run:

```
/home/build/pkg/libpkg/pkg_repo.c:981:18: error: passing argument 1 of 'snprintf' from incompatible pointer type [-Wincompatible-pointer-types]
  981 |         snprintf(clevel_buf, sizeof(clevel_buf), "%d", clevel);
      |                  ^~~~~~~~~~
      |                  |
      |                  char **

```
Fix variable `clevel_buf` that was `char **` which is corrected type to `char *`