### PR TITLE
Limit HTTP mirror list input

### DIFF
--- a/external/fetch/http.c
+++ b/external/fetch/http.c
@@ -1749,7 +1749,8 @@ http_request_body(struct url *URL, const char *op, struct url_stat *us,
 	char hbuf[MAXHOSTNAMELEN + 7], *host;
 	conn_t *conn;
 	struct url *url, *new;
-	int chunked, conn_close, direct, from_cache, ims, noredirect, verbose;
+	int chunked, close_after, conn_close, direct, from_cache, ims, noredirect,
+	    verbose;
 	int e, i, n, val;
 	off_t offset, clength, length, size;
 	time_t mtime;
@@ -1768,6 +1769,8 @@ http_request_body(struct url *URL, const char *op, struct url_stat *us,
 	init_http_auth_challenges(&proxy_challenges);
 
 	direct = CHECK_FLAG('d');
+	/* The internal c flag requests a non-reusable response stream. */
+	close_after = CHECK_FLAG('c');
 	noredirect = CHECK_FLAG('A');
 	verbose = CHECK_FLAG('v');
 	ims = CHECK_FLAG('i');
@@ -2224,7 +2227,8 @@ http_request_body(struct url *URL, const char *op, struct url_stat *us,
 	URL->length = clength;
 
 	/* wrap it up in a FILE */
-	if ((f = http_funopen(conn, chunked, !conn_close && purl == NULL, clength)) == NULL) {
+	if ((f = http_funopen(conn, chunked,
+	    !conn_close && !close_after && purl == NULL, clength)) == NULL) {
 		fetch_syserr();
 		goto ouch;
 	}

--- a/libpkg/fetch_libfetch.c
+++ b/libpkg/fetch_libfetch.c
@@ -54,24 +54,55 @@ struct http_mirror {
 	struct http_mirror *next;
 };
 
+#define PKG_HTTP_MIRROR_LIST_MAX_SIZE	(1024 * 1024)
+#define PKG_HTTP_MIRROR_LIST_MAX_LINE	MAXPATHLEN
+#define PKG_HTTP_MIRROR_LIST_MAX_ENTRIES	256
+
 static void
 gethttpmirrors(struct pkg_repo *repo, const char *url, bool withdoc) {
 	FILE *f;
-	char *line = NULL, *walk;
-	size_t linecap = 0;
-	ssize_t linelen;
-	struct http_mirror *m;
+	char line[PKG_HTTP_MIRROR_LIST_MAX_LINE];
+	char *walk;
+	size_t linelen, total = 0, nmirrors = 0;
+	int c;
+	struct http_mirror *m, *new_mirrors = NULL, *tmp;
 	struct url *u;
+	bool accepted = false;
 
-	if ((f = fetchGetURL(url, "")) == NULL)
+	/*
+	 * The mirror list is advisory and is not protected by repository
+	 * signatures.  Do not reuse its connection so an early error does not
+	 * make fclose() drain an arbitrary response body.
+	 */
+	if ((f = fetchGetURL(url, "c")) == NULL)
 		return;
 
-	while ((linelen = getline(&line, &linecap, f)) > 0) {
+	for (;;) {
+		linelen = 0;
+		while ((c = fgetc(f)) != EOF) {
+			if (++total > PKG_HTTP_MIRROR_LIST_MAX_SIZE) {
+				pkg_emit_error("HTTP mirror list exceeds %d bytes",
+				    PKG_HTTP_MIRROR_LIST_MAX_SIZE);
+				goto done;
+			}
+			if (c == '\0' || linelen == sizeof(line) - 1) {
+				pkg_emit_error("HTTP mirror list contains an invalid line");
+				goto done;
+			}
+			if (c == '\n')
+				break;
+			line[linelen++] = c;
+		}
+		if (ferror(f))
+			goto done;
+		if (linelen == 0 && c == EOF)
+			break;
+		line[linelen] = '\0';
+
 		if (strncmp(line, "URL:", 4) == 0) {
 			walk = line;
-			/* trim '\n' */
-			if (walk[linelen - 1] == '\n')
-				walk[linelen - 1 ] = '\0';
+			if (linelen > 0 && walk[linelen - 1] == '\r')
+				walk[linelen - 1] = '\0';
 
 			walk += 4;
 			while (isspace(*walk)) {
@@ -81,17 +112,34 @@ gethttpmirrors(struct pkg_repo *repo, const char *url, bool withdoc) {
 				continue;
 
 			if ((u = fetchParseURL(walk)) != NULL) {
+				if (nmirrors == PKG_HTTP_MIRROR_LIST_MAX_ENTRIES) {
+					fetchFreeURL(u);
+					pkg_emit_error("HTTP mirror list has too many entries");
+					goto done;
+				}
 				m = xmalloc(sizeof(struct http_mirror));
 				m->reldoc = withdoc;
 				m->url = u;
 				m->next = NULL;
-				LL_APPEND(repo->http, m);
+				LL_APPEND(new_mirrors, m);
+				nmirrors++;
 			}
 		}
+		if (c == EOF)
+			break;
 	}
+	accepted = true;
 
-	free(line);
+done:
 	fclose(f);
+	if (accepted) {
+		LL_CONCAT(repo->http, new_mirrors);
+	} else {
+		LL_FOREACH_SAFE(new_mirrors, m, tmp) {
+			fetchFreeURL(m->url);
+			free(m);
+		}
+	}
 }
 
 /*


### PR DESCRIPTION
gethttpmirrors() reads a configured HTTP mirror list before pkg fetches signed repository metadata. It used getline() and retained every parsed URL: entry, allowing a mirror-list source to cause unbounded memory growth.

This caps the total list at 1 MiB, individual lines at MAXPATHLEN, and parsed entries at 256. Entries are staged until the response completes within those limits, so an over-limit response does not alter mirror selection. The response stream is also made non-reusable, preventing fclose() from draining an oversized body after parsing stops.

The impact is memory exhaustion in the root pkg process if an attacker controls a configured mirror-list source. This applies only to opt-in mirror_type: HTTP repositories; FreeBSD’s normal repository configuration uses SRV mirrors, so I consider it low priority. Package signature verification is unaffected.