### PR TITLE
Create URL package downloads exclusively

### DIFF
--- a/libpkg/pkg_jobs.c
+++ b/libpkg/pkg_jobs.c
@@ -204,6 +204,7 @@ pkg_jobs_maybe_match_url(struct job_pattern *jp, const char *pattern)
 {
 	char path[MAXPATHLEN];
 	const char *name;
+	int fd;
 
 	if (strncmp(pattern, "http://", 7) != 0 &&
 	    strncmp(pattern, "https://", 8) != 0 &&
@@ -219,8 +220,18 @@ pkg_jobs_maybe_match_url(struct job_pattern *jp, const char *pattern)
 	else
 		name++;
 
-	snprintf(path, sizeof(path), "%s/%s.XXXXX",
+	snprintf(path, sizeof(path), "%s/%s.XXXXXX",
 	    getenv("TMPDIR") ? getenv("TMPDIR") : "/tmp", name);
+	fd = mkstemp(path);
+	if (fd == -1) {
+		pkg_emit_errno("mkstemp", path);
+		return (false);
+	}
+	if (close(fd) == -1) {
+		pkg_emit_errno("close", path);
+		unlink(path);
+		return (false);
+	}
 
 	if (pkg_fetch_file(NULL, pattern, path, 0, 0, 0) != EPKG_OK) {
 		pkg_emit_error("Failed to fetch package from '%s'", pattern);

--- a/src/add.c
+++ b/src/add.c
@@ -146,6 +146,7 @@ exec_add(int argc, char **argv)
 	for (i = 0; i < argc; i++) {
 		if (is_url(argv[i]) == EPKG_OK) {
 			const char *name = strrchr(argv[i], '/');
+			int fd;
 			if (name == NULL)
 				name = argv[i];
 			else
@@ -153,7 +154,19 @@ exec_add(int argc, char **argv)
 
 			if ((env = getenv("TMPDIR")) == NULL)
 				env = "/tmp";
-			snprintf(path, sizeof(path), "%s/%s.XXXXX", env, name);
+			snprintf(path, sizeof(path), "%s/%s.XXXXXX", env, name);
+			fd = mkstemp(path);
+			if (fd == -1) {
+				warn("mkstemp %s", path);
+				retcode = EPKG_FATAL;
+				break;
+			}
+			if (close(fd) == -1) {
+				warn("close %s", path);
+				unlink(path);
+				retcode = EPKG_FATAL;
+				break;
+			}
 			if ((retcode = pkg_fetch_file(NULL, argv[i], path, 0, 0, 0)) != EPKG_OK)
 				break;
 
@@ -210,4 +223,3 @@ exec_add(int argc, char **argv)
 
 	return (retcode == EPKG_OK ? EXIT_SUCCESS : EXIT_FAILURE);
 }
-


### PR DESCRIPTION
Direct URL package installs derive a predictable temporary path from the URL basename, then `pkg_fetch_file()` opens it for append. A local user can pre-create a symlink in a shared temporary directory to a package they control. If root uses `pkg add` or `pkg install` with a matching direct URL, pkg follows the symlink and later processes the attacker-controlled package. Its install scripts run as root.

Create the temporary file with `mkstemp()` before fetching in both direct URL paths. This ensures the fetch uses an exclusive caller-owned pathname while preserving the existing fetch and cleanup flow.

I confirmed this on FreeBSD with a harmless package fixture: a non-root user pre-created the symlink, and the privileged direct URL install consumed that package and ran its pre-install script as UID 0.