### PR TITLE
Limit HTTP response line length

### DIFF
--- a/external/fetch/common.c
+++ b/external/fetch/common.c
@@ -1386,6 +1386,7 @@ fetch_read(conn_t *conn, char *buf, size_t len)
  * Read a line of text from a connection w/ timeout
  */
 #define MIN_BUF_SIZE 1024
+#define FETCH_MAX_LINE_SIZE (64 * 1024)
 
 int
 fetch_getln(conn_t *conn)
@@ -1412,6 +1413,10 @@ fetch_getln(conn_t *conn)
 			return (-1);
 		if (len == 0)
 			break;
+		if (conn->buflen == FETCH_MAX_LINE_SIZE) {
+			errno = E2BIG;
+			return (-1);
+		}
 		conn->buf[conn->buflen++] = c;
 		if (conn->buflen == conn->bufsize) {
 			tmp = conn->buf;


### PR DESCRIPTION
`fetch_getln()` is used while parsing HTTP status lines, headers, proxy
responses, and chunk-size lines. It grew `conn->buf` until it found a
newline, without a maximum line length. A peer could therefore keep a
response line open and make pkg allocate memory until the process or system
ran out of resources.

This occurs while fetching a package, before package parsing and signature
verification. An active network attacker against an HTTP repository or
mirror, or a malicious server, could cause a denial of service in the root
pkg process. Default FreeBSD repositories use HTTPS today, but pkg supports
configured HTTP repositories and mirrors.

This change rejects a response line once it reaches 64 KiB and returns
`E2BIG`, while preserving normal HTTP parsing. Let me know if you prefer a
different value.